### PR TITLE
feat(ai): extended thinking + context windowing

### DIFF
--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -31,6 +31,7 @@ func NewClient(apiKey string, logger *slog.Logger) *Client {
 
 // ChatStream sends a request and streams events through the returned channel.
 // The channel is closed when the response is complete or an error occurs.
+// thinkingBudget > 0 enables extended thinking with the given token budget.
 func (c *Client) ChatStream(
 	ctx context.Context,
 	messages []Message,
@@ -38,6 +39,7 @@ func (c *Client) ChatStream(
 	tools []ToolDefinition,
 	model string,
 	maxTokens int,
+	thinkingBudget int,
 ) (<-chan StreamEvent, error) {
 	reqBody := apiRequest{
 		Model:     model,
@@ -46,6 +48,12 @@ func (c *Client) ChatStream(
 		Stream:    true,
 		Messages:  messages,
 		Tools:     tools,
+	}
+	if thinkingBudget > 0 {
+		reqBody.Thinking = &ThinkingConfig{
+			Type:         "enabled",
+			BudgetTokens: thinkingBudget,
+		}
 	}
 
 	body, err := json.Marshal(reqBody)

--- a/internal/ai/models.go
+++ b/internal/ai/models.go
@@ -137,8 +137,8 @@ type TokenUsage struct {
 
 // StreamEvent is emitted during streaming for TUI rendering.
 type StreamEvent struct {
-	Type       string      // "text", "tool_use_start", "tool_input_delta", "tool_use_end", "done", "error"
-	Text       string      // for text deltas
+	Type       string // "text", "thinking", "tool_use_start", "tool_input_delta", "tool_use_end", "done", "error"
+	Text       string // for text deltas and thinking deltas
 	ToolUse    *ToolUseEvent
 	Usage      *TokenUsage
 	StopReason string // on "done": "end_turn" or "tool_use"
@@ -155,13 +155,20 @@ type ToolUseEvent struct {
 
 // --- internal request/response types ---
 
+// ThinkingConfig controls extended thinking (Claude's internal reasoning).
+type ThinkingConfig struct {
+	Type         string `json:"type"`          // "enabled" or "disabled"
+	BudgetTokens int    `json:"budget_tokens"` // max tokens for thinking
+}
+
 type apiRequest struct {
-	Model     string         `json:"model"`
-	MaxTokens int            `json:"max_tokens"`
-	System    []SystemBlock  `json:"system,omitempty"`
-	Stream    bool           `json:"stream"`
-	Messages  []Message      `json:"messages"`
+	Model     string           `json:"model"`
+	MaxTokens int              `json:"max_tokens"`
+	System    []SystemBlock    `json:"system,omitempty"`
+	Stream    bool             `json:"stream"`
+	Messages  []Message        `json:"messages"`
 	Tools     []ToolDefinition `json:"tools,omitempty"`
+	Thinking  *ThinkingConfig  `json:"thinking,omitempty"`
 }
 
 type streamEventRaw struct {
@@ -190,6 +197,7 @@ type contentBlockRaw struct {
 type deltaRaw struct {
 	Type        string `json:"type"`
 	Text        string `json:"text,omitempty"`
+	Thinking    string `json:"thinking,omitempty"`    // for thinking_delta
 	PartialJSON string `json:"partial_json,omitempty"`
 	StopReason  string `json:"stop_reason,omitempty"`
 }

--- a/internal/ai/stream.go
+++ b/internal/ai/stream.go
@@ -19,6 +19,7 @@ func parseStream(r io.Reader, events chan<- StreamEvent) error {
 		currentToolName string
 		inputAccum      strings.Builder
 		usage           TokenUsage
+		inThinking      bool
 	)
 
 	for scanner.Scan() {
@@ -46,7 +47,13 @@ func parseStream(r io.Reader, events chan<- StreamEvent) error {
 			}
 
 		case "content_block_start":
-			if event.ContentBlock != nil && event.ContentBlock.Type == "tool_use" {
+			if event.ContentBlock == nil {
+				continue
+			}
+			switch event.ContentBlock.Type {
+			case "thinking":
+				inThinking = true
+			case "tool_use":
 				currentToolID = event.ContentBlock.ID
 				currentToolName = event.ContentBlock.Name
 				inputAccum.Reset()
@@ -66,6 +73,8 @@ func parseStream(r io.Reader, events chan<- StreamEvent) error {
 			}
 
 			switch delta.Type {
+			case "thinking_delta":
+				events <- StreamEvent{Type: "thinking", Text: delta.Thinking}
 			case "text_delta":
 				events <- StreamEvent{Type: "text", Text: delta.Text}
 			case "input_json_delta":
@@ -81,7 +90,9 @@ func parseStream(r io.Reader, events chan<- StreamEvent) error {
 			}
 
 		case "content_block_stop":
-			if currentToolID != "" {
+			if inThinking {
+				inThinking = false
+			} else if currentToolID != "" {
 				fullInput := json.RawMessage(inputAccum.String())
 				events <- StreamEvent{
 					Type: "tool_use_end",

--- a/internal/mode/modes.go
+++ b/internal/mode/modes.go
@@ -2,9 +2,10 @@ package mode
 
 // Mode defines a ghost operating mode.
 type Mode struct {
-	Name       string
-	MaxTokens  int
-	SystemHint string
+	Name           string
+	MaxTokens      int
+	ThinkingBudget int // 0 = disabled, >0 = extended thinking token budget
+	SystemHint     string
 }
 
 // Modes is the complete set of operating modes.
@@ -15,29 +16,34 @@ var Modes = map[string]Mode{
 		SystemHint: "Conversational coding assistance. Brief answers unless asked to elaborate.",
 	},
 	"code": {
-		Name:      "code",
-		MaxTokens: 4000,
-		SystemHint: "Write correct, tested code. Show file paths and line numbers. Run tests after changes when tests exist.",
+		Name:           "code",
+		MaxTokens:      16000,
+		ThinkingBudget: 10000,
+		SystemHint:     "Write correct, tested code. Show file paths and line numbers. Run tests after changes when tests exist.",
 	},
 	"debug": {
-		Name:      "debug",
-		MaxTokens: 3000,
-		SystemHint: "Systematic debugging. Read error messages carefully. Form hypotheses, verify with grep/read, then fix. Show evidence for every conclusion.",
+		Name:           "debug",
+		MaxTokens:      16000,
+		ThinkingBudget: 10000,
+		SystemHint:     "Systematic debugging. Read error messages carefully. Form hypotheses, verify with grep/read, then fix. Show evidence for every conclusion.",
 	},
 	"review": {
-		Name:      "review",
-		MaxTokens: 3000,
-		SystemHint: "Code review mode. Analyze diffs for bugs, security issues, performance problems, and style. Be constructive and specific.",
+		Name:           "review",
+		MaxTokens:      12000,
+		ThinkingBudget: 8000,
+		SystemHint:     "Code review mode. Analyze diffs for bugs, security issues, performance problems, and style. Be constructive and specific.",
 	},
 	"plan": {
-		Name:      "plan",
-		MaxTokens: 4000,
-		SystemHint: "Architecture and planning. Think before coding. Outline the approach, identify risks, list files to change. Do NOT write code unless explicitly asked.",
+		Name:           "plan",
+		MaxTokens:      16000,
+		ThinkingBudget: 10000,
+		SystemHint:     "Architecture and planning. Think before coding. Outline the approach, identify risks, list files to change. Do NOT write code unless explicitly asked.",
 	},
 	"refactor": {
-		Name:      "refactor",
-		MaxTokens: 3000,
-		SystemHint: "Refactoring mode. Preserve behavior exactly. Make surgical changes. Run tests before and after every change.",
+		Name:           "refactor",
+		MaxTokens:      16000,
+		ThinkingBudget: 10000,
+		SystemHint:     "Refactoring mode. Preserve behavior exactly. Make surgical changes. Run tests before and after every change.",
 	},
 }
 

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -130,11 +130,10 @@ func (s *Session) Send(ctx context.Context, userMsg string, approvalFn ApprovalF
 		var fullResponse string
 		for {
 			s.mu.Lock()
-			msgs := make([]ai.Message, len(s.messages))
-			copy(msgs, s.messages)
+			msgs := s.windowedMessages()
 			s.mu.Unlock()
 
-			stream, err := s.client.ChatStream(ctx, msgs, system, tools, s.model, s.Mode.MaxTokens)
+			stream, err := s.client.ChatStream(ctx, msgs, system, tools, s.model, s.Mode.MaxTokens, s.Mode.ThinkingBudget)
 			if err != nil {
 				events <- ai.StreamEvent{Type: "error", Error: err}
 				return
@@ -148,6 +147,8 @@ func (s *Session) Send(ctx context.Context, userMsg string, approvalFn ApprovalF
 
 			for evt := range stream {
 				switch evt.Type {
+				case "thinking":
+					events <- evt // pass thinking to TUI but don't accumulate
 				case "text":
 					textAccum += evt.Text
 					events <- evt
@@ -294,6 +295,70 @@ func (s *Session) MessageCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.messages)
+}
+
+// maxContextTokens is the target context budget. Messages are trimmed to stay
+// under this when the conversation grows long. Memories and system prompt are
+// separate, so this covers only the messages array.
+const maxContextTokens = 180000
+
+// windowedMessages returns a copy of messages, trimming the oldest exchanges
+// if the estimated token count exceeds maxContextTokens. Must be called with
+// s.mu held.
+func (s *Session) windowedMessages() []ai.Message {
+	msgs := make([]ai.Message, len(s.messages))
+	copy(msgs, s.messages)
+
+	est := estimateTokens(msgs)
+	if est <= maxContextTokens {
+		return msgs
+	}
+
+	// Trim oldest user+assistant pairs (skip tool_result messages that follow).
+	// Keep at least the last 4 messages to preserve recent context.
+	for est > maxContextTokens && len(msgs) > 4 {
+		msgs = msgs[2:] // drop one user+assistant pair
+		// Skip any orphaned tool_result messages at the start.
+		for len(msgs) > 0 && isToolResult(msgs[0]) {
+			msgs = msgs[1:]
+		}
+		est = estimateTokens(msgs)
+	}
+
+	if len(msgs) < len(s.messages) {
+		s.logger.Info("context windowed",
+			"original", len(s.messages), "trimmed", len(msgs),
+			"est_tokens", est)
+	}
+	return msgs
+}
+
+// estimateTokens gives a rough token count. Claude averages ~4 chars per token
+// for English text. This is intentionally conservative (slightly overestimates).
+func estimateTokens(msgs []ai.Message) int {
+	total := 0
+	for _, m := range msgs {
+		for _, b := range m.Content {
+			total += len(b.Text)/3 + len(b.Content)/3
+			if b.Input != nil {
+				total += len(b.Input) / 3
+			}
+		}
+	}
+	return total
+}
+
+// isToolResult checks if a message contains only tool_result blocks.
+func isToolResult(m ai.Message) bool {
+	if m.Role != "user" || len(m.Content) == 0 {
+		return false
+	}
+	for _, b := range m.Content {
+		if b.Type != "tool_result" {
+			return false
+		}
+	}
+	return true
 }
 
 // Store returns the memory store for direct access (e.g., REPL commands).

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -17,6 +17,7 @@ import (
 // LLMProvider abstracts LLM interactions for streaming chat and reflection.
 type LLMProvider interface {
 	// ChatStream sends a conversation to the LLM and streams events back.
+	// thinkingBudget > 0 enables extended thinking with the given token budget.
 	ChatStream(
 		ctx context.Context,
 		messages []ai.Message,
@@ -24,6 +25,7 @@ type LLMProvider interface {
 		tools []ai.ToolDefinition,
 		model string,
 		maxTokens int,
+		thinkingBudget int,
 	) (<-chan ai.StreamEvent, error)
 
 	// Reflect calls a fast model (e.g., Haiku) for memory extraction/reflection.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -226,9 +226,13 @@ func (a App) handleStreamEvent(msg streamEventMsg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
 	switch msg.Type {
+	case "thinking":
+		a.toolbar.setThinking(true)
 	case "text":
+		a.toolbar.setThinking(false)
 		a.chatView.appendToLastAssistant(msg.Text)
 	case "tool_use_start":
+		a.toolbar.setThinking(false)
 		if msg.ToolUse != nil {
 			a.toolbar.addTool(msg.ToolUse.ID, msg.ToolUse.Name)
 		}

--- a/internal/tui/toolbar.go
+++ b/internal/tui/toolbar.go
@@ -20,10 +20,11 @@ type activeTool struct {
 	inputPreview string
 }
 
-// toolbar manages active tool progress spinners.
+// toolbar manages active tool progress spinners and thinking state.
 type toolbar struct {
-	tools   []activeTool
-	spinner spinner.Model
+	tools    []activeTool
+	spinner  spinner.Model
+	thinking bool // true while extended thinking is active
 }
 
 func newToolbar() toolbar {
@@ -72,11 +73,19 @@ func (t *toolbar) denyTool(id string) {
 	}
 }
 
+func (t *toolbar) setThinking(active bool) {
+	t.thinking = active
+}
+
 func (t *toolbar) clear() {
 	t.tools = nil
+	t.thinking = false
 }
 
 func (t *toolbar) hasActive() bool {
+	if t.thinking {
+		return true
+	}
 	for _, tool := range t.tools {
 		if !tool.done {
 			return true
@@ -92,11 +101,17 @@ func (t toolbar) update(msg tea.Msg) (toolbar, tea.Cmd) {
 }
 
 func (t toolbar) view() string {
-	if len(t.tools) == 0 {
+	if len(t.tools) == 0 && !t.thinking {
 		return ""
 	}
 
 	var lines []string
+	if t.thinking {
+		lines = append(lines, fmt.Sprintf("  %s %s",
+			t.spinner.View(),
+			toolNameStyle.Render("thinking..."),
+		))
+	}
 	for _, tool := range t.tools {
 		var line string
 		if tool.denied {


### PR DESCRIPTION
## Summary
- **Extended thinking**: Claude can now reason internally before responding. Enabled for code/debug/plan/refactor modes with 10k token budget. Thinking spinner shows in the TUI toolbar. Thinking content is streamed but not displayed (internal reasoning).
- **Context windowing**: Long conversations no longer crash. Session estimates token count (~3 chars/token) and trims oldest message pairs when exceeding 180k budget, preserving at least 4 recent messages. Orphaned tool_result messages are cleaned up during trimming.
- **Provider interface updated**: `ChatStream()` now takes `thinkingBudget int` parameter

## Changes
- `internal/ai/models.go` — `ThinkingConfig` struct, `thinking` field on `apiRequest`, `thinking_delta` in `deltaRaw`, `"thinking"` event type in `StreamEvent`
- `internal/ai/client.go` — `ChatStream()` accepts `thinkingBudget`, sets `Thinking` config when > 0
- `internal/ai/stream.go` — Handles `thinking` content blocks and `thinking_delta` events
- `internal/mode/modes.go` — `ThinkingBudget` field on `Mode`, code/debug/plan/refactor get 10k budget, max_tokens bumped to 16k
- `internal/orchestrator/session.go` — `windowedMessages()` for context trimming, passes `ThinkingBudget` to `ChatStream`
- `internal/provider/provider.go` — Updated `LLMProvider` interface
- `internal/tui/toolbar.go` — Thinking spinner state
- `internal/tui/app.go` — Handles `"thinking"` stream events

## Test plan
- [x] `go vet ./...` passes
- [x] `go test -tags sqlite_fts5 ./...` passes
- [x] Build succeeds
- [ ] Test thinking: use code/debug/plan mode — should see "thinking..." spinner before response
- [ ] Test context windowing: long conversation should not crash, logs should show trimming
- [ ] Test chat mode: no thinking (budget = 0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended thinking support enables AI to reason more deeply before responding
  * Visual indicator displays active thinking status in the interface
  * Configurable thinking budget parameter allows control over reasoning resource allocation

* **Configuration**
  * Code, debug, review, plan, and refactor modes now include thinking budgets and increased token limits for enhanced analysis capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->