### PR TITLE
feat(ghost): Makefile, config test fix, /image wiring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS  = -ldflags "-X main.version=$(VERSION)"
+TAGS     = -tags sqlite_fts5
+BINARY   = ghost
+
+.PHONY: build test vet clean install
+
+build:
+	CGO_ENABLED=1 go build $(TAGS) $(LDFLAGS) -o $(BINARY) ./cmd/ghost/
+
+test:
+	CGO_ENABLED=1 go test $(TAGS) ./...
+
+vet:
+	go vet $(TAGS) ./...
+
+clean:
+	rm -f $(BINARY)
+
+install: build
+	cp $(BINARY) $(GOPATH)/bin/ 2>/dev/null || cp $(BINARY) ~/go/bin/

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,15 +7,24 @@ import (
 )
 
 func TestLoad_Defaults(t *testing.T) {
-	// Clear any env vars that could interfere.
+	// Isolate from real config files by pointing HOME/XDG to temp dir.
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Unset any env vars that could interfere. We save/restore manually
+	// because t.Setenv("X","") would set it to empty (not unset), and
+	// koanf's env provider treats empty as an override.
 	for _, key := range []string{
 		"GHOST_API_KEY",
 		"GHOST_DEFAULTS_MODE",
 		"GHOST_SERVER_LISTEN_ADDR",
 		"ANTHROPIC_API_KEY",
 	} {
-		t.Setenv(key, "")
-		os.Unsetenv(key)
+		if old, ok := os.LookupEnv(key); ok {
+			os.Unsetenv(key)
+			t.Cleanup(func() { os.Setenv(key, old) })
+		}
 	}
 
 	cfg, err := Load()

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -106,9 +106,43 @@ func (s *Session) SendAsync(ctx context.Context, userMsg string, approvalCh chan
 	return s.Send(ctx, userMsg, approvalFn)
 }
 
+// SendImageAsync sends a user message with an attached image through the agentic loop.
+func (s *Session) SendImageAsync(ctx context.Context, text, mediaType, base64Data string, approvalCh chan<- provider.ApprovalRequest) <-chan ai.StreamEvent {
+	approvalFn := func(toolName string, input json.RawMessage) bool {
+		resp := make(chan bool, 1)
+		select {
+		case approvalCh <- provider.ApprovalRequest{
+			ToolName: toolName,
+			Input:    input,
+			Response: resp,
+		}:
+		case <-ctx.Done():
+			return false
+		}
+		select {
+		case approved := <-resp:
+			return approved
+		case <-ctx.Done():
+			return false
+		case <-time.After(30 * time.Second):
+			s.logger.Warn("approval timeout, denying", "tool", toolName)
+			return false
+		}
+	}
+	imageBlocks := []ai.ContentBlock{ai.ImageBlock(mediaType, base64Data)}
+	msg := ai.MultimodalMessage(text, imageBlocks)
+	return s.SendMessage(ctx, msg, text, approvalFn)
+}
+
 // Send processes a user message through the full agentic loop.
 // It streams events through the returned channel.
 func (s *Session) Send(ctx context.Context, userMsg string, approvalFn ApprovalFunc) <-chan ai.StreamEvent {
+	return s.SendMessage(ctx, ai.TextMessage("user", userMsg), userMsg, approvalFn)
+}
+
+// SendMessage processes a pre-built user message through the agentic loop.
+// userText is the plain text for memory extraction.
+func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userText string, approvalFn ApprovalFunc) <-chan ai.StreamEvent {
 	events := make(chan ai.StreamEvent, 128)
 
 	go func() {
@@ -118,7 +152,7 @@ func (s *Session) Send(ctx context.Context, userMsg string, approvalFn ApprovalF
 		s.LastActiveAt = time.Now()
 
 		// Append user message.
-		s.messages = append(s.messages, ai.TextMessage("user", userMsg))
+		s.messages = append(s.messages, userMessage)
 
 		// Build system blocks.
 		system := s.builder.BuildSystemBlocks(ctx, s.projectCtx, s.Mode)
@@ -238,7 +272,7 @@ func (s *Session) Send(ctx context.Context, userMsg string, approvalFn ApprovalF
 				}()
 				reflection.ExtractMemories(
 					context.Background(), s.client, s.store, s.logger,
-					s.ProjectID, userMsg, fullResponse,
+					s.ProjectID, userText, fullResponse,
 				)
 			}()
 			go func() {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -440,11 +441,30 @@ func (a App) handleCommand(msg commandMsg) (tea.Model, tea.Cmd) {
 	case "/image":
 		if len(msg.Args) > 0 {
 			path := strings.Join(msg.Args, " ")
-			if isImagePath(path) {
-				imgStr := renderImageFile(path, a.imgProtocol)
-				a.chatView.addMessage(chatMessage{kind: msgAssistant, raw: imgStr})
-				// TODO: send image to Claude via SendMultimodal
+			if !isImagePath(path) {
+				a.chatView.addMessage(chatMessage{kind: msgError, raw: "unsupported image format"})
+				return a, nil
 			}
+			// Load and base64-encode the image.
+			data, mediaType, err := loadImageBase64(path)
+			if err != nil {
+				a.chatView.addMessage(chatMessage{kind: msgError, raw: err.Error()})
+				return a, nil
+			}
+			// Show preview in chat.
+			imgStr := renderImageFile(path, a.imgProtocol)
+			a.chatView.addMessage(chatMessage{kind: msgUser, raw: fmt.Sprintf("[image: %s]", filepath.Base(path))})
+			if imgStr != "" {
+				a.chatView.addMessage(chatMessage{kind: msgAssistant, raw: imgStr})
+			}
+			// Send to Claude with vision API.
+			a.isProcessing = true
+			a.status.isProcessing = true
+			a.chatView.startNewAssistantMessage()
+			a.activeStream = a.session.SendImageAsync(
+				a.ctx, "Describe and analyze this image.", mediaType, data, a.approvalCh,
+			)
+			return a, waitForStreamEvent(a.activeStream)
 		}
 
 	case "auto-approve":


### PR DESCRIPTION
## Summary
- **Makefile**: build/test/vet/clean/install targets with `-tags sqlite_fts5` and version injection via ldflags
- **Config test fix**: Properly unset `GHOST_*` env vars instead of setting to empty string — koanf's env provider treats empty as an override, breaking default assertions
- **`/image` command**: Wired to Claude vision API via new `SendImageAsync()` method. Loads image, base64-encodes, shows terminal preview, sends as multimodal content block
- **`Send()` → `SendMessage()` refactor**: Extracted core agentic loop into `SendMessage()` accepting pre-built `ai.Message`, allowing both text and multimodal input without duplicating the loop

## Test plan
- [x] `go vet ./...` passes
- [x] `go test -tags sqlite_fts5 ./...` passes (config test now isolated from host env)
- [x] `go build -tags sqlite_fts5 ./...` compiles cleanly