### PR TITLE
fix(security): remaining medium-severity hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+export GOTOOLCHAIN = auto
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS  = -ldflags "-X main.version=$(VERSION)"
 TAGS     = -tags sqlite_fts5

--- a/internal/calendar/caldav.go
+++ b/internal/calendar/caldav.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/emersion/go-webdav"
@@ -37,7 +38,11 @@ type Config struct {
 }
 
 // NewClient creates a CalDAV client and discovers calendars.
+// The URL must use HTTPS to protect credentials in transit.
 func NewClient(ctx context.Context, cfg Config, logger *slog.Logger) (*Client, error) {
+	if cfg.URL != "" && !strings.HasPrefix(cfg.URL, "https://") {
+		return nil, fmt.Errorf("caldav URL must use HTTPS (got %q) — credentials would be transmitted in plaintext over HTTP", cfg.URL)
+	}
 	httpClient := webdav.HTTPClientWithBasicAuth(nil, cfg.Username, cfg.Password)
 	c, err := caldav.NewClient(httpClient, cfg.URL)
 	if err != nil {

--- a/internal/tool/glob.go
+++ b/internal/tool/glob.go
@@ -52,6 +52,8 @@ func execGlob(ctx context.Context, projectPath string, input json.RawMessage) Re
 		modTime int64
 	}
 
+	const maxDepth = 15
+
 	var matches []fileEntry
 	pattern := in.Pattern
 
@@ -59,10 +61,14 @@ func execGlob(ctx context.Context, projectPath string, input json.RawMessage) Re
 		if err != nil {
 			return nil // skip errors
 		}
-		// Skip common ignored directories.
+		// Skip common ignored directories and enforce depth limit.
 		if info.IsDir() {
 			name := info.Name()
 			if name == ".git" || name == "node_modules" || name == "vendor" || name == ".next" || name == "dist" || name == "build" {
+				return filepath.SkipDir
+			}
+			relDir, _ := filepath.Rel(basePath, path)
+			if relDir != "." && strings.Count(relDir, string(filepath.Separator)) >= maxDepth {
 				return filepath.SkipDir
 			}
 			return nil
@@ -82,10 +88,13 @@ func execGlob(ctx context.Context, projectPath string, input json.RawMessage) Re
 
 		if matched {
 			matches = append(matches, fileEntry{relPath, info.ModTime().Unix()})
+			if len(matches) >= 1000 {
+				return fmt.Errorf("match limit reached")
+			}
 		}
 		return nil
 	})
-	if err != nil {
+	if err != nil && len(matches) == 0 {
 		return Result{Content: fmt.Sprintf("glob error: %v", err), IsError: true}
 	}
 

--- a/internal/tui/approval.go
+++ b/internal/tui/approval.go
@@ -13,11 +13,12 @@ import (
 
 // approvalDialog shows a non-blocking overlay for tool approval.
 type approvalDialog struct {
-	active   bool
-	request  provider.ApprovalRequest
-	toolName string
-	summary  string
-	width    int
+	active      bool
+	request     provider.ApprovalRequest
+	toolName    string
+	summary     string
+	width       int
+	confirmAll  bool // true when showing "are you sure?" for Allow All
 }
 
 func newApprovalDialog() approvalDialog {
@@ -49,17 +50,29 @@ func (a approvalDialog) update(msg tea.Msg) (approvalDialog, tea.Cmd) {
 	}
 
 	if msg, ok := msg.(tea.KeyPressMsg); ok {
+		if a.confirmAll {
+			// Second confirmation for Allow All.
+			switch {
+			case key.Matches(msg, keys.Approve):
+				a.confirmAll = false
+				a.respond(true)
+				return a, func() tea.Msg {
+					return commandMsg{Command: "auto-approve"}
+				}
+			default:
+				// Any other key cancels the confirmation.
+				a.confirmAll = false
+			}
+			return a, nil
+		}
+
 		switch {
 		case key.Matches(msg, keys.Approve):
 			a.respond(true)
 		case key.Matches(msg, keys.Deny), key.Matches(msg, keys.Cancel):
 			a.respond(false)
 		case key.Matches(msg, keys.ApproveAll):
-			a.respond(true)
-			// Return a command to set auto-approve.
-			return a, func() tea.Msg {
-				return commandMsg{Command: "auto-approve"}
-			}
+			a.confirmAll = true // require second confirmation
 		}
 	}
 
@@ -81,11 +94,18 @@ func (a approvalDialog) view() string {
 		content = fmt.Sprintf("%s\n\n%s", title, tool)
 	}
 
-	hint := fmt.Sprintf("\n%s Allow  %s Deny  %s Allow All",
-		approvalKeyStyle.Render("[y]"),
-		approvalKeyStyle.Render("[n]"),
-		approvalKeyStyle.Render("[a]"),
-	)
+	var hint string
+	if a.confirmAll {
+		hint = fmt.Sprintf("\n%s to auto-approve ALL tools this session?",
+			approvalKeyStyle.Render("[y] Confirm"),
+		)
+	} else {
+		hint = fmt.Sprintf("\n%s Allow  %s Deny  %s Allow All",
+			approvalKeyStyle.Render("[y]"),
+			approvalKeyStyle.Render("[n]"),
+			approvalKeyStyle.Render("[a]"),
+		)
+	}
 
 	boxWidth := a.width - 10
 	if boxWidth < 40 {


### PR DESCRIPTION
## Summary
- **CalDAV HTTPS enforcement** — reject `http://` URLs to prevent plaintext credential transmission
- **Approval dialog confirmation** — pressing `[a]` now requires a second `[y]` to confirm auto-approve, preventing accidental permanent bypass
- **Glob depth + match limits** — directory walk capped at 15 levels deep, early exit at 1000 matches to prevent DoS on huge repos
- **Makefile** — `export GOTOOLCHAIN=auto` so `make build` works without manual env setup

Closes all medium-severity findings from security audit.

## Test plan
- [x] `make build` works without GOTOOLCHAIN
- [x] `make vet` passes
- [x] `make test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added HTTPS URL validation for CalDAV to protect credentials during transmission.
  * Implemented safeguards against excessive resource usage through directory traversal depth limits and result caps.

* **New Features**
  * Added two-step confirmation for "Allow All" actions to prevent accidental approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->