### PR TITLE
feat(server): streaming chat API via SSE

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -311,8 +311,21 @@ func runServe() {
 		}
 	}
 
+	// --- Orchestrator for chat API (optional — requires API key) ---
+	var orch *orchestrator.Orchestrator
+	if cfg.API.Key != "" {
+		aiClient := ai.NewClient(cfg.API.Key, logger)
+		chatRegistry := tool.NewRegistry()
+		tool.RegisterAll(chatRegistry, store)
+		orch = orchestrator.New(aiClient, store, chatRegistry, cfg, logger)
+		logger.Info("chat API enabled")
+	} else {
+		logger.Warn("no API key, chat endpoints disabled (memory API still available)")
+	}
+
 	// --- HTTP server (blocks) ---
 	srv := server.New(store, &cfg.Server, logger)
+	srv.SetOrchestrator(orch)
 	if err := srv.Run(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -1,0 +1,326 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wcatz/ghost/internal/ai"
+	"github.com/wcatz/ghost/internal/provider"
+)
+
+// sessionInfo is the JSON representation of a session.
+type sessionInfo struct {
+	ID          string    `json:"id"`
+	ProjectPath string    `json:"project_path"`
+	ProjectName string    `json:"project_name"`
+	Mode        string    `json:"mode"`
+	Active      bool      `json:"active"`
+	Messages    int       `json:"messages"`
+	CreatedAt   time.Time `json:"created_at"`
+	LastActive  time.Time `json:"last_active_at"`
+}
+
+// pendingApproval tracks a tool approval waiting for the HTTP client.
+type pendingApproval struct {
+	ToolName string          `json:"tool_name"`
+	Input    json.RawMessage `json:"input"`
+	response chan bool
+}
+
+// chatState holds per-session streaming state for HTTP clients.
+type chatState struct {
+	mu       sync.Mutex
+	pending  *pendingApproval
+}
+
+// --- Session Handlers ---
+
+type createSessionRequest struct {
+	Path string `json:"path"`
+	Mode string `json:"mode,omitempty"`
+}
+
+func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
+	var req createSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Path == "" {
+		writeError(w, http.StatusBadRequest, "path is required")
+		return
+	}
+
+	session, err := s.orchestrator.StartSession(req.Path)
+	if err != nil {
+		s.logger.Error("start session", "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	if req.Mode != "" {
+		session.SetMode(req.Mode)
+	}
+
+	writeJSON(w, http.StatusCreated, sessionInfo{
+		ID:          session.ProjectID,
+		ProjectPath: session.ProjectPath,
+		ProjectName: session.ProjectName,
+		Mode:        session.Mode.Name,
+		Active:      session.Active,
+		Messages:    session.MessageCount(),
+		CreatedAt:   session.CreatedAt,
+		LastActive:  session.LastActiveAt,
+	})
+}
+
+func (s *Server) handleListSessions(w http.ResponseWriter, _ *http.Request) {
+	sessions := s.orchestrator.ListSessions()
+	infos := make([]sessionInfo, len(sessions))
+	for i, sess := range sessions {
+		infos[i] = sessionInfo{
+			ID:          sess.ProjectID,
+			ProjectPath: sess.ProjectPath,
+			ProjectName: sess.ProjectName,
+			Mode:        sess.Mode.Name,
+			Active:      sess.Active,
+			Messages:    sess.MessageCount(),
+			CreatedAt:   sess.CreatedAt,
+			LastActive:  sess.LastActiveAt,
+		}
+	}
+	writeJSON(w, http.StatusOK, infos)
+}
+
+func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	session := s.orchestrator.GetSessionByID(id)
+	if session == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	if err := s.orchestrator.StopSession(session.ProjectPath); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
+}
+
+// --- Chat SSE Handler ---
+
+type sendRequest struct {
+	Message string `json:"message"`
+}
+
+func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	session := s.orchestrator.GetSessionByID(id)
+	if session == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	var req sendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Message == "" {
+		writeError(w, http.StatusBadRequest, "message is required")
+		return
+	}
+
+	// Set up SSE headers.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	// Create approval channel for this request.
+	approvalCh := make(chan provider.ApprovalRequest, 1)
+
+	// Track pending approval for this session.
+	state := &chatState{}
+	s.chatMu.Lock()
+	s.chatStates[id] = state
+	s.chatMu.Unlock()
+	defer func() {
+		s.chatMu.Lock()
+		delete(s.chatStates, id)
+		s.chatMu.Unlock()
+	}()
+
+	// Start streaming.
+	events := session.SendAsync(r.Context(), req.Message, approvalCh)
+
+	for {
+		select {
+		case evt, ok := <-events:
+			if !ok {
+				// Stream complete.
+				writeSSE(w, flusher, "done", map[string]string{"status": "complete"})
+				return
+			}
+			s.handleStreamEvent(w, flusher, evt)
+
+		case approval := <-approvalCh:
+			// Tool needs approval — emit event and store pending.
+			// We need a bidirectional channel to both send and receive.
+			respCh := make(chan bool, 1)
+			// Forward the response back to the approval request's send-only channel.
+			go func() {
+				v := <-respCh
+				approval.Response <- v
+			}()
+			state.mu.Lock()
+			state.pending = &pendingApproval{
+				ToolName: approval.ToolName,
+				Input:    approval.Input,
+				response: respCh,
+			}
+			state.mu.Unlock()
+
+			writeSSE(w, flusher, "approval_required", map[string]interface{}{
+				"tool_name": approval.ToolName,
+				"input":     json.RawMessage(approval.Input),
+			})
+
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+func (s *Server) handleStreamEvent(w http.ResponseWriter, flusher http.Flusher, evt ai.StreamEvent) {
+	switch evt.Type {
+	case "text":
+		writeSSE(w, flusher, "text", map[string]string{"text": evt.Text})
+	case "thinking":
+		writeSSE(w, flusher, "thinking", map[string]string{"text": evt.Text})
+	case "tool_use_start":
+		if evt.ToolUse != nil {
+			writeSSE(w, flusher, "tool_use_start", map[string]string{
+				"id":   evt.ToolUse.ID,
+				"name": evt.ToolUse.Name,
+			})
+		}
+	case "tool_input_delta":
+		if evt.ToolUse != nil {
+			writeSSE(w, flusher, "tool_input_delta", map[string]string{
+				"id":    evt.ToolUse.ID,
+				"delta": evt.ToolUse.InputDelta,
+			})
+		}
+	case "tool_use_end":
+		if evt.ToolUse != nil {
+			writeSSE(w, flusher, "tool_use_end", map[string]string{
+				"id":   evt.ToolUse.ID,
+				"name": evt.ToolUse.Name,
+			})
+		}
+	case "done":
+		data := map[string]interface{}{
+			"stop_reason": evt.StopReason,
+		}
+		if evt.Usage != nil {
+			data["usage"] = evt.Usage
+		}
+		writeSSE(w, flusher, "done", data)
+	case "error":
+		msg := "unknown error"
+		if evt.Error != nil {
+			msg = evt.Error.Error()
+		}
+		writeSSE(w, flusher, "error", map[string]string{"error": msg})
+	}
+}
+
+// --- Approval Handler ---
+
+type approvalResponse struct {
+	Approved bool `json:"approved"`
+}
+
+func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	var req approvalResponse
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	s.chatMu.RLock()
+	state, ok := s.chatStates[id]
+	s.chatMu.RUnlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, "no active stream for session")
+		return
+	}
+
+	state.mu.Lock()
+	pending := state.pending
+	state.pending = nil
+	state.mu.Unlock()
+
+	if pending == nil {
+		writeError(w, http.StatusConflict, "no pending approval")
+		return
+	}
+
+	pending.response <- req.Approved
+	writeJSON(w, http.StatusOK, map[string]string{"status": "responded"})
+}
+
+// --- Mode Handler ---
+
+type modeRequest struct {
+	Mode string `json:"mode"`
+}
+
+func (s *Server) handleSetMode(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	session := s.orchestrator.GetSessionByID(id)
+	if session == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	var req modeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Mode == "" {
+		writeError(w, http.StatusBadRequest, "mode is required")
+		return
+	}
+
+	session.SetMode(req.Mode)
+	writeJSON(w, http.StatusOK, map[string]string{
+		"mode": session.Mode.Name,
+	})
+}
+
+// --- SSE Helper ---
+
+func writeSSE(w http.ResponseWriter, flusher http.Flusher, eventType string, data interface{}) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, b)
+	flusher.Flush()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,40 +10,53 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/wcatz/ghost/internal/config"
+	"github.com/wcatz/ghost/internal/orchestrator"
 	"github.com/wcatz/ghost/internal/provider"
 )
 
 // Server is the ghost HTTP daemon.
 type Server struct {
-	store  provider.MemoryStore
-	cfg    *config.ServerConfig
-	logger *slog.Logger
-	srv    *http.Server
+	store        provider.MemoryStore
+	cfg          *config.ServerConfig
+	orchestrator *orchestrator.Orchestrator
+	logger       *slog.Logger
+	srv          *http.Server
+
+	// Chat streaming state.
+	chatMu     sync.RWMutex
+	chatStates map[string]*chatState // key: session/project ID
 }
 
 // New creates a new server.
 func New(store provider.MemoryStore, cfg *config.ServerConfig, logger *slog.Logger) *Server {
 	return &Server{
-		store:  store,
-		cfg:    cfg,
-		logger: logger,
+		store:      store,
+		cfg:        cfg,
+		logger:     logger,
+		chatStates: make(map[string]*chatState),
 	}
+}
+
+// SetOrchestrator wires the orchestrator for chat endpoints.
+// Must be called before Run() if chat endpoints are needed.
+func (s *Server) SetOrchestrator(o *orchestrator.Orchestrator) {
+	s.orchestrator = o
 }
 
 // Run starts the HTTP server. Blocks until ctx is cancelled.
 func (s *Server) Run(ctx context.Context) error {
 	r := chi.NewRouter()
 
-	// Middleware.
+	// Middleware (no global timeout — SSE streams run indefinitely).
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.RealIP)
 	r.Use(s.logMiddleware)
-	r.Use(middleware.Timeout(30 * time.Second))
 
 	// Routes.
 	r.Get("/api/v1/health", s.handleHealth)
@@ -60,6 +73,18 @@ func (s *Server) Run(ctx context.Context) error {
 			r.Delete("/{memoryID}", s.handleDelete)
 		})
 		r.Get("/api/v1/projects", s.handleListProjects)
+
+		// Chat streaming endpoints (requires orchestrator).
+		if s.orchestrator != nil {
+			r.Route("/api/v1/sessions", func(r chi.Router) {
+				r.Post("/", s.handleCreateSession)
+				r.Get("/", s.handleListSessions)
+				r.Delete("/{id}", s.handleDeleteSession)
+				r.Post("/{id}/send", s.handleSendMessage)
+				r.Post("/{id}/approve", s.handleApprove)
+				r.Post("/{id}/mode", s.handleSetMode)
+			})
+		}
 	})
 
 	s.srv = &http.Server{


### PR DESCRIPTION
## Summary
- **6 new endpoints** for frontend integration (VSCode extension, web clients):
  - `POST /api/v1/sessions` — create session for a project path
  - `GET /api/v1/sessions` — list active sessions  
  - `DELETE /api/v1/sessions/{id}` — stop session
  - `POST /api/v1/sessions/{id}/send` — send message, stream response via SSE
  - `POST /api/v1/sessions/{id}/approve` — respond to pending tool approval
  - `POST /api/v1/sessions/{id}/mode` — change session mode
- **SSE event types**: `text`, `thinking`, `tool_use_start`, `tool_input_delta`, `tool_use_end`, `approval_required`, `done`, `error`
- Orchestrator wired into `ghost serve` — creates AI client + tool registry when API key is available
- Chat endpoints gated behind orchestrator presence — memory-only mode still works without API key
- Removed global 30s chi timeout middleware (it breaks SSE flushing)

This unlocks Phase 4 (VSCode extension) — any HTTP client can now have a full agentic conversation with Ghost.

## Test plan
- [x] `make build` compiles
- [x] `make vet` passes
- [x] `make test` — all existing tests pass (chat routes don't interfere)
- [ ] Manual: `ghost serve` + `curl -N -X POST /api/v1/sessions` + `/send` streams SSE events