### PR TITLE
fix(security): path traversal, body limits, git bypass, race condition, file perms

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -268,7 +268,7 @@ func DataDir() (string, error) {
 		dataHome = filepath.Join(home, ".local", "share")
 	}
 	dir := filepath.Join(dataHome, "ghost")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
 	return dir, nil
@@ -288,10 +288,10 @@ func EnsureConfigFile() (path string, created bool, err error) {
 		return path, false, nil
 	}
 
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", false, err
 	}
-	if err := os.WriteFile(path, exampleConfig, 0o644); err != nil {
+	if err := os.WriteFile(path, exampleConfig, 0o600); err != nil {
 		return "", false, err
 	}
 	return path, true, nil

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -150,14 +150,22 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	// Create approval channel for this request.
 	approvalCh := make(chan provider.ApprovalRequest, 1)
 
-	// Track pending approval for this session.
+	// Reject concurrent sends — only one stream per session.
 	state := &chatState{}
 	s.chatMu.Lock()
+	if _, active := s.chatStates[id]; active {
+		s.chatMu.Unlock()
+		writeError(w, http.StatusConflict, "stream already active for this session")
+		return
+	}
 	s.chatStates[id] = state
 	s.chatMu.Unlock()
 	defer func() {
 		s.chatMu.Lock()
-		delete(s.chatStates, id)
+		// Only delete if we own the state (prevents race on cleanup).
+		if s.chatStates[id] == state {
+			delete(s.chatStates, id)
+		}
 		s.chatMu.Unlock()
 	}()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -67,6 +67,7 @@ func (s *Server) Run(ctx context.Context) error {
 			r.Use(s.authMiddleware)
 		}
 		r.Route("/api/v1/memories", func(r chi.Router) {
+			r.Use(bodyLimitMiddleware(1 << 20)) // 1MB
 			r.Post("/search", s.handleSearch)
 			r.Post("/", s.handleCreate)
 			r.Get("/{projectID}", s.handleList)
@@ -77,12 +78,12 @@ func (s *Server) Run(ctx context.Context) error {
 		// Chat streaming endpoints (requires orchestrator).
 		if s.orchestrator != nil {
 			r.Route("/api/v1/sessions", func(r chi.Router) {
-				r.Post("/", s.handleCreateSession)
+				r.Post("/", withBodyLimit(s.handleCreateSession, 1<<20))      // 1MB
 				r.Get("/", s.handleListSessions)
 				r.Delete("/{id}", s.handleDeleteSession)
-				r.Post("/{id}/send", s.handleSendMessage)
-				r.Post("/{id}/approve", s.handleApprove)
-				r.Post("/{id}/mode", s.handleSetMode)
+				r.Post("/{id}/send", withBodyLimit(s.handleSendMessage, 10<<20)) // 10MB (large messages)
+				r.Post("/{id}/approve", withBodyLimit(s.handleApprove, 1<<20))
+				r.Post("/{id}/mode", withBodyLimit(s.handleSetMode, 1<<20))
 			})
 		}
 	})
@@ -295,6 +296,30 @@ func (s *Server) logMiddleware(next http.Handler) http.Handler {
 			"duration_ms", time.Since(start).Milliseconds(),
 		)
 	})
+}
+
+// --- Body Limit ---
+
+// bodyLimitMiddleware wraps all requests in the group with a body size limit.
+func bodyLimitMiddleware(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Body != nil {
+				r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// withBodyLimit wraps a single handler with a body size limit.
+func withBodyLimit(h http.HandlerFunc, maxBytes int64) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+		}
+		h(w, r)
+	}
 }
 
 // --- Helpers ---

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -74,8 +74,36 @@ func New(cfg Config, store provider.MemoryStore, ghMonitor *gh.Monitor, sched *s
 
 // Run starts the bot polling loop. Blocks until ctx is cancelled.
 func (tb *Bot) Run(ctx context.Context) {
+	// Clear old commands and register Ghost's command menu.
+	tb.registerCommands(ctx)
 	tb.logger.Info("telegram bot starting")
 	tb.bot.Start(ctx)
+}
+
+// registerCommands pushes Ghost's command menu to the Telegram API,
+// replacing any previously registered commands.
+func (tb *Bot) registerCommands(ctx context.Context) {
+	// Delete all existing commands first.
+	if _, err := tb.bot.DeleteMyCommands(ctx, &bot.DeleteMyCommandsParams{}); err != nil {
+		tb.logger.Error("delete old telegram commands", "error", err)
+	}
+
+	commands := []models.BotCommand{
+		{Command: "status", Description: "System status + notification summary"},
+		{Command: "notifications", Description: "List unread GitHub notifications"},
+		{Command: "memory", Description: "Search memories: /memory search <project> <query>"},
+		{Command: "remind", Description: "Set a reminder: /remind <message>"},
+		{Command: "briefing", Description: "Get your morning briefing"},
+		{Command: "help", Description: "Show available commands"},
+	}
+
+	if _, err := tb.bot.SetMyCommands(ctx, &bot.SetMyCommandsParams{
+		Commands: commands,
+	}); err != nil {
+		tb.logger.Error("set telegram commands", "error", err)
+	} else {
+		tb.logger.Info("telegram commands registered", "count", len(commands))
+	}
 }
 
 // SendMessage sends a message to a specific chat. Used for proactive alerts.

--- a/internal/tool/git.go
+++ b/internal/tool/git.go
@@ -77,6 +77,17 @@ func execGit(ctx context.Context, projectPath string, input json.RawMessage) Res
 			}
 		}
 	}
+	// Block flags that redirect git to a different repository.
+	for _, arg := range in.Args {
+		lower := strings.ToLower(arg)
+		if lower == "-c" || strings.HasPrefix(lower, "--git-dir") || strings.HasPrefix(lower, "--work-tree") {
+			return Result{Content: fmt.Sprintf("blocked: '%s' flag not allowed — git must operate in project directory", arg), IsError: true}
+		}
+	}
+	// Also block -C passed as the subcommand itself (git -C /path ...).
+	if strings.ToLower(in.Subcommand) == "-c" {
+		return Result{Content: "blocked: '-C' flag not allowed — git must operate in project directory", IsError: true}
+	}
 
 	args := append([]string{in.Subcommand}, in.Args...)
 	cmd := exec.CommandContext(ctx, "git", args...)

--- a/internal/tool/glob.go
+++ b/internal/tool/glob.go
@@ -44,7 +44,11 @@ func execGlob(ctx context.Context, projectPath string, input json.RawMessage) Re
 
 	basePath := projectPath
 	if in.Path != "" {
-		basePath = resolvePath(projectPath, in.Path)
+		var err error
+		basePath, err = safePath(projectPath, in.Path)
+		if err != nil {
+			return Result{Content: fmt.Sprintf("path error: %v", err), IsError: true}
+		}
 	}
 
 	type fileEntry struct {

--- a/internal/tool/grep.go
+++ b/internal/tool/grep.go
@@ -48,7 +48,11 @@ func execGrep(ctx context.Context, projectPath string, input json.RawMessage) Re
 
 	searchPath := projectPath
 	if in.Path != "" {
-		searchPath = resolvePath(projectPath, in.Path)
+		var err error
+		searchPath, err = safePath(projectPath, in.Path)
+		if err != nil {
+			return Result{Content: fmt.Sprintf("path error: %v", err), IsError: true}
+		}
 	}
 
 	maxResults := in.MaxResults


### PR DESCRIPTION
## Summary
Security audit round 2 — 5 findings fixed + telegram bot command registration.

| Severity | Fix |
|----------|-----|
| **HIGH** | grep/glob tools used `resolvePath()` → `safePath()` — LLM could read `/etc/passwd`, `~/.ssh/` without approval |
| **HIGH** | No HTTP body size limits → `MaxBytesReader` middleware (1MB API, 10MB chat) |
| **MEDIUM** | git tool accepted `-C`/`--git-dir`/`--work-tree` → now blocked |
| **MEDIUM** | Concurrent SSE sends overwrote approval state → 409 Conflict + ownership check |
| **LOW** | Config/data dirs `0755`/`0644` → `0700`/`0600` (protects API keys) |

Also adds `DeleteMyCommands` + `SetMyCommands` to telegram bot startup so old BotFather commands are replaced with Ghost's menu.

## Test plan
- [x] `go vet` clean on all changed packages
- [x] `go test ./internal/tool/... ./internal/server/... ./internal/config/...` — all pass
- [ ] Manual: verify grep with `path: "../../"` returns path error
- [ ] Manual: verify telegram bot shows Ghost commands in menu after startup