### PR TITLE
fix(security): audit sweep round 2 fixes

### DIFF
--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -77,7 +77,7 @@ func (c *Client) ChatStream(
 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("API returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
@@ -126,7 +126,7 @@ func (c *Client) Reflect(ctx context.Context, prompt string) (string, TokenUsage
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB limit
 	if err != nil {
 		return "", TokenUsage{}, fmt.Errorf("read reflect response: %w", err)
 	}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -101,6 +101,13 @@ func (s *Server) registerTools() {
 		if args.Category == "" {
 			args.Category = "fact"
 		}
+		validCategories := map[string]bool{
+			"architecture": true, "decision": true, "pattern": true, "convention": true,
+			"gotcha": true, "dependency": true, "preference": true, "fact": true,
+		}
+		if !validCategories[args.Category] {
+			return nil, nil, fmt.Errorf("invalid category %q — must be one of: architecture, decision, pattern, convention, gotcha, dependency, preference, fact", args.Category)
+		}
 		if args.Importance <= 0 {
 			args.Importance = 0.7
 		}

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -58,7 +58,7 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 	session, err := s.orchestrator.StartSession(req.Path)
 	if err != nil {
 		s.logger.Error("start session", "error", err)
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeError(w, http.StatusInternalServerError, "failed to start session")
 		return
 	}
 
@@ -104,7 +104,8 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.orchestrator.StopSession(session.ProjectPath); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.logger.Error("stop session", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to stop session")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
@@ -134,23 +135,8 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set up SSE headers.
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("X-Accel-Buffering", "no")
-	w.WriteHeader(http.StatusOK)
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		writeError(w, http.StatusInternalServerError, "streaming not supported")
-		return
-	}
-
-	// Create approval channel for this request.
-	approvalCh := make(chan provider.ApprovalRequest, 1)
-
 	// Reject concurrent sends — only one stream per session.
+	// Must happen before writing SSE headers (can't send JSON error after SSE 200).
 	state := &chatState{}
 	s.chatMu.Lock()
 	if _, active := s.chatStates[id]; active {
@@ -160,6 +146,25 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	s.chatStates[id] = state
 	s.chatMu.Unlock()
+
+	// Set up SSE headers.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		s.chatMu.Lock()
+		delete(s.chatStates, id)
+		s.chatMu.Unlock()
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	// Create approval channel for this request.
+	approvalCh := make(chan provider.ApprovalRequest, 1)
 	defer func() {
 		s.chatMu.Lock()
 		// Only delete if we own the state (prevents race on cleanup).

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -92,6 +92,8 @@ func (s *Server) Run(ctx context.Context) error {
 		Addr:              s.cfg.ListenAddr,
 		Handler:           r,
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		IdleTimeout:       120 * time.Second,
 		BaseContext:       func(_ net.Listener) context.Context { return ctx },
 	}
 

--- a/internal/voice/pipeline.go
+++ b/internal/voice/pipeline.go
@@ -178,6 +178,9 @@ func (p *Pipeline) HandlePushToTalk(ctx context.Context) (transcript, response s
 	return transcript, response, nil
 }
 
+// maxRecordingBytes caps recording at ~5 minutes of 16kHz 16-bit mono audio (~9.6MB).
+const maxRecordingBytes = 10 * 1024 * 1024
+
 // collectUntilSilence accumulates audio frames until VAD detects
 // sustained silence (silenceMs worth of non-speech frames).
 func (p *Pipeline) collectUntilSilence(ctx context.Context, frames <-chan []byte) ([]byte, error) {
@@ -201,6 +204,12 @@ func (p *Pipeline) collectUntilSilence(ctx context.Context, frames <-chan []byte
 			}
 
 			buf.Write(frame)
+
+			// Cap recording to prevent unbounded memory growth.
+			if buf.Len() > maxRecordingBytes {
+				p.logger.Warn("max recording size reached", "bytes", buf.Len())
+				return buf.Bytes(), nil
+			}
 
 			// If no VAD, collect until channel closes (manual stop).
 			if p.vad == nil {

--- a/internal/voice/stt_whisper.go
+++ b/internal/voice/stt_whisper.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 )
 
@@ -45,12 +44,18 @@ func (w *WhisperSTT) Transcribe(ctx context.Context, audio []byte) (string, erro
 	}
 
 	// Write audio as WAV to temp file (whisper expects WAV input).
-	tmpDir := os.TempDir()
-	wavPath := filepath.Join(tmpDir, "ghost-stt.wav")
+	// Use CreateTemp for unique name + secure permissions.
+	tmpFile, err := os.CreateTemp("", "ghost-stt-*.wav")
+	if err != nil {
+		return "", fmt.Errorf("create temp wav: %w", err)
+	}
+	wavPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(wavPath)
+
 	if err := writeWAV(wavPath, audio, 16000); err != nil {
 		return "", fmt.Errorf("write temp wav: %w", err)
 	}
-	defer os.Remove(wavPath)
 
 	// Run whisper.
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
## Summary
- **MEDIUM**: Limit API error response reads with `io.LimitReader` (prevents OOM on malicious responses)
- **MEDIUM**: Add `ReadTimeout: 30s` + `IdleTimeout: 120s` to HTTP server (prevents slowloris)
- **LOW**: Move SSE conflict check before header write (was sending JSON error inside SSE stream)
- **LOW**: Sanitize internal error details from session handler responses
- **LOW**: Use `os.CreateTemp` for whisper WAV files (unique name, secure permissions)
- **LOW**: Cap audio recording buffer at 10MB (~5 min) to prevent unbounded memory growth
- **LOW**: Add category validation in MCP server `ghost_memory_save` tool

## Test plan
- [x] `go vet` passes on all changed packages
- [x] Voice tests pass (13/13)