### PR TITLE
fix(telegram): use MarkdownV1 to avoid reserved char escaping

### DIFF
--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -111,7 +111,7 @@ func (tb *Bot) SendMessage(ctx context.Context, chatID int64, text string) error
 	_, err := tb.bot.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID:    chatID,
 		Text:      text,
-		ParseMode: models.ParseModeMarkdown,
+		ParseMode: models.ParseModeMarkdownV1,
 	})
 	return err
 }
@@ -296,7 +296,7 @@ func (tb *Bot) reply(ctx context.Context, b *bot.Bot, update *models.Update, tex
 	_, err := b.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID:    update.Message.Chat.ID,
 		Text:      text,
-		ParseMode: models.ParseModeMarkdown,
+		ParseMode: models.ParseModeMarkdownV1,
 	})
 	if err != nil {
 		tb.logger.Error("telegram send", "error", err, "chat_id", update.Message.Chat.ID)

--- a/vscode-ghost/package.json
+++ b/vscode-ghost/package.json
@@ -62,7 +62,7 @@
       "properties": {
         "ghost.serverUrl": {
           "type": "string",
-          "default": "http://127.0.0.1:2444",
+          "default": "http://127.0.0.1:2187",
           "description": "URL of the ghost serve daemon"
         },
         "ghost.authToken": {

--- a/vscode-ghost/src/extension.ts
+++ b/vscode-ghost/src/extension.ts
@@ -167,7 +167,7 @@ function createClient(): GhostClient {
   const config = vscode.workspace.getConfiguration("ghost");
   const serverUrl = config.get<string>(
     "serverUrl",
-    "http://127.0.0.1:2444"
+    "http://127.0.0.1:2187"
   );
   const authToken = config.get<string>("authToken", "");
   return new GhostClient(serverUrl, authToken);


### PR DESCRIPTION
## Summary
- `ParseModeMarkdown` in go-telegram/bot resolves to `MarkdownV2`, which requires escaping `.` `-` `(` `)` etc. Switched to `ParseModeMarkdownV1` which handles `*bold*`, `_italic_`, `` `code` `` without needing to escape every special character.
- Fixed VSCode extension default port from `2444` → `2187` to match `ghost serve` config.

## Test plan
- [ ] Start `ghost serve`, verify Telegram bot no longer throws parse errors on startup
- [ ] Verify `/status`, `/briefing`, `/notifications` commands render correctly
- [ ] Verify VSCode extension connects without manual port config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Telegram message parsing format configuration.

* **Configuration**
  * Updated default Ghost server port from 2444 to 2187.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->