### PR TITLE
fix(telegram): pass nil to DeleteMyCommands to fix decode error

### DIFF
--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -84,8 +84,8 @@ func (tb *Bot) Run(ctx context.Context) {
 // replacing any previously registered commands.
 func (tb *Bot) registerCommands(ctx context.Context) {
 	// Delete all existing commands first.
-	if _, err := tb.bot.DeleteMyCommands(ctx, &bot.DeleteMyCommandsParams{}); err != nil {
-		tb.logger.Error("delete old telegram commands", "error", err)
+	if _, err := tb.bot.DeleteMyCommands(ctx, nil); err != nil {
+		tb.logger.Warn("delete old telegram commands (non-fatal)", "error", err)
 	}
 
 	commands := []models.BotCommand{


### PR DESCRIPTION
## Summary
- Empty `&bot.DeleteMyCommandsParams{}` causes the library to send an empty multipart form body, which Telegram returns as a response that fails JSON decode
- Passing `nil` skips form encoding entirely, fixing the startup error
- Downgraded log from Error to Warn since command registration succeeds regardless

## Test plan
- [ ] Start `ghost serve`, confirm no more `delete old telegram commands` error
- [ ] Verify commands still register (`telegram commands registered count=6`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for bot command deletion to ensure the bot continues operating even if command deletion fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->