### PR TITLE
fix(telegram): remove / prefix from command handler registration

### DIFF
--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -62,12 +62,12 @@ func New(cfg Config, store provider.MemoryStore, ghMonitor *gh.Monitor, sched *s
 	tb.bot = b
 
 	// Register commands.
-	b.RegisterHandler(bot.HandlerTypeMessageText, "/status", bot.MatchTypeCommand, tb.handleStatus)
-	b.RegisterHandler(bot.HandlerTypeMessageText, "/notifications", bot.MatchTypeCommand, tb.handleNotifications)
-	b.RegisterHandler(bot.HandlerTypeMessageText, "/memory", bot.MatchTypeCommand, tb.handleMemory)
-	b.RegisterHandler(bot.HandlerTypeMessageText, "/remind", bot.MatchTypeCommand, tb.handleRemind)
-	b.RegisterHandler(bot.HandlerTypeMessageText, "/briefing", bot.MatchTypeCommand, tb.handleBriefing)
-	b.RegisterHandler(bot.HandlerTypeMessageText, "/help", bot.MatchTypeCommand, tb.handleHelp)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "status", bot.MatchTypeCommand, tb.handleStatus)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "notifications", bot.MatchTypeCommand, tb.handleNotifications)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "memory", bot.MatchTypeCommand, tb.handleMemory)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "remind", bot.MatchTypeCommand, tb.handleRemind)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "briefing", bot.MatchTypeCommand, tb.handleBriefing)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "help", bot.MatchTypeCommand, tb.handleHelp)
 
 	return tb, nil
 }


### PR DESCRIPTION
## Summary
- `MatchTypeCommand` expects the command name without the `/` prefix (e.g. `"status"` not `"/status"`)
- With the prefix, no handlers matched and every command fell through to the default handler responding "Use /help to see available commands."

## Test plan
- [ ] Rebuild and restart `ghost serve`
- [ ] Send `/status`, `/help`, `/notifications` in Telegram — verify proper responses