### PR TITLE
feat(vscode): polished extension with markdown, cost, slash commands, auto-approve

### DIFF
--- a/assets/embed.go
+++ b/assets/embed.go
@@ -1,6 +1,1 @@
 package assets
-
-import _ "embed"
-
-//go:embed logo.png
-var LogoPNG []byte

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -327,6 +327,32 @@ func (s *Server) handleSetMode(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// --- Auto-Approve Handler ---
+
+type autoApproveRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+func (s *Server) handleAutoApprove(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	session := s.orchestrator.GetSessionByID(id)
+	if session == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	var req autoApproveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	session.SetAutoApprove(req.Enabled)
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"auto_approve": req.Enabled,
+	})
+}
+
 // --- SSE Helper ---
 
 func writeSSE(w http.ResponseWriter, flusher http.Flusher, eventType string, data interface{}) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,6 +84,7 @@ func (s *Server) Run(ctx context.Context) error {
 				r.Post("/{id}/send", withBodyLimit(s.handleSendMessage, 10<<20)) // 10MB (large messages)
 				r.Post("/{id}/approve", withBodyLimit(s.handleApprove, 1<<20))
 				r.Post("/{id}/mode", withBodyLimit(s.handleSetMode, 1<<20))
+				r.Post("/{id}/auto-approve", withBodyLimit(s.handleAutoApprove, 1<<20))
 			})
 		}
 	})

--- a/internal/tui/viewport.go
+++ b/internal/tui/viewport.go
@@ -2,33 +2,11 @@ package tui
 
 import (
 	"strings"
-	"sync"
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/wcatz/ghost/assets"
 )
-
-// ghostBanner is the large ASCII art for the welcome screen.
-var ghostBanner = strings.Join([]string{
-	`  ██████╗ ██╗  ██╗ ██████╗ ███████╗████████╗`,
-	` ██╔════╝ ██║  ██║██╔═══██╗██╔════╝╚══██╔══╝`,
-	` ██║  ███╗███████║██║   ██║███████╗   ██║   `,
-	` ██║   ██║██╔══██║██║   ██║╚════██║   ██║   `,
-	` ╚██████╔╝██║  ██║╚██████╔╝███████║   ██║   `,
-	`  ╚═════╝ ╚═╝  ╚═╝ ╚═════╝ ╚══════╝   ╚═╝   `,
-}, "\n")
-
-// ghostShadow is a small dim ghost watermark at the top of chat.
-var ghostShadow = strings.Join([]string{
-	`    ▄█████▄`,
-	`   █████████`,
-	`   ██ █ █ ██`,
-	`   █████████`,
-	`   █████████`,
-	`    █ █ █ █`,
-}, "\n")
 
 // chatViewport wraps a bubbles viewport with message management.
 type chatViewport struct {
@@ -104,11 +82,6 @@ func (cv *chatViewport) startNewAssistantMessage() {
 func (cv *chatViewport) rerender() {
 	var b strings.Builder
 
-	// Ghost shadow watermark at the top of chat history.
-	shadow := lipgloss.NewStyle().Foreground(colorSubtle).Render(ghostShadow)
-	b.WriteString(lipgloss.PlaceHorizontal(cv.width, lipgloss.Center, shadow))
-	b.WriteString("\n\n")
-
 	for _, msg := range cv.messages {
 		b.WriteString(cv.renderer.render(msg))
 		b.WriteString("\n")
@@ -134,34 +107,12 @@ func (cv chatViewport) update(msg tea.Msg) (chatViewport, tea.Cmd) {
 	return cv, cmd
 }
 
-// cachedLogo caches the half-block logo render (computed once).
-var (
-	cachedLogo     string
-	cachedLogoOnce sync.Once
-)
-
-func getLogoHalfBlock() string {
-	cachedLogoOnce.Do(func() {
-		cachedLogo = renderImageHalfBlock(assets.LogoPNG, 24)
-	})
-	return cachedLogo
-}
-
 // welcomeView renders a centered welcome screen when chat is empty.
 func (cv chatViewport) welcomeView() string {
-	// Try rendering the actual logo as half-block characters.
-	logo := getLogoHalfBlock()
-
-	var banner string
-	if logo != "" {
-		banner = logo
-	} else {
-		// Fallback to ASCII banner.
-		banner = lipgloss.NewStyle().
-			Foreground(colorGhost).
-			Bold(true).
-			Render(ghostBanner)
-	}
+	title := lipgloss.NewStyle().
+		Foreground(colorGhost).
+		Bold(true).
+		Render("ghost")
 
 	tagline := lipgloss.NewStyle().
 		Foreground(colorDim).
@@ -173,7 +124,7 @@ func (cv chatViewport) welcomeView() string {
 		Render("enter send · shift+enter newline · ctrl+k commands")
 
 	content := lipgloss.JoinVertical(lipgloss.Center,
-		banner,
+		title,
 		"",
 		tagline,
 		"",

--- a/vscode-ghost/media/chat.css
+++ b/vscode-ghost/media/chat.css
@@ -1,4 +1,4 @@
-/* Use VSCode's CSS variables for native look */
+/* Ghost Chat — VSCode native theme integration */
 :root {
   --ghost-accent: var(--vscode-textLink-foreground, #4fc1ff);
   --ghost-bg: var(--vscode-editor-background, #1e1e1e);
@@ -12,16 +12,14 @@
   --ghost-error: var(--vscode-errorForeground, #f44747);
   --ghost-success: var(--vscode-testing-iconPassed, #73c991);
   --ghost-muted: var(--vscode-descriptionForeground, #888);
+  --ghost-widget-bg: var(--vscode-editorWidget-background, #252526);
+  --ghost-hover: var(--vscode-list-hoverBackground, #2a2d2e);
 }
 
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+* { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: var(--vscode-font-family, monospace);
+  font-family: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, sans-serif);
   font-size: var(--vscode-font-size, 13px);
   color: var(--ghost-fg);
   background: var(--ghost-bg);
@@ -31,56 +29,101 @@ body {
   overflow: hidden;
 }
 
-/* --- Status Bar --- */
-#status-bar {
+body.drag-over { outline: 2px dashed var(--ghost-accent); outline-offset: -4px; }
+
+/* --- Header --- */
+#header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--ghost-border);
+  flex-shrink: 0;
+  font-size: 12px;
+}
+
+#header-left, #header-right {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 8px;
-  border-bottom: 1px solid var(--ghost-border);
-  font-size: 11px;
-  color: var(--ghost-muted);
+}
+
+.dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  display: inline-block;
   flex-shrink: 0;
 }
+.dot.connected { background: var(--ghost-success); }
+.dot.disconnected { background: var(--ghost-error); }
 
-#connection-status.connected {
-  color: var(--ghost-success);
-}
+#session-info { color: var(--ghost-fg); font-weight: 500; }
 
-#connection-status.disconnected {
-  color: var(--ghost-error);
-}
-
-#mode-display {
-  margin-left: auto;
+.mode-badge {
+  font-size: 11px;
+  padding: 1px 8px;
+  border-radius: 10px;
   background: var(--ghost-input-bg);
-  padding: 1px 6px;
-  border-radius: 3px;
+  color: var(--ghost-muted);
+  border: 1px solid var(--ghost-border);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.mode-badge.mode-code { color: var(--ghost-accent); border-color: var(--ghost-accent); }
+.mode-badge.mode-debug { color: #e5c07b; border-color: #e5c07b; }
+.mode-badge.mode-review { color: #c678dd; border-color: #c678dd; }
+.mode-badge.mode-plan { color: #98c379; border-color: #98c379; }
+.mode-badge.mode-refactor { color: #e06c75; border-color: #e06c75; }
+
+.header-btn {
+  background: none;
+  border: 1px solid var(--ghost-border);
+  border-radius: 4px;
+  color: var(--ghost-muted);
+  cursor: pointer;
+  padding: 2px 6px;
+  font-size: 14px;
+  line-height: 1;
+}
+.header-btn:hover { background: var(--ghost-hover); color: var(--ghost-fg); }
+
+#session-cost {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 11px;
+  color: var(--ghost-muted);
 }
 
 /* --- Messages --- */
 #messages {
   flex: 1;
   overflow-y: auto;
-  padding: 8px;
+  padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
+  scroll-behavior: smooth;
 }
 
 .message {
-  padding: 6px 10px;
-  border-radius: 6px;
-  line-height: 1.5;
-  white-space: pre-wrap;
+  padding: 8px 12px;
+  border-radius: 8px;
+  line-height: 1.6;
   word-break: break-word;
   max-width: 95%;
+  animation: fadeIn 0.15s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 .message.user {
   align-self: flex-end;
   background: var(--vscode-textBlockQuote-background, #2a2d2e);
   border: 1px solid var(--ghost-border);
+  border-radius: 8px 8px 2px 8px;
+  white-space: pre-wrap;
 }
 
 .message.assistant {
@@ -88,96 +131,246 @@ body {
   background: transparent;
 }
 
-.message.thinking {
-  align-self: flex-start;
+.message.system {
+  align-self: center;
   color: var(--ghost-muted);
+  font-size: 0.85em;
   font-style: italic;
-  font-size: 0.9em;
-  border-left: 2px solid var(--ghost-border);
-  padding-left: 8px;
 }
 
 .message.error {
   color: var(--ghost-error);
+  font-size: 0.9em;
+  border-left: 3px solid var(--ghost-error);
+  padding-left: 10px;
+}
+
+/* --- Thinking blocks (collapsible) --- */
+.thinking-block {
+  border-left: 2px solid var(--ghost-accent);
+  margin: 4px 0;
+  animation: fadeIn 0.15s ease-out;
+}
+
+.thinking-block summary {
+  font-size: 0.85em;
+  color: var(--ghost-muted);
+  cursor: pointer;
+  padding: 4px 10px;
+  user-select: none;
+}
+.thinking-block summary:hover { color: var(--ghost-fg); }
+
+.thinking-content {
+  font-size: 0.85em;
+  color: var(--ghost-muted);
+  font-style: italic;
+  padding: 4px 10px;
+  white-space: pre-wrap;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+/* --- Code blocks --- */
+.code-block {
+  background: var(--vscode-textCodeBlock-background, #1a1a1a);
+  border: 1px solid var(--ghost-border);
+  border-radius: 6px;
+  margin: 6px 0;
+  overflow: hidden;
+}
+
+.code-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 10px;
+  background: rgba(255,255,255,0.03);
+  border-bottom: 1px solid var(--ghost-border);
+  font-size: 11px;
+}
+
+.code-lang { color: var(--ghost-muted); text-transform: uppercase; letter-spacing: 0.5px; }
+
+.copy-btn {
+  background: none;
+  border: 1px solid var(--ghost-border);
+  color: var(--ghost-muted);
+  border-radius: 3px;
+  padding: 1px 8px;
+  cursor: pointer;
+  font-size: 11px;
+}
+.copy-btn:hover { color: var(--ghost-fg); background: var(--ghost-hover); }
+
+.code-block pre {
+  margin: 0;
+  padding: 10px;
+  overflow-x: auto;
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: var(--vscode-editor-font-size, 13px);
+  line-height: 1.5;
+}
+
+.code-block code { color: var(--ghost-fg); }
+
+.inline-code {
+  background: var(--vscode-textCodeBlock-background, #1a1a1a);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: var(--vscode-editor-font-family, monospace);
   font-size: 0.9em;
 }
 
 /* --- Tool Indicators --- */
 .tool-indicator {
   font-size: 0.85em;
-  padding: 3px 8px;
+  padding: 4px 10px;
   color: var(--ghost-muted);
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
+  animation: fadeIn 0.15s ease-out;
 }
 
-.tool-indicator.running .tool-icon {
-  animation: spin 1s linear infinite;
+.tool-name { font-family: var(--vscode-editor-font-family, monospace); }
+.tool-time { font-size: 0.85em; opacity: 0.6; }
+
+.spinner {
   display: inline-block;
+  width: 12px; height: 12px;
+  border: 2px solid var(--ghost-border);
+  border-top-color: var(--ghost-accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
 }
 
-.tool-indicator.done .tool-icon {
-  color: var(--ghost-success);
-}
+.check { color: var(--ghost-success); font-weight: bold; }
 
 @keyframes spin {
-  from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
 
 /* --- Usage Info --- */
 .usage-info {
   font-size: 0.8em;
+  font-family: var(--vscode-editor-font-family, monospace);
   color: var(--ghost-muted);
   text-align: right;
-  padding: 2px 8px;
+  padding: 2px 10px;
+  animation: fadeIn 0.15s ease-out;
 }
+
+/* --- Slash Command Menu --- */
+#slash-menu {
+  position: absolute;
+  bottom: 80px;
+  left: 12px;
+  right: 12px;
+  background: var(--ghost-widget-bg);
+  border: 1px solid var(--ghost-border);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+  max-height: 250px;
+  overflow-y: auto;
+  z-index: 100;
+}
+#slash-menu.hidden { display: none; }
+
+.slash-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+.slash-item:hover, .slash-item.selected {
+  background: var(--ghost-hover);
+}
+.slash-cmd {
+  font-family: var(--vscode-editor-font-family, monospace);
+  color: var(--ghost-accent);
+  font-weight: 500;
+  min-width: 130px;
+}
+.slash-desc { color: var(--ghost-muted); font-size: 0.9em; }
 
 /* --- Approval Bar --- */
 #approval-bar {
+  border-top: 1px solid var(--ghost-accent);
+  background: var(--ghost-widget-bg);
+  padding: 8px 12px;
+  flex-shrink: 0;
+  animation: slideUp 0.2s ease-out;
+}
+#approval-bar.hidden { display: none; }
+
+@keyframes slideUp {
+  from { transform: translateY(10px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.approval-content {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  background: var(--vscode-editorWidget-background, #252526);
-  border-top: 1px solid var(--ghost-border);
-  flex-shrink: 0;
+  justify-content: space-between;
+  gap: 12px;
 }
 
-#approval-bar.hidden {
-  display: none;
-}
+#approval-tool { font-size: 0.9em; flex: 1; }
 
-#approval-tool {
-  flex: 1;
-  font-size: 0.9em;
-}
-
-#approval-bar button {
-  padding: 3px 12px;
+.approval-actions { display: flex; gap: 6px; }
+.approval-actions button {
+  padding: 4px 14px;
   border: none;
-  border-radius: 3px;
+  border-radius: 4px;
   cursor: pointer;
-  font-size: 0.85em;
+  font-size: 12px;
+  font-weight: 500;
 }
-
-#approval-bar button.approve {
+#approve-btn {
   background: var(--ghost-button-bg);
   color: var(--ghost-button-fg);
 }
-
-#approval-bar button.deny {
+#approve-btn:hover { opacity: 0.9; }
+#deny-btn {
   background: var(--vscode-button-secondaryBackground, #3a3d41);
   color: var(--vscode-button-secondaryForeground, #d4d4d4);
 }
+#deny-btn:hover { opacity: 0.9; }
+
+/* --- Image Preview --- */
+#image-preview {
+  padding: 4px 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+#image-preview.hidden { display: none; }
+
+#preview-img {
+  max-height: 60px;
+  max-width: 120px;
+  border-radius: 4px;
+  border: 1px solid var(--ghost-border);
+}
+
+#remove-image {
+  background: none;
+  border: none;
+  color: var(--ghost-muted);
+  cursor: pointer;
+  font-size: 18px;
+}
+#remove-image:hover { color: var(--ghost-error); }
 
 /* --- Input Area --- */
 #input-area {
   display: flex;
   align-items: flex-end;
-  gap: 4px;
-  padding: 6px 8px;
+  gap: 6px;
+  padding: 8px 12px;
   border-top: 1px solid var(--ghost-border);
   flex-shrink: 0;
 }
@@ -187,57 +380,66 @@ body {
   background: var(--ghost-input-bg);
   color: var(--ghost-input-fg);
   border: 1px solid var(--ghost-input-border);
-  border-radius: 4px;
-  padding: 6px 8px;
+  border-radius: 6px;
+  padding: 8px 10px;
   font-family: inherit;
   font-size: inherit;
   resize: none;
   outline: none;
-  min-height: 32px;
-  max-height: 120px;
+  min-height: 36px;
+  max-height: 150px;
+  line-height: 1.4;
+  transition: border-color 0.15s;
 }
+#input:focus { border-color: var(--ghost-accent); }
+#input::placeholder { color: var(--ghost-muted); }
 
-#input:focus {
-  border-color: var(--ghost-accent);
-}
+#input-actions { display: flex; gap: 4px; align-items: flex-end; }
 
-#send-btn, #abort-btn {
-  width: 32px;
-  height: 32px;
+.icon-btn {
+  width: 32px; height: 32px;
   border: none;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
   font-size: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  transition: background 0.15s, opacity 0.15s;
 }
 
-#send-btn {
-  background: var(--ghost-button-bg);
-  color: var(--ghost-button-fg);
+#send-btn { background: var(--ghost-button-bg); color: var(--ghost-button-fg); }
+#send-btn:hover { opacity: 0.9; }
+#abort-btn { background: var(--ghost-error); color: #fff; }
+#abort-btn:hover { opacity: 0.9; }
+#attach-btn { background: none; color: var(--ghost-muted); border: 1px solid var(--ghost-border); }
+#attach-btn:hover { color: var(--ghost-fg); background: var(--ghost-hover); }
+
+/* --- Footer --- */
+#footer {
+  display: flex;
+  justify-content: space-between;
+  padding: 3px 12px;
+  font-size: 11px;
+  font-family: var(--vscode-editor-font-family, monospace);
+  color: var(--ghost-muted);
+  border-top: 1px solid var(--ghost-border);
+  flex-shrink: 0;
+  min-height: 18px;
 }
 
-#abort-btn {
-  background: var(--ghost-error);
-  color: #fff;
-}
+#footer-savings { color: var(--ghost-success); }
 
-.hidden {
-  display: none !important;
-}
+/* --- Utilities --- */
+.hidden { display: none !important; }
 
-/* Scrollbar styling */
-#messages::-webkit-scrollbar {
-  width: 6px;
-}
+a { color: var(--ghost-accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+strong { font-weight: 600; }
 
-#messages::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-#messages::-webkit-scrollbar-thumb {
-  background: var(--ghost-border);
-  border-radius: 3px;
-}
+/* Scrollbar */
+#messages::-webkit-scrollbar { width: 6px; }
+#messages::-webkit-scrollbar-track { background: transparent; }
+#messages::-webkit-scrollbar-thumb { background: var(--ghost-border); border-radius: 3px; }
+#messages::-webkit-scrollbar-thumb:hover { background: var(--ghost-muted); }

--- a/vscode-ghost/src/chat-editor.ts
+++ b/vscode-ghost/src/chat-editor.ts
@@ -4,6 +4,7 @@ import {
   Session,
   ApprovalRequest,
 } from "./ghost-client";
+import { getChatHtml } from "./webview-html";
 
 export class ChatEditorPanel {
   public static readonly viewType = "ghost.chatEditor";
@@ -39,11 +40,7 @@ export class ChatEditorPanel {
       }
     );
 
-    ChatEditorPanel.currentPanel = new ChatEditorPanel(
-      panel,
-      extensionUri,
-      client
-    );
+    ChatEditorPanel.currentPanel = new ChatEditorPanel(panel, extensionUri, client);
     return ChatEditorPanel.currentPanel;
   }
 
@@ -55,13 +52,8 @@ export class ChatEditorPanel {
     this.panel = panel;
     this.client = client;
 
-    this.panel.iconPath = vscode.Uri.joinPath(
-      extensionUri,
-      "media",
-      "ghost-icon.svg"
-    );
-
-    this.panel.webview.html = this.getHtml(this.panel.webview);
+    this.panel.iconPath = vscode.Uri.joinPath(extensionUri, "media", "ghost-icon.svg");
+    this.panel.webview.html = getChatHtml(this.panel.webview, this.extensionUri);
 
     this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
 
@@ -69,7 +61,7 @@ export class ChatEditorPanel {
       async (msg) => {
         switch (msg.type) {
           case "send":
-            await this.handleSend(msg.text);
+            await this.handleSend(msg.text, msg.image);
             break;
           case "approve":
             await this.handleApprove(msg.approved);
@@ -79,6 +71,12 @@ export class ChatEditorPanel {
             break;
           case "setMode":
             await this.handleSetMode(msg.mode);
+            break;
+          case "set_auto_approve":
+            await this.handleAutoApprove(msg.enabled);
+            break;
+          case "attach_image":
+            await this.handleAttachImage();
             break;
           case "ready":
             await this.handleReady();
@@ -99,86 +97,54 @@ export class ChatEditorPanel {
     this.panel.dispose();
     while (this.disposables.length) {
       const d = this.disposables.pop();
-      if (d) {
-        d.dispose();
-      }
+      if (d) d.dispose();
     }
   }
 
   private async handleReady(): Promise<void> {
     const available = await this.client.isAvailable();
     this.postMessage({ type: "status", connected: available });
-    if (available) {
-      await this.ensureSession();
-    }
+    if (available) await this.ensureSession();
   }
 
   private async ensureSession(): Promise<void> {
-    if (this.session) {
-      return;
-    }
+    if (this.session) return;
     const folders = vscode.workspace.workspaceFolders;
     if (!folders || folders.length === 0) {
-      this.postMessage({
-        type: "error",
-        text: "No workspace folder open. Open a project first.",
-      });
+      this.postMessage({ type: "error", text: "No workspace folder open." });
       return;
     }
     try {
       this.session = await this.client.createSession(folders[0].uri.fsPath);
       this.postMessage({ type: "session", session: this.session });
     } catch (err) {
-      this.postMessage({
-        type: "error",
-        text: `Failed to create session: ${err}`,
-      });
+      this.postMessage({ type: "error", text: `Failed to create session: ${err}` });
     }
   }
 
-  private async handleSend(text: string): Promise<void> {
-    if (!text.trim()) {
-      return;
-    }
+  private async handleSend(text: string, image?: { media_type: string; data: string }): Promise<void> {
+    if (!text.trim() && !image) return;
     await this.ensureSession();
-    if (!this.session) {
-      return;
-    }
+    if (!this.session) return;
 
     this.postMessage({ type: "user_message", text });
     this.postMessage({ type: "streaming", active: true });
 
-    const { events, abort } = this.client.sendMessage(this.session.id, text);
+    const { events, abort } = this.client.sendMessage(this.session.id, text, image);
     this.abortFn = abort;
 
-    events.on("text", (t: string) => {
-      this.postMessage({ type: "text_delta", text: t });
-    });
-    events.on("thinking", (t: string) => {
-      this.postMessage({ type: "thinking_delta", text: t });
-    });
-    events.on("tool_start", (data: { id: string; name: string }) => {
-      this.postMessage({ type: "tool_start", ...data });
-    });
-    events.on("tool_delta", (data: { id: string; delta: string }) => {
-      this.postMessage({ type: "tool_delta", ...data });
-    });
-    events.on("tool_end", (data: { id: string; name: string }) => {
-      this.postMessage({ type: "tool_end", ...data });
-    });
-    events.on("approval", (data: ApprovalRequest) => {
-      this.postMessage({
-        type: "approval_required",
-        tool_name: data.tool_name,
-        input: data.input,
-      });
-    });
+    events.on("text", (t: string) => this.postMessage({ type: "text_delta", text: t }));
+    events.on("thinking", (t: string) => this.postMessage({ type: "thinking_delta", text: t }));
+    events.on("tool_start", (data: { id: string; name: string }) =>
+      this.postMessage({ type: "tool_start", ...data }));
+    events.on("tool_delta", (data: { id: string; delta: string }) =>
+      this.postMessage({ type: "tool_delta", ...data }));
+    events.on("tool_end", (data: { id: string; name: string }) =>
+      this.postMessage({ type: "tool_end", ...data }));
+    events.on("approval", (data: ApprovalRequest) =>
+      this.postMessage({ type: "approval_required", tool_name: data.tool_name, input: data.input }));
     events.on("done", (data: Record<string, unknown>) => {
-      this.postMessage({
-        type: "done",
-        usage: data.usage,
-        stop_reason: data.stop_reason,
-      });
+      this.postMessage({ type: "done", usage: data.usage, stop_reason: data.stop_reason });
       this.postMessage({ type: "streaming", active: false });
       this.abortFn = undefined;
     });
@@ -194,9 +160,7 @@ export class ChatEditorPanel {
   }
 
   private async handleApprove(approved: boolean): Promise<void> {
-    if (!this.session) {
-      return;
-    }
+    if (!this.session) return;
     try {
       await this.client.approve(this.session.id, approved);
     } catch (err) {
@@ -213,9 +177,7 @@ export class ChatEditorPanel {
   }
 
   private async handleSetMode(mode: string): Promise<void> {
-    if (!this.session) {
-      return;
-    }
+    if (!this.session) return;
     try {
       const result = await this.client.setMode(this.session.id, mode);
       this.postMessage({ type: "mode_changed", mode: result.mode });
@@ -224,219 +186,35 @@ export class ChatEditorPanel {
     }
   }
 
+  private async handleAutoApprove(enabled: boolean): Promise<void> {
+    if (!this.session) return;
+    try {
+      await this.client.setAutoApprove(this.session.id, enabled);
+    } catch (err) {
+      this.postMessage({ type: "error", text: `Auto-approve failed: ${err}` });
+    }
+  }
+
+  private async handleAttachImage(): Promise<void> {
+    const uris = await vscode.window.showOpenDialog({
+      canSelectMany: false,
+      filters: { Images: ["png", "jpg", "jpeg", "gif", "webp"] },
+    });
+    if (!uris || uris.length === 0) return;
+    const data = await vscode.workspace.fs.readFile(uris[0]);
+    const base64 = Buffer.from(data).toString("base64");
+    const ext = uris[0].fsPath.split(".").pop()?.toLowerCase() || "png";
+    const mimeMap: Record<string, string> = {
+      png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
+      gif: "image/gif", webp: "image/webp",
+    };
+    this.postMessage({
+      type: "image_data",
+      image: { media_type: mimeMap[ext] || "image/png", data: base64 },
+    });
+  }
+
   public postMessage(msg: Record<string, unknown>): void {
     this.panel.webview.postMessage(msg);
   }
-
-  private getHtml(webview: vscode.Webview): string {
-    const nonce = getNonce();
-    const styleUri = webview.asWebviewUri(
-      vscode.Uri.joinPath(this.extensionUri, "media", "chat.css")
-    );
-
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy"
-    content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
-  <link rel="stylesheet" href="${styleUri}">
-  <title>Ghost Chat</title>
-</head>
-<body>
-  <div id="status-bar">
-    <span id="connection-status">Connecting...</span>
-    <span id="session-info"></span>
-    <span id="mode-display"></span>
-  </div>
-  <div id="messages"></div>
-  <div id="approval-bar" class="hidden">
-    <span id="approval-tool"></span>
-    <button id="approve-btn" class="approve">Allow</button>
-    <button id="deny-btn" class="deny">Deny</button>
-  </div>
-  <div id="input-area">
-    <textarea id="input" placeholder="Message Ghost..." rows="2"></textarea>
-    <button id="send-btn" title="Send (Enter)">&#x27A4;</button>
-    <button id="abort-btn" class="hidden" title="Stop">&#x25A0;</button>
-  </div>
-  <script nonce="${nonce}">
-    const vscode = acquireVsCodeApi();
-    const messagesEl = document.getElementById('messages');
-    const inputEl = document.getElementById('input');
-    const sendBtn = document.getElementById('send-btn');
-    const abortBtn = document.getElementById('abort-btn');
-    const approvalBar = document.getElementById('approval-bar');
-    const approvalTool = document.getElementById('approval-tool');
-    const approveBtn = document.getElementById('approve-btn');
-    const denyBtn = document.getElementById('deny-btn');
-    const connectionStatus = document.getElementById('connection-status');
-    const sessionInfo = document.getElementById('session-info');
-    const modeDisplay = document.getElementById('mode-display');
-
-    let currentAssistantEl = null;
-    let currentThinkingEl = null;
-    let streaming = false;
-
-    function scrollToBottom() {
-      messagesEl.scrollTop = messagesEl.scrollHeight;
-    }
-
-    function addMessage(role, text) {
-      const div = document.createElement('div');
-      div.className = 'message ' + role;
-      div.textContent = text;
-      messagesEl.appendChild(div);
-      scrollToBottom();
-      return div;
-    }
-
-    function ensureAssistantBubble() {
-      if (!currentAssistantEl) {
-        currentAssistantEl = document.createElement('div');
-        currentAssistantEl.className = 'message assistant';
-        messagesEl.appendChild(currentAssistantEl);
-      }
-      return currentAssistantEl;
-    }
-
-    function addToolIndicator(name, status) {
-      const div = document.createElement('div');
-      div.className = 'tool-indicator ' + status;
-      div.dataset.toolName = name;
-      div.innerHTML = '<span class="tool-icon">' +
-        (status === 'running' ? '&#9881;' : '&#10003;') +
-        '</span> ' + name;
-      messagesEl.appendChild(div);
-      scrollToBottom();
-      return div;
-    }
-
-    function send() {
-      const text = inputEl.value.trim();
-      if (!text || streaming) return;
-      vscode.postMessage({ type: 'send', text });
-      inputEl.value = '';
-      inputEl.style.height = 'auto';
-    }
-
-    sendBtn.addEventListener('click', send);
-    inputEl.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        send();
-      }
-    });
-
-    inputEl.addEventListener('input', () => {
-      inputEl.style.height = 'auto';
-      inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';
-    });
-
-    abortBtn.addEventListener('click', () => {
-      vscode.postMessage({ type: 'abort' });
-    });
-
-    approveBtn.addEventListener('click', () => {
-      vscode.postMessage({ type: 'approve', approved: true });
-      approvalBar.classList.add('hidden');
-    });
-    denyBtn.addEventListener('click', () => {
-      vscode.postMessage({ type: 'approve', approved: false });
-      approvalBar.classList.add('hidden');
-    });
-
-    window.addEventListener('message', (event) => {
-      const msg = event.data;
-      switch (msg.type) {
-        case 'status':
-          connectionStatus.textContent = msg.connected ? 'Connected' : 'Disconnected';
-          connectionStatus.className = msg.connected ? 'connected' : 'disconnected';
-          break;
-        case 'session':
-          sessionInfo.textContent = msg.session.project_name;
-          modeDisplay.textContent = msg.session.mode;
-          break;
-        case 'user_message':
-          addMessage('user', msg.text);
-          currentAssistantEl = null;
-          currentThinkingEl = null;
-          break;
-        case 'text_delta':
-          ensureAssistantBubble().textContent += msg.text;
-          scrollToBottom();
-          break;
-        case 'thinking_delta':
-          if (!currentThinkingEl) {
-            currentThinkingEl = document.createElement('div');
-            currentThinkingEl.className = 'message thinking';
-            messagesEl.appendChild(currentThinkingEl);
-          }
-          currentThinkingEl.textContent += msg.text;
-          scrollToBottom();
-          break;
-        case 'tool_start':
-          addToolIndicator(msg.name, 'running');
-          break;
-        case 'tool_end': {
-          const indicators = messagesEl.querySelectorAll('.tool-indicator.running');
-          indicators.forEach(el => {
-            if (el.dataset.toolName === msg.name) {
-              el.className = 'tool-indicator done';
-              el.querySelector('.tool-icon').innerHTML = '&#10003;';
-            }
-          });
-          break;
-        }
-        case 'approval_required':
-          approvalTool.textContent = msg.tool_name + ': approve?';
-          approvalBar.classList.remove('hidden');
-          scrollToBottom();
-          break;
-        case 'done':
-          currentAssistantEl = null;
-          currentThinkingEl = null;
-          if (msg.usage) {
-            const usage = msg.usage;
-            const info = document.createElement('div');
-            info.className = 'usage-info';
-            info.textContent = 'in:' + (usage.input_tokens || 0) +
-              ' out:' + (usage.output_tokens || 0);
-            if (usage.cache_read_input_tokens) {
-              info.textContent += ' cache:' + usage.cache_read_input_tokens;
-            }
-            messagesEl.appendChild(info);
-            scrollToBottom();
-          }
-          break;
-        case 'streaming':
-          streaming = msg.active;
-          sendBtn.classList.toggle('hidden', msg.active);
-          abortBtn.classList.toggle('hidden', !msg.active);
-          break;
-        case 'mode_changed':
-          modeDisplay.textContent = msg.mode;
-          break;
-        case 'error':
-          addMessage('error', msg.text);
-          break;
-      }
-    });
-
-    vscode.postMessage({ type: 'ready' });
-  </script>
-</body>
-</html>`;
-  }
-}
-
-function getNonce(): string {
-  let text = "";
-  const chars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  for (let i = 0; i < 32; i++) {
-    text += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return text;
 }

--- a/vscode-ghost/src/chat-panel.ts
+++ b/vscode-ghost/src/chat-panel.ts
@@ -2,9 +2,9 @@ import * as vscode from "vscode";
 import {
   GhostClient,
   Session,
-  StreamEvent,
   ApprovalRequest,
 } from "./ghost-client";
+import { getChatHtml } from "./webview-html";
 
 export class ChatPanelProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = "ghost.chat";
@@ -39,12 +39,12 @@ export class ChatPanelProvider implements vscode.WebviewViewProvider {
       ],
     };
 
-    webviewView.webview.html = this.getHtml(webviewView.webview);
+    webviewView.webview.html = getChatHtml(webviewView.webview, this.extensionUri);
 
     webviewView.webview.onDidReceiveMessage(async (msg) => {
       switch (msg.type) {
         case "send":
-          await this.handleSend(msg.text);
+          await this.handleSend(msg.text, msg.image);
           break;
         case "approve":
           await this.handleApprove(msg.approved);
@@ -55,6 +55,12 @@ export class ChatPanelProvider implements vscode.WebviewViewProvider {
         case "setMode":
           await this.handleSetMode(msg.mode);
           break;
+        case "set_auto_approve":
+          await this.handleAutoApprove(msg.enabled);
+          break;
+        case "attach_image":
+          await this.handleAttachImage();
+          break;
         case "ready":
           await this.handleReady();
           break;
@@ -64,11 +70,7 @@ export class ChatPanelProvider implements vscode.WebviewViewProvider {
 
   private async handleReady(): Promise<void> {
     const available = await this.client.isAvailable();
-    this.postMessage({
-      type: "status",
-      connected: available,
-    });
-
+    this.postMessage({ type: "status", connected: available });
     if (available) {
       await this.ensureSession();
     }
@@ -78,7 +80,6 @@ export class ChatPanelProvider implements vscode.WebviewViewProvider {
     if (this.session) {
       return;
     }
-
     const folders = vscode.workspace.workspaceFolders;
     if (!folders || folders.length === 0) {
       this.postMessage({
@@ -87,28 +88,18 @@ export class ChatPanelProvider implements vscode.WebviewViewProvider {
       });
       return;
     }
-
     try {
-      this.session = await this.client.createSession(
-        folders[0].uri.fsPath
-      );
-      this.postMessage({
-        type: "session",
-        session: this.session,
-      });
+      this.session = await this.client.createSession(folders[0].uri.fsPath);
+      this.postMessage({ type: "session", session: this.session });
     } catch (err) {
-      this.postMessage({
-        type: "error",
-        text: `Failed to create session: ${err}`,
-      });
+      this.postMessage({ type: "error", text: `Failed to create session: ${err}` });
     }
   }
 
-  private async handleSend(text: string): Promise<void> {
-    if (!text.trim()) {
+  private async handleSend(text: string, image?: { media_type: string; data: string }): Promise<void> {
+    if (!text.trim() && !image) {
       return;
     }
-
     await this.ensureSession();
     if (!this.session) {
       return;
@@ -117,59 +108,29 @@ export class ChatPanelProvider implements vscode.WebviewViewProvider {
     this.postMessage({ type: "user_message", text });
     this.postMessage({ type: "streaming", active: true });
 
-    const { events, abort } = this.client.sendMessage(
-      this.session.id,
-      text
-    );
+    const { events, abort } = this.client.sendMessage(this.session.id, text, image);
     this.abortFn = abort;
 
-    events.on("text", (text: string) => {
-      this.postMessage({ type: "text_delta", text });
-    });
-
-    events.on("thinking", (text: string) => {
-      this.postMessage({ type: "thinking_delta", text });
-    });
-
-    events.on("tool_start", (data: { id: string; name: string }) => {
-      this.postMessage({ type: "tool_start", ...data });
-    });
-
-    events.on(
-      "tool_delta",
-      (data: { id: string; delta: string }) => {
-        this.postMessage({ type: "tool_delta", ...data });
-      }
-    );
-
-    events.on("tool_end", (data: { id: string; name: string }) => {
-      this.postMessage({ type: "tool_end", ...data });
-    });
-
-    events.on("approval", (data: ApprovalRequest) => {
-      this.postMessage({
-        type: "approval_required",
-        tool_name: data.tool_name,
-        input: data.input,
-      });
-    });
-
+    events.on("text", (t: string) => this.postMessage({ type: "text_delta", text: t }));
+    events.on("thinking", (t: string) => this.postMessage({ type: "thinking_delta", text: t }));
+    events.on("tool_start", (data: { id: string; name: string }) =>
+      this.postMessage({ type: "tool_start", ...data }));
+    events.on("tool_delta", (data: { id: string; delta: string }) =>
+      this.postMessage({ type: "tool_delta", ...data }));
+    events.on("tool_end", (data: { id: string; name: string }) =>
+      this.postMessage({ type: "tool_end", ...data }));
+    events.on("approval", (data: ApprovalRequest) =>
+      this.postMessage({ type: "approval_required", tool_name: data.tool_name, input: data.input }));
     events.on("done", (data: Record<string, unknown>) => {
-      this.postMessage({
-        type: "done",
-        usage: data.usage,
-        stop_reason: data.stop_reason,
-      });
+      this.postMessage({ type: "done", usage: data.usage, stop_reason: data.stop_reason });
       this.postMessage({ type: "streaming", active: false });
       this.abortFn = undefined;
     });
-
     events.on("error", (err: Error) => {
       this.postMessage({ type: "error", text: err.message });
       this.postMessage({ type: "streaming", active: false });
       this.abortFn = undefined;
     });
-
     events.on("close", () => {
       this.postMessage({ type: "streaming", active: false });
       this.abortFn = undefined;
@@ -177,16 +138,11 @@ export class ChatPanelProvider implements vscode.WebviewViewProvider {
   }
 
   private async handleApprove(approved: boolean): Promise<void> {
-    if (!this.session) {
-      return;
-    }
+    if (!this.session) return;
     try {
       await this.client.approve(this.session.id, approved);
     } catch (err) {
-      this.postMessage({
-        type: "error",
-        text: `Approval failed: ${err}`,
-      });
+      this.postMessage({ type: "error", text: `Approval failed: ${err}` });
     }
   }
 
@@ -199,250 +155,44 @@ export class ChatPanelProvider implements vscode.WebviewViewProvider {
   }
 
   private async handleSetMode(mode: string): Promise<void> {
-    if (!this.session) {
-      return;
-    }
+    if (!this.session) return;
     try {
       const result = await this.client.setMode(this.session.id, mode);
       this.postMessage({ type: "mode_changed", mode: result.mode });
     } catch (err) {
-      this.postMessage({
-        type: "error",
-        text: `Set mode failed: ${err}`,
-      });
+      this.postMessage({ type: "error", text: `Set mode failed: ${err}` });
     }
+  }
+
+  private async handleAutoApprove(enabled: boolean): Promise<void> {
+    if (!this.session) return;
+    try {
+      await this.client.setAutoApprove(this.session.id, enabled);
+    } catch (err) {
+      this.postMessage({ type: "error", text: `Auto-approve failed: ${err}` });
+    }
+  }
+
+  private async handleAttachImage(): Promise<void> {
+    const uris = await vscode.window.showOpenDialog({
+      canSelectMany: false,
+      filters: { Images: ["png", "jpg", "jpeg", "gif", "webp"] },
+    });
+    if (!uris || uris.length === 0) return;
+    const data = await vscode.workspace.fs.readFile(uris[0]);
+    const base64 = Buffer.from(data).toString("base64");
+    const ext = uris[0].fsPath.split(".").pop()?.toLowerCase() || "png";
+    const mimeMap: Record<string, string> = {
+      png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
+      gif: "image/gif", webp: "image/webp",
+    };
+    this.postMessage({
+      type: "image_data",
+      image: { media_type: mimeMap[ext] || "image/png", data: base64 },
+    });
   }
 
   public postMessage(msg: Record<string, unknown>): void {
     this.view?.webview.postMessage(msg);
   }
-
-  private getHtml(webview: vscode.Webview): string {
-    const nonce = getNonce();
-    const styleUri = webview.asWebviewUri(
-      vscode.Uri.joinPath(this.extensionUri, "media", "chat.css")
-    );
-
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy"
-    content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
-  <link rel="stylesheet" href="${styleUri}">
-  <title>Ghost Chat</title>
-</head>
-<body>
-  <div id="status-bar">
-    <span id="connection-status">Connecting...</span>
-    <span id="session-info"></span>
-    <span id="mode-display"></span>
-  </div>
-  <div id="messages"></div>
-  <div id="approval-bar" class="hidden">
-    <span id="approval-tool"></span>
-    <button id="approve-btn" class="approve">Allow</button>
-    <button id="deny-btn" class="deny">Deny</button>
-  </div>
-  <div id="input-area">
-    <textarea id="input" placeholder="Message Ghost..." rows="2"></textarea>
-    <button id="send-btn" title="Send (Enter)">&#x27A4;</button>
-    <button id="abort-btn" class="hidden" title="Stop">&#x25A0;</button>
-  </div>
-  <script nonce="${nonce}">
-    const vscode = acquireVsCodeApi();
-    const messagesEl = document.getElementById('messages');
-    const inputEl = document.getElementById('input');
-    const sendBtn = document.getElementById('send-btn');
-    const abortBtn = document.getElementById('abort-btn');
-    const approvalBar = document.getElementById('approval-bar');
-    const approvalTool = document.getElementById('approval-tool');
-    const approveBtn = document.getElementById('approve-btn');
-    const denyBtn = document.getElementById('deny-btn');
-    const connectionStatus = document.getElementById('connection-status');
-    const sessionInfo = document.getElementById('session-info');
-    const modeDisplay = document.getElementById('mode-display');
-
-    let currentAssistantEl = null;
-    let currentThinkingEl = null;
-    let streaming = false;
-
-    function scrollToBottom() {
-      messagesEl.scrollTop = messagesEl.scrollHeight;
-    }
-
-    function addMessage(role, text) {
-      const div = document.createElement('div');
-      div.className = 'message ' + role;
-      div.textContent = text;
-      messagesEl.appendChild(div);
-      scrollToBottom();
-      return div;
-    }
-
-    function ensureAssistantBubble() {
-      if (!currentAssistantEl) {
-        currentAssistantEl = document.createElement('div');
-        currentAssistantEl.className = 'message assistant';
-        messagesEl.appendChild(currentAssistantEl);
-      }
-      return currentAssistantEl;
-    }
-
-    function addToolIndicator(name, status) {
-      const div = document.createElement('div');
-      div.className = 'tool-indicator ' + status;
-      div.dataset.toolName = name;
-      div.innerHTML = '<span class="tool-icon">' +
-        (status === 'running' ? '&#9881;' : '&#10003;') +
-        '</span> ' + name;
-      messagesEl.appendChild(div);
-      scrollToBottom();
-      return div;
-    }
-
-    // --- Send ---
-    function send() {
-      const text = inputEl.value.trim();
-      if (!text || streaming) return;
-      vscode.postMessage({ type: 'send', text });
-      inputEl.value = '';
-      inputEl.style.height = 'auto';
-    }
-
-    sendBtn.addEventListener('click', send);
-    inputEl.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        send();
-      }
-    });
-
-    // Auto-resize textarea.
-    inputEl.addEventListener('input', () => {
-      inputEl.style.height = 'auto';
-      inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';
-    });
-
-    // --- Abort ---
-    abortBtn.addEventListener('click', () => {
-      vscode.postMessage({ type: 'abort' });
-    });
-
-    // --- Approval ---
-    approveBtn.addEventListener('click', () => {
-      vscode.postMessage({ type: 'approve', approved: true });
-      approvalBar.classList.add('hidden');
-    });
-    denyBtn.addEventListener('click', () => {
-      vscode.postMessage({ type: 'approve', approved: false });
-      approvalBar.classList.add('hidden');
-    });
-
-    // --- Messages from extension ---
-    window.addEventListener('message', (event) => {
-      const msg = event.data;
-      switch (msg.type) {
-        case 'status':
-          connectionStatus.textContent = msg.connected ? 'Connected' : 'Disconnected';
-          connectionStatus.className = msg.connected ? 'connected' : 'disconnected';
-          break;
-
-        case 'session':
-          sessionInfo.textContent = msg.session.project_name;
-          modeDisplay.textContent = msg.session.mode;
-          break;
-
-        case 'user_message':
-          addMessage('user', msg.text);
-          currentAssistantEl = null;
-          currentThinkingEl = null;
-          break;
-
-        case 'text_delta':
-          ensureAssistantBubble().textContent += msg.text;
-          scrollToBottom();
-          break;
-
-        case 'thinking_delta':
-          if (!currentThinkingEl) {
-            currentThinkingEl = document.createElement('div');
-            currentThinkingEl.className = 'message thinking';
-            messagesEl.appendChild(currentThinkingEl);
-          }
-          currentThinkingEl.textContent += msg.text;
-          scrollToBottom();
-          break;
-
-        case 'tool_start':
-          addToolIndicator(msg.name, 'running');
-          break;
-
-        case 'tool_end': {
-          const indicators = messagesEl.querySelectorAll('.tool-indicator.running');
-          indicators.forEach(el => {
-            if (el.dataset.toolName === msg.name) {
-              el.className = 'tool-indicator done';
-              el.querySelector('.tool-icon').innerHTML = '&#10003;';
-            }
-          });
-          break;
-        }
-
-        case 'approval_required':
-          approvalTool.textContent = msg.tool_name + ': approve?';
-          approvalBar.classList.remove('hidden');
-          scrollToBottom();
-          break;
-
-        case 'done':
-          currentAssistantEl = null;
-          currentThinkingEl = null;
-          if (msg.usage) {
-            const usage = msg.usage;
-            const info = document.createElement('div');
-            info.className = 'usage-info';
-            info.textContent = 'in:' + (usage.input_tokens || 0) +
-              ' out:' + (usage.output_tokens || 0);
-            if (usage.cache_read_input_tokens) {
-              info.textContent += ' cache:' + usage.cache_read_input_tokens;
-            }
-            messagesEl.appendChild(info);
-            scrollToBottom();
-          }
-          break;
-
-        case 'streaming':
-          streaming = msg.active;
-          sendBtn.classList.toggle('hidden', msg.active);
-          abortBtn.classList.toggle('hidden', !msg.active);
-          break;
-
-        case 'mode_changed':
-          modeDisplay.textContent = msg.mode;
-          break;
-
-        case 'error':
-          addMessage('error', msg.text);
-          break;
-      }
-    });
-
-    // Signal ready.
-    vscode.postMessage({ type: 'ready' });
-  </script>
-</body>
-</html>`;
-  }
-}
-
-function getNonce(): string {
-  let text = "";
-  const chars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  for (let i = 0; i < 32; i++) {
-    text += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return text;
 }

--- a/vscode-ghost/src/ghost-client.ts
+++ b/vscode-ghost/src/ghost-client.ts
@@ -112,11 +112,23 @@ export class GhostClient extends EventEmitter {
     );
   }
 
+  async setAutoApprove(
+    sessionId: string,
+    enabled: boolean
+  ): Promise<{ auto_approve: boolean }> {
+    return this.request(
+      "POST",
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/auto-approve`,
+      { enabled }
+    );
+  }
+
   // --- Chat (SSE streaming) ---
 
   sendMessage(
     sessionId: string,
-    message: string
+    message: string,
+    image?: { media_type: string; data: string }
   ): { events: EventEmitter; abort: () => void } {
     const emitter = new EventEmitter();
     const url = new URL(
@@ -124,7 +136,11 @@ export class GhostClient extends EventEmitter {
       this.baseUrl
     );
 
-    const body = JSON.stringify({ message });
+    const payload: Record<string, unknown> = { message };
+    if (image) {
+      payload.images = [{ type: "base64", media_type: image.media_type, data: image.data }];
+    }
+    const body = JSON.stringify(payload);
     const isHttps = url.protocol === "https:";
     const mod = isHttps ? https : http;
 

--- a/vscode-ghost/src/webview-html.ts
+++ b/vscode-ghost/src/webview-html.ts
@@ -1,0 +1,573 @@
+import * as vscode from "vscode";
+
+/**
+ * Generates the chat webview HTML used by both sidebar and editor panels.
+ * Contains markdown rendering, cost tracking, slash commands, thinking display,
+ * auto-approve toggle, and image attachment support.
+ */
+export function getChatHtml(
+  webview: vscode.Webview,
+  extensionUri: vscode.Uri
+): string {
+  const nonce = getNonce();
+  const styleUri = webview.asWebviewUri(
+    vscode.Uri.joinPath(extensionUri, "media", "chat.css")
+  );
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; img-src data: ${webview.cspSource};">
+  <link rel="stylesheet" href="${styleUri}">
+  <title>Ghost Chat</title>
+</head>
+<body>
+  <div id="header">
+    <div id="header-left">
+      <span id="connection-dot"></span>
+      <span id="session-info"></span>
+      <span id="mode-badge"></span>
+    </div>
+    <div id="header-right">
+      <button id="auto-approve-btn" class="header-btn" title="Toggle auto-approve">&#x1f512;</button>
+      <span id="session-cost"></span>
+    </div>
+  </div>
+  <div id="messages"></div>
+  <div id="slash-menu" class="hidden"></div>
+  <div id="approval-bar" class="hidden">
+    <div class="approval-content">
+      <span id="approval-tool"></span>
+      <div class="approval-actions">
+        <button id="approve-btn">Allow</button>
+        <button id="deny-btn">Deny</button>
+      </div>
+    </div>
+  </div>
+  <div id="image-preview" class="hidden">
+    <img id="preview-img" />
+    <button id="remove-image">&times;</button>
+  </div>
+  <div id="input-area">
+    <textarea id="input" placeholder="Message Ghost... (/ for commands)" rows="1"></textarea>
+    <div id="input-actions">
+      <button id="attach-btn" class="icon-btn" title="Attach image">&#x1f4ce;</button>
+      <button id="send-btn" class="icon-btn" title="Send (Enter)">&#x27A4;</button>
+      <button id="abort-btn" class="icon-btn hidden" title="Stop">&#x25A0;</button>
+    </div>
+  </div>
+  <div id="footer">
+    <span id="footer-cost"></span>
+    <span id="footer-savings"></span>
+  </div>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const messagesEl = document.getElementById('messages');
+    const inputEl = document.getElementById('input');
+    const sendBtn = document.getElementById('send-btn');
+    const abortBtn = document.getElementById('abort-btn');
+    const attachBtn = document.getElementById('attach-btn');
+    const approvalBar = document.getElementById('approval-bar');
+    const approvalTool = document.getElementById('approval-tool');
+    const approveBtn = document.getElementById('approve-btn');
+    const denyBtn = document.getElementById('deny-btn');
+    const connectionDot = document.getElementById('connection-dot');
+    const sessionInfo = document.getElementById('session-info');
+    const modeBadge = document.getElementById('mode-badge');
+    const autoApproveBtn = document.getElementById('auto-approve-btn');
+    const slashMenu = document.getElementById('slash-menu');
+    const imagePreview = document.getElementById('image-preview');
+    const previewImg = document.getElementById('preview-img');
+    const removeImageBtn = document.getElementById('remove-image');
+    const footerCost = document.getElementById('footer-cost');
+    const footerSavings = document.getElementById('footer-savings');
+
+    let currentAssistantEl = null;
+    let currentAssistantText = '';
+    let currentThinkingEl = null;
+    let currentThinkingText = '';
+    let streaming = false;
+    let autoApprove = false;
+    let pendingImage = null;
+    let toolTimers = {};
+
+    // --- Cost tracking ---
+    let sessionTotals = { input: 0, output: 0, cacheCreate: 0, cacheRead: 0 };
+
+    function estimateCost(usage) {
+      const i = (usage.input_tokens || 0) * 3.0 / 1e6;
+      const o = (usage.output_tokens || 0) * 15.0 / 1e6;
+      const cw = (usage.cache_creation_input_tokens || 0) * 3.75 / 1e6;
+      const cr = (usage.cache_read_input_tokens || 0) * 0.30 / 1e6;
+      return i + o + cw + cr;
+    }
+
+    function cacheSavings(usage) {
+      return (usage.cache_read_input_tokens || 0) * (3.0 - 0.30) / 1e6;
+    }
+
+    function formatUSD(n) {
+      if (n < 0.01) return '$' + n.toFixed(4);
+      return '$' + n.toFixed(2);
+    }
+
+    function formatTokens(n) {
+      if (n < 1000) return '' + n;
+      if (n < 10000) return (n / 1000).toFixed(1) + 'k';
+      return Math.round(n / 1000) + 'k';
+    }
+
+    function updateFooter() {
+      const total = estimateCost({
+        input_tokens: sessionTotals.input,
+        output_tokens: sessionTotals.output,
+        cache_creation_input_tokens: sessionTotals.cacheCreate,
+        cache_read_input_tokens: sessionTotals.cacheRead
+      });
+      const saved = sessionTotals.cacheRead * (3.0 - 0.30) / 1e6;
+      footerCost.textContent = total > 0 ? formatUSD(total) : '';
+      if (saved > 0) {
+        const pct = Math.round(sessionTotals.cacheRead / (sessionTotals.input + sessionTotals.cacheRead + 1) * 100);
+        footerSavings.textContent = 'saved ' + formatUSD(saved) + ' (' + pct + '% cache)';
+      } else {
+        footerSavings.textContent = '';
+      }
+    }
+
+    // --- Markdown rendering ---
+    function renderMarkdown(text) {
+      let html = escapeHtml(text);
+      // Code blocks
+      html = html.replace(/\`\`\`(\\w*)?\\n([\\s\\S]*?)\`\`\`/g, (_, lang, code) => {
+        const id = 'cb-' + Math.random().toString(36).substr(2, 6);
+        return '<div class="code-block"><div class="code-header"><span class="code-lang">' +
+          (lang || '') + '</span><button class="copy-btn" data-target="' + id +
+          '">Copy</button></div><pre><code id="' + id + '">' + code.trim() + '</code></pre></div>';
+      });
+      // Inline code
+      html = html.replace(/\`([^\`]+)\`/g, '<code class="inline-code">$1</code>');
+      // Bold
+      html = html.replace(/\\*\\*(.+?)\\*\\*/g, '<strong>$1</strong>');
+      // Italic
+      html = html.replace(/(?<![*])\\*(?![*])(.+?)(?<![*])\\*(?![*])/g, '<em>$1</em>');
+      // Links
+      html = html.replace(/\\[([^\\]]+)\\]\\(([^)]+)\\)/g, '<a href="$2">$1</a>');
+      // Line breaks
+      html = html.replace(/\\n/g, '<br>');
+      return html;
+    }
+
+    function escapeHtml(text) {
+      const d = document.createElement('div');
+      d.textContent = text;
+      return d.innerHTML;
+    }
+
+    function scrollToBottom() {
+      messagesEl.scrollTo({ top: messagesEl.scrollHeight, behavior: 'smooth' });
+    }
+
+    // --- Message rendering ---
+    function addMessage(role, text) {
+      const div = document.createElement('div');
+      div.className = 'message ' + role;
+      if (role === 'user') {
+        div.textContent = text;
+      } else {
+        div.innerHTML = renderMarkdown(text);
+      }
+      messagesEl.appendChild(div);
+      scrollToBottom();
+      return div;
+    }
+
+    function ensureAssistantBubble() {
+      if (!currentAssistantEl) {
+        currentAssistantEl = document.createElement('div');
+        currentAssistantEl.className = 'message assistant';
+        messagesEl.appendChild(currentAssistantEl);
+      }
+      return currentAssistantEl;
+    }
+
+    function addToolIndicator(name, status) {
+      const div = document.createElement('div');
+      div.className = 'tool-indicator ' + status;
+      div.dataset.toolName = name;
+      div.dataset.toolId = name;
+      const icon = status === 'running' ? '<span class="spinner"></span>' : '<span class="check">&#10003;</span>';
+      div.innerHTML = icon + ' <span class="tool-name">' + escapeHtml(name) + '</span><span class="tool-time"></span>';
+      messagesEl.appendChild(div);
+      if (status === 'running') {
+        toolTimers[name] = Date.now();
+      }
+      scrollToBottom();
+      return div;
+    }
+
+    // --- Slash commands ---
+    const slashCommands = [
+      { cmd: '/mode code', desc: 'Code writing mode' },
+      { cmd: '/mode chat', desc: 'Conversational mode' },
+      { cmd: '/mode debug', desc: 'Debugging mode' },
+      { cmd: '/mode review', desc: 'Code review mode' },
+      { cmd: '/mode plan', desc: 'Architecture planning' },
+      { cmd: '/mode refactor', desc: 'Refactoring mode' },
+      { cmd: '/clear', desc: 'Clear conversation' },
+      { cmd: '/cost', desc: 'Show session cost' },
+      { cmd: '/auto-approve', desc: 'Toggle auto-approve' },
+    ];
+    let slashSelected = 0;
+
+    function showSlashMenu(query) {
+      const q = query.toLowerCase();
+      const filtered = slashCommands.filter(c =>
+        c.cmd.toLowerCase().includes(q) || c.desc.toLowerCase().includes(q)
+      );
+      if (filtered.length === 0) {
+        slashMenu.classList.add('hidden');
+        return;
+      }
+      slashSelected = Math.min(slashSelected, filtered.length - 1);
+      slashMenu.innerHTML = filtered.map((c, i) =>
+        '<div class="slash-item' + (i === slashSelected ? ' selected' : '') + '" data-cmd="' +
+        escapeHtml(c.cmd) + '"><span class="slash-cmd">' + escapeHtml(c.cmd) +
+        '</span><span class="slash-desc">' + escapeHtml(c.desc) + '</span></div>'
+      ).join('');
+      slashMenu.classList.remove('hidden');
+
+      slashMenu.querySelectorAll('.slash-item').forEach(el => {
+        el.addEventListener('click', () => {
+          executeSlashCommand(el.dataset.cmd);
+          slashMenu.classList.add('hidden');
+          inputEl.value = '';
+          inputEl.focus();
+        });
+      });
+    }
+
+    function executeSlashCommand(cmd) {
+      if (cmd.startsWith('/mode ')) {
+        const mode = cmd.split(' ')[1];
+        vscode.postMessage({ type: 'setMode', mode });
+      } else if (cmd === '/clear') {
+        messagesEl.innerHTML = '';
+        currentAssistantEl = null;
+        currentThinkingEl = null;
+        currentAssistantText = '';
+        currentThinkingText = '';
+        sessionTotals = { input: 0, output: 0, cacheCreate: 0, cacheRead: 0 };
+        updateFooter();
+      } else if (cmd === '/cost') {
+        const total = estimateCost({
+          input_tokens: sessionTotals.input, output_tokens: sessionTotals.output,
+          cache_creation_input_tokens: sessionTotals.cacheCreate,
+          cache_read_input_tokens: sessionTotals.cacheRead
+        });
+        const saved = sessionTotals.cacheRead * 2.70 / 1e6;
+        addMessage('system', 'Session cost: ' + formatUSD(total) +
+          ' | in:' + formatTokens(sessionTotals.input) +
+          ' out:' + formatTokens(sessionTotals.output) +
+          (sessionTotals.cacheRead > 0 ? ' | Cache saved: ' + formatUSD(saved) : ''));
+      } else if (cmd === '/auto-approve') {
+        autoApprove = !autoApprove;
+        autoApproveBtn.innerHTML = autoApprove ? '&#x1f513;' : '&#x1f512;';
+        autoApproveBtn.title = autoApprove ? 'Auto-approve ON' : 'Auto-approve OFF';
+        vscode.postMessage({ type: 'set_auto_approve', enabled: autoApprove });
+        addMessage('system', 'Auto-approve ' + (autoApprove ? 'enabled' : 'disabled'));
+      }
+    }
+
+    // --- Send ---
+    function send() {
+      const text = inputEl.value.trim();
+      if (!text || streaming) return;
+
+      // Handle slash commands locally
+      if (text.startsWith('/')) {
+        const match = slashCommands.find(c => c.cmd === text || text.startsWith(c.cmd));
+        if (match) {
+          executeSlashCommand(match.cmd);
+          inputEl.value = '';
+          inputEl.style.height = 'auto';
+          slashMenu.classList.add('hidden');
+          return;
+        }
+      }
+
+      const msg = { type: 'send', text };
+      if (pendingImage) {
+        msg.image = pendingImage;
+        pendingImage = null;
+        imagePreview.classList.add('hidden');
+      }
+      vscode.postMessage(msg);
+      inputEl.value = '';
+      inputEl.style.height = 'auto';
+      slashMenu.classList.add('hidden');
+    }
+
+    sendBtn.addEventListener('click', send);
+    inputEl.addEventListener('keydown', (e) => {
+      if (slashMenu.classList.contains('hidden') === false) {
+        const items = slashMenu.querySelectorAll('.slash-item');
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          slashSelected = Math.min(slashSelected + 1, items.length - 1);
+          showSlashMenu(inputEl.value);
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          slashSelected = Math.max(slashSelected - 1, 0);
+          showSlashMenu(inputEl.value);
+          return;
+        }
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          if (items[slashSelected]) {
+            executeSlashCommand(items[slashSelected].dataset.cmd);
+            inputEl.value = '';
+            slashMenu.classList.add('hidden');
+          }
+          return;
+        }
+        if (e.key === 'Escape') {
+          slashMenu.classList.add('hidden');
+          return;
+        }
+      }
+      if (e.key === 'Escape' && streaming) {
+        e.preventDefault();
+        vscode.postMessage({ type: 'abort' });
+        return;
+      }
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        send();
+      }
+    });
+
+    inputEl.addEventListener('input', () => {
+      inputEl.style.height = 'auto';
+      inputEl.style.height = Math.min(inputEl.scrollHeight, 150) + 'px';
+      const val = inputEl.value;
+      if (val.startsWith('/')) {
+        slashSelected = 0;
+        showSlashMenu(val);
+      } else {
+        slashMenu.classList.add('hidden');
+      }
+    });
+
+    // --- Abort ---
+    abortBtn.addEventListener('click', () => vscode.postMessage({ type: 'abort' }));
+
+    // --- Auto-approve toggle ---
+    autoApproveBtn.addEventListener('click', () => {
+      autoApprove = !autoApprove;
+      autoApproveBtn.innerHTML = autoApprove ? '&#x1f513;' : '&#x1f512;';
+      autoApproveBtn.title = autoApprove ? 'Auto-approve ON' : 'Auto-approve OFF';
+      vscode.postMessage({ type: 'set_auto_approve', enabled: autoApprove });
+    });
+
+    // --- Approval ---
+    approveBtn.addEventListener('click', () => {
+      vscode.postMessage({ type: 'approve', approved: true });
+      approvalBar.classList.add('hidden');
+    });
+    denyBtn.addEventListener('click', () => {
+      vscode.postMessage({ type: 'approve', approved: false });
+      approvalBar.classList.add('hidden');
+    });
+
+    // --- Image attach ---
+    attachBtn.addEventListener('click', () => vscode.postMessage({ type: 'attach_image' }));
+    removeImageBtn.addEventListener('click', () => {
+      pendingImage = null;
+      imagePreview.classList.add('hidden');
+    });
+
+    // Drag-drop
+    document.body.addEventListener('dragover', (e) => { e.preventDefault(); document.body.classList.add('drag-over'); });
+    document.body.addEventListener('dragleave', () => document.body.classList.remove('drag-over'));
+    document.body.addEventListener('drop', (e) => {
+      e.preventDefault();
+      document.body.classList.remove('drag-over');
+      const file = e.dataTransfer.files[0];
+      if (file && file.type.startsWith('image/')) {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const base64 = reader.result.split(',')[1];
+          pendingImage = { media_type: file.type, data: base64 };
+          previewImg.src = reader.result;
+          imagePreview.classList.remove('hidden');
+        };
+        reader.readAsDataURL(file);
+      }
+    });
+
+    // Copy buttons (delegated)
+    document.addEventListener('click', (e) => {
+      if (e.target.classList.contains('copy-btn')) {
+        const target = document.getElementById(e.target.dataset.target);
+        if (target) {
+          navigator.clipboard.writeText(target.textContent);
+          e.target.textContent = 'Copied!';
+          setTimeout(() => { e.target.textContent = 'Copy'; }, 1500);
+        }
+      }
+    });
+
+    // --- Messages from extension ---
+    window.addEventListener('message', (event) => {
+      const msg = event.data;
+      switch (msg.type) {
+        case 'status':
+          connectionDot.className = msg.connected ? 'dot connected' : 'dot disconnected';
+          break;
+
+        case 'session':
+          sessionInfo.textContent = msg.session.project_name;
+          modeBadge.textContent = msg.session.mode;
+          modeBadge.className = 'mode-badge mode-' + msg.session.mode;
+          break;
+
+        case 'user_message':
+          addMessage('user', msg.text);
+          currentAssistantEl = null;
+          currentAssistantText = '';
+          currentThinkingEl = null;
+          currentThinkingText = '';
+          break;
+
+        case 'text_delta':
+          currentAssistantText += msg.text;
+          const el = ensureAssistantBubble();
+          el.innerHTML = renderMarkdown(currentAssistantText);
+          scrollToBottom();
+          break;
+
+        case 'thinking_delta':
+          currentThinkingText += msg.text;
+          if (!currentThinkingEl) {
+            const details = document.createElement('details');
+            details.className = 'thinking-block';
+            details.innerHTML = '<summary>Thinking...</summary><div class="thinking-content"></div>';
+            messagesEl.appendChild(details);
+            currentThinkingEl = details.querySelector('.thinking-content');
+          }
+          currentThinkingEl.textContent = currentThinkingText;
+          scrollToBottom();
+          break;
+
+        case 'tool_start':
+          addToolIndicator(msg.name, 'running');
+          break;
+
+        case 'tool_end': {
+          const indicators = messagesEl.querySelectorAll('.tool-indicator.running');
+          indicators.forEach(ind => {
+            if (ind.dataset.toolName === msg.name) {
+              ind.className = 'tool-indicator done';
+              ind.querySelector('.spinner, .check').outerHTML = '<span class="check">&#10003;</span>';
+              const elapsed = toolTimers[msg.name] ? ((Date.now() - toolTimers[msg.name]) / 1000).toFixed(1) + 's' : '';
+              const timeEl = ind.querySelector('.tool-time');
+              if (timeEl && elapsed) timeEl.textContent = ' ' + elapsed;
+              delete toolTimers[msg.name];
+            }
+          });
+          break;
+        }
+
+        case 'approval_required':
+          if (autoApprove) {
+            vscode.postMessage({ type: 'approve', approved: true });
+          } else {
+            approvalTool.innerHTML = '<strong>' + escapeHtml(msg.tool_name) + '</strong> requires approval';
+            approvalBar.classList.remove('hidden');
+            scrollToBottom();
+          }
+          break;
+
+        case 'done': {
+          currentAssistantEl = null;
+          currentAssistantText = '';
+          currentThinkingEl = null;
+          currentThinkingText = '';
+          if (msg.usage) {
+            const u = msg.usage;
+            sessionTotals.input += (u.input_tokens || 0);
+            sessionTotals.output += (u.output_tokens || 0);
+            sessionTotals.cacheCreate += (u.cache_creation_input_tokens || 0);
+            sessionTotals.cacheRead += (u.cache_read_input_tokens || 0);
+
+            const cost = estimateCost(u);
+            const saved = cacheSavings(u);
+            const info = document.createElement('div');
+            info.className = 'usage-info';
+            let text = formatUSD(cost) + ' | in:' + formatTokens(u.input_tokens || 0) +
+              ' out:' + formatTokens(u.output_tokens || 0);
+            if (u.cache_read_input_tokens > 0) {
+              text += ' | cached:' + formatTokens(u.cache_read_input_tokens) +
+                ' (saved ' + formatUSD(saved) + ')';
+            }
+            info.textContent = text;
+            messagesEl.appendChild(info);
+            scrollToBottom();
+            updateFooter();
+          }
+          break;
+        }
+
+        case 'streaming':
+          streaming = msg.active;
+          sendBtn.classList.toggle('hidden', msg.active);
+          abortBtn.classList.toggle('hidden', !msg.active);
+          if (msg.active) {
+            attachBtn.classList.add('hidden');
+          } else {
+            attachBtn.classList.remove('hidden');
+          }
+          break;
+
+        case 'mode_changed':
+          modeBadge.textContent = msg.mode;
+          modeBadge.className = 'mode-badge mode-' + msg.mode;
+          break;
+
+        case 'image_data':
+          pendingImage = msg.image;
+          previewImg.src = 'data:' + msg.image.media_type + ';base64,' + msg.image.data;
+          imagePreview.classList.remove('hidden');
+          break;
+
+        case 'error':
+          addMessage('error', msg.text);
+          break;
+
+        case 'send_from_command':
+          inputEl.value = msg.text;
+          send();
+          break;
+      }
+    });
+
+    vscode.postMessage({ type: 'ready' });
+  </script>
+</body>
+</html>`;
+}
+
+export function getNonce(): string {
+  let text = "";
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  for (let i = 0; i < 32; i++) {
+    text += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return text;
+}


### PR DESCRIPTION
## Summary
Major overhaul of the Ghost VSCode extension — from functional alpha to polished UX.

- **Markdown rendering** — code blocks with Copy buttons, inline code, bold/italic, links
- **Collapsible thinking** — `<details>` blocks with "Thinking..." summary, cyan left border
- **Cost tracking** — per-response cost + cumulative session total with cache savings display
- **Slash commands** — type `/` for dropdown: `/mode`, `/clear`, `/cost`, `/auto-approve`
- **Auto-approve toggle** — lock/unlock icon in header, new server endpoint
- **Image attachment** — paperclip button + drag-drop onto chat
- **Esc to abort** — press Escape during streaming to cancel
- **Visual polish** — animations, mode badges, connection dot, tool spinners with elapsed time
- **Shared HTML** — `webview-html.ts` eliminates 400 lines of duplication
- **TUI cleanup** — removed gopher ASCII art and logo.png from welcome screen

## Server changes
- New `POST /api/v1/sessions/{id}/auto-approve` endpoint (calls existing `SetAutoApprove`)

## Test plan
- [x] `npm run compile` — TypeScript compiles clean
- [x] `go vet ./...` — no issues
- [x] VSIX packages and installs successfully
- [x] Extension loads in VSCode with sidebar and editor chat