### PR TITLE
feat(approval): deny with instructions + fix CodeQL path injection

### DIFF
--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -75,15 +75,15 @@ func NewSession(
 
 // ApprovalFunc is the legacy synchronous approval callback.
 // Deprecated: Use SendAsync with channel-based approval instead.
-type ApprovalFunc func(toolName string, input json.RawMessage) bool
+type ApprovalFunc func(toolName string, input json.RawMessage) provider.ApprovalResponse
 
 // SendAsync processes a user message through the full agentic loop.
 // Approval requests are sent to approvalCh; the frontend must respond via
 // the embedded Response channel. The 30s timeout prevents deadlock if the
 // frontend dies.
 func (s *Session) SendAsync(ctx context.Context, userMsg string, approvalCh chan<- provider.ApprovalRequest) <-chan ai.StreamEvent {
-	approvalFn := func(toolName string, input json.RawMessage) bool {
-		resp := make(chan bool, 1)
+	approvalFn := func(toolName string, input json.RawMessage) provider.ApprovalResponse {
+		resp := make(chan provider.ApprovalResponse, 1)
 		select {
 		case approvalCh <- provider.ApprovalRequest{
 			ToolName: toolName,
@@ -91,16 +91,16 @@ func (s *Session) SendAsync(ctx context.Context, userMsg string, approvalCh chan
 			Response: resp,
 		}:
 		case <-ctx.Done():
-			return false
+			return provider.ApprovalResponse{Approved: false}
 		}
 		select {
-		case approved := <-resp:
-			return approved
+		case ar := <-resp:
+			return ar
 		case <-ctx.Done():
-			return false
+			return provider.ApprovalResponse{Approved: false}
 		case <-time.After(30 * time.Second):
 			s.logger.Warn("approval timeout, denying", "tool", toolName)
-			return false
+			return provider.ApprovalResponse{Approved: false}
 		}
 	}
 	return s.Send(ctx, userMsg, approvalFn)
@@ -108,8 +108,8 @@ func (s *Session) SendAsync(ctx context.Context, userMsg string, approvalCh chan
 
 // SendImageAsync sends a user message with an attached image through the agentic loop.
 func (s *Session) SendImageAsync(ctx context.Context, text, mediaType, base64Data string, approvalCh chan<- provider.ApprovalRequest) <-chan ai.StreamEvent {
-	approvalFn := func(toolName string, input json.RawMessage) bool {
-		resp := make(chan bool, 1)
+	approvalFn := func(toolName string, input json.RawMessage) provider.ApprovalResponse {
+		resp := make(chan provider.ApprovalResponse, 1)
 		select {
 		case approvalCh <- provider.ApprovalRequest{
 			ToolName: toolName,
@@ -117,16 +117,16 @@ func (s *Session) SendImageAsync(ctx context.Context, text, mediaType, base64Dat
 			Response: resp,
 		}:
 		case <-ctx.Done():
-			return false
+			return provider.ApprovalResponse{Approved: false}
 		}
 		select {
-		case approved := <-resp:
-			return approved
+		case ar := <-resp:
+			return ar
 		case <-ctx.Done():
-			return false
+			return provider.ApprovalResponse{Approved: false}
 		case <-time.After(30 * time.Second):
 			s.logger.Warn("approval timeout, denying", "tool", toolName)
-			return false
+			return provider.ApprovalResponse{Approved: false}
 		}
 	}
 	imageBlocks := []ai.ContentBlock{ai.ImageBlock(mediaType, base64Data)}
@@ -233,13 +233,20 @@ func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userT
 				// Check approval.
 				level := s.registry.GetApprovalLevel(tc.Name)
 				if level == tool.ApprovalRequire && !s.autoApprove {
-					if approvalFn != nil && !approvalFn(tc.Name, tc.Input) {
-						results = append(results, ai.ToolResult{
-							ToolUseID: tc.ID,
-							Content:   "User denied this operation",
-							IsError:   true,
-						})
-						continue
+					if approvalFn != nil {
+						ar := approvalFn(tc.Name, tc.Input)
+						if !ar.Approved {
+							msg := "User denied this operation"
+							if ar.Instructions != "" {
+								msg = "User denied with instructions: " + ar.Instructions
+							}
+							results = append(results, ai.ToolResult{
+								ToolUseID: tc.ID,
+								Content:   msg,
+								IsError:   true,
+							})
+							continue
+						}
 					}
 				}
 

--- a/internal/project/context.go
+++ b/internal/project/context.go
@@ -32,6 +32,11 @@ func Detect(path string) (*Context, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve path: %w", err)
 	}
+	// Resolve symlinks to get a canonical path (mitigates path traversal).
+	absPath, err = filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve symlinks: %w", err)
+	}
 
 	h := sha256.Sum256([]byte(absPath))
 	ctx := &Context{
@@ -72,15 +77,17 @@ func Detect(path string) (*Context, error) {
 
 	// CLAUDE.md or .ghost.md.
 	for _, name := range []string{"CLAUDE.md", ".ghost.md"} {
-		content, err := os.ReadFile(filepath.Join(absPath, name))
-		if err == nil {
-			ctx.ClaudeMD = string(content)
-			break
+		if p := safeJoin(absPath, name); p != "" {
+			content, err := os.ReadFile(p)
+			if err == nil {
+				ctx.ClaudeMD = string(content)
+				break
+			}
 		}
 	}
 
 	// README summary.
-	readme, err := os.ReadFile(filepath.Join(absPath, "README.md"))
+	readme, err := os.ReadFile(safeJoin(absPath, "README.md"))
 	if err == nil {
 		s := string(readme)
 		if len(s) > 500 {
@@ -90,6 +97,15 @@ func Detect(path string) (*Context, error) {
 	}
 
 	return ctx, nil
+}
+
+// safeJoin joins base and name, ensuring the result stays within base.
+func safeJoin(base, name string) string {
+	joined := filepath.Join(base, filepath.Clean(name))
+	if !strings.HasPrefix(joined, base+string(filepath.Separator)) && joined != base {
+		return ""
+	}
+	return joined
 }
 
 func detectLanguage(path string) string {
@@ -111,8 +127,10 @@ func detectLanguage(path string) string {
 		{"Chart.yaml", "Helm"},
 	}
 	for _, c := range checks {
-		if _, err := os.Stat(filepath.Join(path, c.file)); err == nil {
-			return c.lang
+		if p := safeJoin(path, c.file); p != "" {
+			if _, err := os.Stat(p); err == nil {
+				return c.lang
+			}
 		}
 	}
 	return "unknown"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -89,18 +89,23 @@ type PromptBuilder interface {
 	BuildSystemBlocks(ctx context.Context, projCtx *project.Context, m mode.Mode) []ai.SystemBlock
 }
 
+// ApprovalResponse carries the user's decision and optional instructions.
+type ApprovalResponse struct {
+	Approved     bool
+	Instructions string // non-empty when denying with feedback
+}
+
 // ApprovalRequest is sent from the agentic loop to the frontend when a tool
-// needs user approval. The frontend writes true (approve) or false (deny) to
-// the Response channel.
+// needs user approval. The frontend writes an ApprovalResponse to the channel.
 type ApprovalRequest struct {
 	ToolName string
 	Input    json.RawMessage
-	Response chan<- bool
+	Response chan<- ApprovalResponse
 }
 
 // ApprovalFunc is the legacy synchronous approval callback.
 // Deprecated: Use ApprovalRequest channel-based flow instead.
-type ApprovalFunc func(toolName string, input json.RawMessage) bool
+type ApprovalFunc func(toolName string, input json.RawMessage) ApprovalResponse
 
 // InputSource produces user text (keyboard, voice transcription, etc.).
 type InputSource interface {

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -28,7 +28,7 @@ type sessionInfo struct {
 type pendingApproval struct {
 	ToolName string          `json:"tool_name"`
 	Input    json.RawMessage `json:"input"`
-	response chan bool
+	response chan provider.ApprovalResponse
 }
 
 // chatState holds per-session streaming state for HTTP clients.
@@ -190,7 +190,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		case approval := <-approvalCh:
 			// Tool needs approval — emit event and store pending.
 			// We need a bidirectional channel to both send and receive.
-			respCh := make(chan bool, 1)
+			respCh := make(chan provider.ApprovalResponse, 1)
 			// Forward the response back to the approval request's send-only channel.
 			go func() {
 				v := <-respCh
@@ -262,7 +262,8 @@ func (s *Server) handleStreamEvent(w http.ResponseWriter, flusher http.Flusher, 
 // --- Approval Handler ---
 
 type approvalResponse struct {
-	Approved bool `json:"approved"`
+	Approved     bool   `json:"approved"`
+	Instructions string `json:"instructions,omitempty"`
 }
 
 func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request) {
@@ -293,7 +294,10 @@ func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pending.response <- req.Approved
+	pending.response <- provider.ApprovalResponse{
+		Approved:     req.Approved,
+		Instructions: req.Instructions,
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "responded"})
 }
 

--- a/internal/tui/approval.go
+++ b/internal/tui/approval.go
@@ -33,10 +33,14 @@ func (a *approvalDialog) show(req provider.ApprovalRequest) {
 }
 
 func (a *approvalDialog) respond(approved bool) {
+	a.respondWith(provider.ApprovalResponse{Approved: approved})
+}
+
+func (a *approvalDialog) respondWith(resp provider.ApprovalResponse) {
 	if !a.active {
 		return
 	}
-	a.request.Response <- approved
+	a.request.Response <- resp
 	a.active = false
 }
 

--- a/internal/tui/oneshot.go
+++ b/internal/tui/oneshot.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/wcatz/ghost/internal/ai"
 	"github.com/wcatz/ghost/internal/orchestrator"
+	"github.com/wcatz/ghost/internal/provider"
 	"golang.org/x/term"
 )
 
@@ -20,7 +21,7 @@ func IsTerminal() bool {
 // RunOneShot sends a single message and prints the streamed response.
 // Used for pipe mode and one-shot CLI mode. No bubbletea involved.
 func RunOneShot(session *orchestrator.Session, message string, showCost bool) {
-	approvalFn := func(toolName string, toolInput json.RawMessage) bool {
+	approvalFn := func(toolName string, toolInput json.RawMessage) provider.ApprovalResponse {
 		// In one-shot mode, auto-approve reads, prompt for writes.
 		fmt.Fprintf(os.Stderr, "\n%s⚡ [%s]%s ", colorYellow, toolName, colorReset)
 
@@ -35,14 +36,15 @@ func RunOneShot(session *orchestrator.Session, message string, showCost bool) {
 
 		// If not a terminal, auto-approve.
 		if !IsTerminal() {
-			return true
+			return provider.ApprovalResponse{Approved: true}
 		}
 
 		fmt.Fprintf(os.Stderr, "Allow? [y/n]: ")
 		reader := bufio.NewReader(os.Stdin)
 		response, _ := reader.ReadString('\n')
 		response = strings.TrimSpace(strings.ToLower(response))
-		return response == "y" || response == "yes"
+		approved := response == "y" || response == "yes"
+		return provider.ApprovalResponse{Approved: approved}
 	}
 
 	events := session.Send(nil, message, approvalFn)

--- a/internal/tui/repl.go
+++ b/internal/tui/repl.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/wcatz/ghost/internal/orchestrator"
+	"github.com/wcatz/ghost/internal/provider"
 )
 
 // Colors for terminal output.
@@ -93,7 +94,7 @@ func (r *REPL) RunOneShot(session *orchestrator.Session, message string) error {
 }
 
 func (r *REPL) sendMessage(input string) {
-	approvalFn := func(toolName string, toolInput json.RawMessage) bool {
+	approvalFn := func(toolName string, toolInput json.RawMessage) provider.ApprovalResponse {
 		fmt.Printf("\n%s⚡ [%s]%s ", colorYellow, toolName, colorReset)
 
 		// Show a summary of what the tool wants to do.
@@ -110,7 +111,8 @@ func (r *REPL) sendMessage(input string) {
 		reader := bufio.NewReader(os.Stdin)
 		response, _ := reader.ReadString('\n')
 		response = strings.TrimSpace(strings.ToLower(response))
-		return response == "y" || response == "yes"
+		approved := response == "y" || response == "yes"
+		return provider.ApprovalResponse{Approved: approved}
 	}
 
 	events := r.active.Send(r.ctx, input, approvalFn)


### PR DESCRIPTION
## Summary
- Upgrade `ApprovalResponse` from `bool` to struct with `Instructions` field
- When denying a tool, users can provide feedback that Ghost reads and adjusts to
- Fix 3 HIGH CodeQL path injection findings in `project/context.go`
- Clean up duplicate projects in database

## Changes
- `provider/provider.go` — New `ApprovalResponse` struct, updated channel types
- `orchestrator/session.go` — Use `ApprovalResponse` in approval flow, pass instructions as tool result
- `server/chat.go` — Accept `instructions` field in approve endpoint, forward to session
- `tui/approval.go` — Use `ApprovalResponse` in TUI dialog
- `tui/oneshot.go`, `tui/repl.go` — Update approval callbacks to return struct
- `project/context.go` — `EvalSymlinks` + `safeJoin` for all file operations

## CodeQL fixes
- Alert #1 (line 75): CLAUDE.md read — now uses `safeJoin`
- Alert #2 (line 83): README.md read — now uses `safeJoin`
- Alert #3 (line 114): Language detection stat — now uses `safeJoin`

## Test plan
- [x] `go vet ./...` clean
- [x] All tests pass
- [x] `go build` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced the approval system to provide richer feedback when tool actions are denied, now including optional instructions or guidance messages that clarify why an action was rejected and provide guidance for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->