### PR TITLE
feat(serve): wire Google Calendar + Gmail into daemon startup

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/wcatz/ghost/internal/config"
 	"github.com/wcatz/ghost/internal/embedding"
 	"github.com/wcatz/ghost/internal/github"
+	goog "github.com/wcatz/ghost/internal/google"
 	"github.com/wcatz/ghost/internal/mcpserver"
 	"github.com/wcatz/ghost/internal/memory"
 	"github.com/wcatz/ghost/internal/orchestrator"
@@ -258,6 +259,21 @@ func runServe() {
 		}
 	}
 
+	// --- Google Calendar + Gmail (OAuth2) ---
+	var googleClient *goog.Client
+	credFile := expandHome(cfg.Google.CredentialsFile)
+	if _, err := os.Stat(credFile); err == nil {
+		googleClient, err = goog.NewClient(ctx, goog.Config{
+			CredentialsFile: credFile,
+			TokenFile:       expandHome(cfg.Google.TokenFile),
+		}, logger)
+		if err != nil {
+			logger.Warn("google API init failed", "error", err)
+		} else {
+			logger.Info("google API connected (calendar + gmail)")
+		}
+	}
+
 	// --- Telegram bot ---
 	var tgBot *telegram.Bot
 	if cfg.Telegram.Token != "" {
@@ -284,6 +300,17 @@ func runServe() {
 		sched.OnAlert(func(message string) {
 			tgBot.SendToAll(ctx, message)
 		})
+
+		// Wire Google Calendar/Gmail to Telegram.
+		if googleClient != nil {
+			tgBot.SetGoogle(googleClient)
+
+			// Start meeting notifier.
+			notifier := goog.NewMeetingNotifier(googleClient, func(msg string) {
+				tgBot.SendToAll(ctx, msg)
+			}, logger)
+			go notifier.Run(ctx)
+		}
 
 		go tgBot.Run(ctx)
 		logger.Info("telegram bot started", "allowed_users", len(allowedIDs))
@@ -382,4 +409,16 @@ func bootstrap() (*config.Config, *slog.Logger, *memory.Store, *sql.DB) {
 
 	store := memory.NewStore(db, logger)
 	return cfg, logger, store, db
+}
+
+// expandHome replaces a leading ~ with the user's home directory.
+func expandHome(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[2:])
+	}
+	return path
 }

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -10,7 +10,8 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
-	"time"
+
+	goog "github.com/wcatz/ghost/internal/google"
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
@@ -35,26 +36,9 @@ type Bot struct {
 
 // GoogleProvider is the interface for Google Calendar/Gmail access.
 type GoogleProvider interface {
-	TodayEvents(ctx context.Context) ([]GoogleEvent, error)
+	TodayEvents(ctx context.Context) ([]goog.Event, error)
 	UnreadCount(ctx context.Context) (int, error)
-	RecentUnread(ctx context.Context, limit int) ([]GoogleEmail, error)
-}
-
-// GoogleEvent is a simplified calendar event for Telegram display.
-type GoogleEvent struct {
-	Summary  string
-	Start    time.Time
-	End      time.Time
-	Location string
-	MeetLink string
-	AllDay   bool
-}
-
-// GoogleEmail is a simplified email for Telegram display.
-type GoogleEmail struct {
-	From    string
-	Subject string
-	Snippet string
+	RecentUnread(ctx context.Context, limit int) ([]goog.Email, error)
 }
 
 // Config holds Telegram bot configuration.


### PR DESCRIPTION
## Summary
- Wire Google OAuth2 client into `ghost serve` startup
- Auto-initializes when `~/.config/ghost/google-credentials.json` exists
- Connects Google Calendar/Gmail to Telegram bot (`/meetings`, `/emails`)
- Starts meeting notifier (10min/5min alerts with Meet links via Telegram)
- Telegram bot interface uses `google.Event`/`google.Email` types directly

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./cmd/ghost/` compiles
- [x] Without credentials file: starts normally, skips Google init
- [x] With credentials file: prints OAuth URL on first run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Calendar and Gmail integration with Telegram
  * Automatic meeting notifications delivered to all connected users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->