### PR TITLE
feat(telegram): approval forwarding + /sessions + /chat commands

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -353,6 +353,13 @@ func runServe() {
 	// --- HTTP server (blocks) ---
 	srv := server.New(store, &cfg.Server, logger)
 	srv.SetOrchestrator(orch)
+
+	// Wire Telegram bot as approval notifier + give it the server address.
+	if tgBot != nil {
+		srv.SetApprovalNotifier(tgBot)
+		tgBot.SetServerAddr(cfg.Server.ListenAddr)
+	}
+
 	if err := srv.Run(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -209,6 +209,15 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 				"input":     json.RawMessage(approval.Input),
 			})
 
+			// Forward to external notifier (Telegram) if configured.
+			if s.approvalNotifier != nil {
+				projectName := ""
+				if session != nil {
+					projectName = session.ProjectName
+				}
+				go s.approvalNotifier.NotifyApproval(id, projectName, approval.ToolName, approval.Input)
+			}
+
 		case <-r.Context().Done():
 			return
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,13 +20,20 @@ import (
 	"github.com/wcatz/ghost/internal/provider"
 )
 
+// ApprovalNotifier is called when a tool needs approval.
+// The Telegram bot implements this to forward approvals to the user's phone.
+type ApprovalNotifier interface {
+	NotifyApproval(sessionID, projectName, toolName string, input json.RawMessage)
+}
+
 // Server is the ghost HTTP daemon.
 type Server struct {
-	store        provider.MemoryStore
-	cfg          *config.ServerConfig
-	orchestrator *orchestrator.Orchestrator
-	logger       *slog.Logger
-	srv          *http.Server
+	store             provider.MemoryStore
+	cfg               *config.ServerConfig
+	orchestrator      *orchestrator.Orchestrator
+	approvalNotifier  ApprovalNotifier
+	logger            *slog.Logger
+	srv               *http.Server
 
 	// Chat streaming state.
 	chatMu     sync.RWMutex
@@ -47,6 +54,16 @@ func New(store provider.MemoryStore, cfg *config.ServerConfig, logger *slog.Logg
 // Must be called before Run() if chat endpoints are needed.
 func (s *Server) SetOrchestrator(o *orchestrator.Orchestrator) {
 	s.orchestrator = o
+}
+
+// SetApprovalNotifier wires an external approval forwarder (e.g. Telegram bot).
+func (s *Server) SetApprovalNotifier(n ApprovalNotifier) {
+	s.approvalNotifier = n
+}
+
+// ListenAddr returns the configured listen address.
+func (s *Server) ListenAddr() string {
+	return s.cfg.ListenAddr
 }
 
 // Run starts the HTTP server. Blocks until ctx is cancelled.

--- a/internal/telegram/approval.go
+++ b/internal/telegram/approval.go
@@ -1,0 +1,238 @@
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+	"github.com/wcatz/ghost/internal/mdv2"
+)
+
+// approvalState tracks which session has a pending approval for instruction replies.
+type approvalState struct {
+	mu        sync.Mutex
+	sessionID string // session with pending approval
+	toolName  string
+}
+
+// SetServerAddr configures the Ghost server address for API calls.
+func (tb *Bot) SetServerAddr(addr string) {
+	tb.serverAddr = addr
+}
+
+// NotifyApproval sends an approval request to all allowed Telegram users
+// with Allow / Deny inline buttons. Implements server.ApprovalNotifier.
+func (tb *Bot) NotifyApproval(sessionID, projectName, toolName string, input json.RawMessage) {
+	// Format the input for display.
+	inputStr := formatToolInput(toolName, input)
+
+	var sb strings.Builder
+	sb.WriteString("🔐 *Approval Required*\n\n")
+	if projectName != "" {
+		fmt.Fprintf(&sb, "Project: `%s`\n", mdv2.Esc(projectName))
+	}
+	fmt.Fprintf(&sb, "Tool: `%s`\n\n", mdv2.Esc(toolName))
+	if inputStr != "" {
+		fmt.Fprintf(&sb, "```\n%s\n```\n\n", inputStr)
+	}
+	sb.WriteString("_Reply to this message with text to deny with instructions_")
+
+	text := sb.String()
+	keyboard := &models.InlineKeyboardMarkup{
+		InlineKeyboard: [][]models.InlineKeyboardButton{
+			{
+				{Text: "✅ Allow", CallbackData: "approve:" + sessionID},
+				{Text: "❌ Deny", CallbackData: "deny:" + sessionID},
+			},
+		},
+	}
+
+	tb.approval.mu.Lock()
+	tb.approval.sessionID = sessionID
+	tb.approval.toolName = toolName
+	tb.approval.mu.Unlock()
+
+	for id := range tb.allowedIDs {
+		_, err := tb.bot.SendMessage(context.Background(), &bot.SendMessageParams{
+			ChatID:    id,
+			Text:      text,
+			ParseMode: models.ParseModeMarkdown,
+			ReplyMarkup: keyboard,
+			LinkPreviewOptions: &models.LinkPreviewOptions{
+				IsDisabled: bot.True(),
+			},
+		})
+		if err != nil {
+			tb.logger.Error("telegram approval notify", "error", err, "user_id", id)
+		}
+	}
+}
+
+// handleApprovalCallback handles Allow/Deny button presses.
+func (tb *Bot) handleApprovalCallback(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if update.CallbackQuery == nil {
+		return
+	}
+
+	data := update.CallbackQuery.Data
+	var approved bool
+	var sessionID string
+
+	if strings.HasPrefix(data, "approve:") {
+		approved = true
+		sessionID = strings.TrimPrefix(data, "approve:")
+	} else if strings.HasPrefix(data, "deny:") {
+		approved = false
+		sessionID = strings.TrimPrefix(data, "deny:")
+	} else {
+		return
+	}
+
+	// Call Ghost server approve endpoint.
+	err := tb.callApproveAPI(sessionID, approved, "")
+	if err != nil {
+		tb.logger.Error("telegram approval callback", "error", err)
+		_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+			CallbackQueryID: update.CallbackQuery.ID,
+			Text:            "Error: " + err.Error(),
+			ShowAlert:       true,
+		})
+		return
+	}
+
+	// Answer callback and edit the message.
+	action := "✅ Approved"
+	if !approved {
+		action = "❌ Denied"
+	}
+
+	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+		CallbackQueryID: update.CallbackQuery.ID,
+		Text:            action,
+	})
+
+	// Edit the approval message to show the result.
+	if update.CallbackQuery.Message.Message != nil {
+		_, _ = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+			ChatID:    update.CallbackQuery.Message.Message.Chat.ID,
+			MessageID: update.CallbackQuery.Message.Message.ID,
+			Text:      update.CallbackQuery.Message.Message.Text + "\n\n" + action,
+			ParseMode: models.ParseModeMarkdown,
+		})
+	}
+
+	tb.approval.mu.Lock()
+	tb.approval.sessionID = ""
+	tb.approval.toolName = ""
+	tb.approval.mu.Unlock()
+}
+
+// handleInstructionReply checks if a message is a reply to an approval prompt
+// and sends it as deny-with-instructions.
+func (tb *Bot) handleInstructionReply(ctx context.Context, b *bot.Bot, update *models.Update) bool {
+	if update.Message == nil || update.Message.ReplyToMessage == nil {
+		return false
+	}
+
+	// Check if there's a pending approval.
+	tb.approval.mu.Lock()
+	sessionID := tb.approval.sessionID
+	tb.approval.mu.Unlock()
+
+	if sessionID == "" {
+		return false
+	}
+
+	// Check if the reply is to a message from the bot (approval message).
+	if update.Message.ReplyToMessage.From == nil || !update.Message.ReplyToMessage.From.IsBot {
+		return false
+	}
+
+	instructions := update.Message.Text
+	if instructions == "" {
+		return false
+	}
+
+	err := tb.callApproveAPI(sessionID, false, instructions)
+	if err != nil {
+		tb.reply(ctx, b, update, "Failed to send instructions: "+mdv2.Esc(err.Error()))
+	} else {
+		tb.reply(ctx, b, update, fmt.Sprintf("❌ Denied with instructions:\n_%s_", mdv2.Esc(instructions)))
+	}
+
+	tb.approval.mu.Lock()
+	tb.approval.sessionID = ""
+	tb.approval.toolName = ""
+	tb.approval.mu.Unlock()
+
+	return true
+}
+
+// callApproveAPI calls the Ghost server's approve endpoint.
+func (tb *Bot) callApproveAPI(sessionID string, approved bool, instructions string) error {
+	if tb.serverAddr == "" {
+		return fmt.Errorf("server address not configured")
+	}
+
+	payload := map[string]interface{}{
+		"approved": approved,
+	}
+	if instructions != "" {
+		payload["instructions"] = instructions
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("http://%s/api/v1/sessions/%s/approve", tb.serverAddr, sessionID)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body)) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("approve API call: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("approve API returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// formatToolInput extracts the most relevant info from tool input for display.
+func formatToolInput(toolName string, input json.RawMessage) string {
+	var m map[string]interface{}
+	if err := json.Unmarshal(input, &m); err != nil {
+		return string(input)
+	}
+
+	switch toolName {
+	case "bash":
+		if cmd, ok := m["command"].(string); ok {
+			return cmd
+		}
+	case "file_write", "file_edit":
+		if path, ok := m["path"].(string); ok {
+			return path
+		}
+	case "git":
+		if sub, ok := m["subcommand"].(string); ok {
+			args, _ := m["args"].(string)
+			return "git " + sub + " " + args
+		}
+	}
+
+	// Fallback: compact JSON, truncated.
+	b, _ := json.Marshal(m)
+	s := string(b)
+	if len(s) > 200 {
+		s = s[:200] + "..."
+	}
+	return s
+}

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -39,6 +39,8 @@ type Bot struct {
 	db              *sql.DB
 	logger          *slog.Logger
 	allowedIDs      map[int64]bool
+	serverAddr      string        // Ghost serve address for API calls
+	approval        approvalState // pending approval tracking
 }
 
 // GoogleProvider is the interface for Google Calendar/Gmail access.
@@ -87,6 +89,12 @@ func New(cfg Config, store provider.MemoryStore, ghMonitor *gh.Monitor, sched *s
 	b.RegisterHandler(bot.HandlerTypeMessageText, "meetings", bot.MatchTypeCommand, tb.handleMeetings)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "emails", bot.MatchTypeCommand, tb.handleEmails)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "help", bot.MatchTypeCommand, tb.handleHelp)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "sessions", bot.MatchTypeCommand, tb.handleSessions)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "chat", bot.MatchTypeCommand, tb.handleChat)
+
+	// Callback query handlers for inline button approvals.
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "approve:", bot.MatchTypePrefix, tb.handleApprovalCallback)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "deny:", bot.MatchTypePrefix, tb.handleApprovalCallback)
 
 	return tb, nil
 }
@@ -114,6 +122,8 @@ func (tb *Bot) registerCommands(ctx context.Context) {
 		{Command: "notifications", Description: "List unread GitHub notifications"},
 		{Command: "meetings", Description: "Today's calendar with Meet links"},
 		{Command: "emails", Description: "Recent unread emails"},
+		{Command: "sessions", Description: "List active Ghost sessions"},
+		{Command: "chat", Description: "Chat with a session: /chat <id> <msg>"},
 		{Command: "memory", Description: "Search memories: /memory search <project> <query>"},
 		{Command: "remind", Description: "Set a reminder: /remind <message>"},
 		{Command: "briefing", Description: "Get your morning briefing"},
@@ -458,6 +468,8 @@ func (tb *Bot) handleHelp(ctx context.Context, b *bot.Bot, update *models.Update
 /notifications — List unread GitHub notifications
 /meetings — Today's calendar with Meet links
 /emails — Recent unread emails
+/sessions — List active Ghost sessions
+/chat — Chat with a session
 /memory search — Search memories
 /remind — Set a reminder
 /briefing — Get your morning briefing
@@ -466,6 +478,10 @@ func (tb *Bot) handleHelp(ctx context.Context, b *bot.Bot, update *models.Update
 
 func (tb *Bot) handleDefault(ctx context.Context, b *bot.Bot, update *models.Update) {
 	if update.Message == nil {
+		return
+	}
+	// Check if this is a reply to an approval message with instructions.
+	if tb.handleInstructionReply(ctx, b, update) {
 		return
 	}
 	tb.reply(ctx, b, update, "Use /help to see available commands\\.")

--- a/internal/telegram/sessions.go
+++ b/internal/telegram/sessions.go
@@ -1,0 +1,146 @@
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+	"github.com/wcatz/ghost/internal/mdv2"
+)
+
+type apiSession struct {
+	ID          string `json:"id"`
+	ProjectPath string `json:"project_path"`
+	ProjectName string `json:"project_name"`
+	Mode        string `json:"mode"`
+	Active      bool   `json:"active"`
+	Messages    int    `json:"messages"`
+}
+
+// handleSessions lists all active Ghost sessions.
+func (tb *Bot) handleSessions(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if tb.serverAddr == "" {
+		tb.reply(ctx, b, update, "Ghost server not configured\\.")
+		return
+	}
+
+	tb.sendTyping(ctx, update)
+
+	sessions, err := tb.fetchSessions()
+	if err != nil {
+		tb.reply(ctx, b, update, "Error fetching sessions: "+mdv2.Esc(err.Error()))
+		return
+	}
+
+	if len(sessions) == 0 {
+		tb.reply(ctx, b, update, "No active sessions\\.")
+		return
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "*Active Sessions* \\(%d\\)\n\n", len(sessions))
+	for _, s := range sessions {
+		status := "🟢"
+		if !s.Active {
+			status = "🔴"
+		}
+		fmt.Fprintf(&sb, "%s `%s`\n  %s \\| %s \\| %d msgs\n\n",
+			status, mdv2.Esc(s.ID[:8]), mdv2.Esc(s.ProjectName), mdv2.Esc(s.Mode), s.Messages)
+	}
+	sb.WriteString("Use `/chat <session_id> <message>` to interact")
+	tb.reply(ctx, b, update, sb.String())
+}
+
+// handleChat sends a message to a specific Ghost session.
+func (tb *Bot) handleChat(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if tb.serverAddr == "" {
+		tb.reply(ctx, b, update, "Ghost server not configured\\.")
+		return
+	}
+
+	text := update.Message.Text
+	parts := strings.SplitN(text, " ", 3)
+	if len(parts) < 3 {
+		tb.reply(ctx, b, update, "Usage: `/chat <session_id> <message>`")
+		return
+	}
+
+	sessionID := parts[1]
+	message := parts[2]
+
+	// Resolve short session IDs.
+	sessions, err := tb.fetchSessions()
+	if err != nil {
+		tb.reply(ctx, b, update, "Error: "+mdv2.Esc(err.Error()))
+		return
+	}
+
+	fullID := ""
+	for _, s := range sessions {
+		if strings.HasPrefix(s.ID, sessionID) {
+			fullID = s.ID
+			break
+		}
+	}
+	if fullID == "" {
+		tb.reply(ctx, b, update, "Session not found\\. Use /sessions to list\\.")
+		return
+	}
+
+	tb.sendTyping(ctx, update)
+
+	// Send message via API. This returns an SSE stream — we just report success.
+	err = tb.sendChatMessage(fullID, message)
+	if err != nil {
+		tb.reply(ctx, b, update, "Error: "+mdv2.Esc(err.Error()))
+		return
+	}
+
+	tb.reply(ctx, b, update, fmt.Sprintf("📤 Sent to `%s`:\n_%s_",
+		mdv2.Esc(fullID[:8]), mdv2.Esc(message)))
+}
+
+func (tb *Bot) fetchSessions() ([]apiSession, error) {
+	url := fmt.Sprintf("http://%s/api/v1/sessions", tb.serverAddr)
+	resp, err := http.Get(url) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var sessions []apiSession
+	if err := json.NewDecoder(resp.Body).Decode(&sessions); err != nil {
+		return nil, err
+	}
+	return sessions, nil
+}
+
+func (tb *Bot) sendChatMessage(sessionID, message string) error {
+	payload, _ := json.Marshal(map[string]string{"message": message})
+	url := fmt.Sprintf("http://%s/api/v1/sessions/%s/send", tb.serverAddr, sessionID)
+
+	resp, err := http.Post(url, "application/json", bytes.NewReader(payload)) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// The send endpoint returns SSE — just drain it.
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server returned %d: %s", resp.StatusCode, body)
+	}
+	// Drain SSE stream so the request completes.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}


### PR DESCRIPTION
## Summary
- **Approval forwarding**: When Ghost needs tool approval, sends to Telegram with Allow/Deny inline buttons
- **Deny with instructions**: Reply to an approval message with text to deny and provide alternative instructions
- **/sessions**: Lists all active Ghost sessions (ID, project, mode, message count)
- **/chat <id> <msg>**: Send a message to a specific Ghost session from Telegram
- Short session IDs supported (prefix match)
- Server `ApprovalNotifier` interface decouples approval forwarding from Telegram

## Architecture
```
Ghost Agent Loop → approval_required → SSE to frontend
                                     → ApprovalNotifier.NotifyApproval() → Telegram
Telegram Allow button → POST /sessions/{id}/approve → Agent continues
Telegram reply text → POST /sessions/{id}/approve {instructions} → Agent gets feedback
```

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./cmd/ghost/` succeeds
- [x] No import cycles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Telegram bot integration for approvals: Receive approval requests with Approve/Deny buttons, including project and tool context for informed decisions.
  * Telegram session management: View active sessions with status indicators and send messages directly to specific sessions using bot commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->