### PR TITLE
feat(telegram): inline session picker with reply-to-chat

### DIFF
--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 
 	goog "github.com/wcatz/ghost/internal/google"
 	"github.com/wcatz/ghost/internal/mdv2"
@@ -41,6 +42,8 @@ type Bot struct {
 	allowedIDs      map[int64]bool
 	serverAddr      string        // Ghost serve address for API calls
 	approval        approvalState // pending approval tracking
+	mu              sync.Mutex
+	pendingChat     map[int64]string // chatID → sessionID for reply routing
 }
 
 // GoogleProvider is the interface for Google Calendar/Gmail access.
@@ -64,7 +67,8 @@ func New(cfg Config, store provider.MemoryStore, ghMonitor *gh.Monitor, sched *s
 		sched:      sched,
 		db:         db,
 		logger:     logger,
-		allowedIDs: make(map[int64]bool, len(cfg.AllowedIDs)),
+		allowedIDs:  make(map[int64]bool, len(cfg.AllowedIDs)),
+		pendingChat: make(map[int64]string),
 	}
 
 	for _, id := range cfg.AllowedIDs {
@@ -92,9 +96,10 @@ func New(cfg Config, store provider.MemoryStore, ghMonitor *gh.Monitor, sched *s
 	b.RegisterHandler(bot.HandlerTypeMessageText, "sessions", bot.MatchTypeCommand, tb.handleSessions)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "chat", bot.MatchTypeCommand, tb.handleChat)
 
-	// Callback query handlers for inline button approvals.
+	// Callback query handlers.
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "approve:", bot.MatchTypePrefix, tb.handleApprovalCallback)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "deny:", bot.MatchTypePrefix, tb.handleApprovalCallback)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "chat:", bot.MatchTypePrefix, tb.handleChatCallback)
 
 	return tb, nil
 }
@@ -482,6 +487,10 @@ func (tb *Bot) handleDefault(ctx context.Context, b *bot.Bot, update *models.Upd
 	}
 	// Check if this is a reply to an approval message with instructions.
 	if tb.handleInstructionReply(ctx, b, update) {
+		return
+	}
+	// Check if this is a reply to a pending chat session prompt.
+	if tb.handlePendingChatReply(ctx, b, update) {
 		return
 	}
 	tb.reply(ctx, b, update, "Use /help to see available commands\\.")

--- a/internal/telegram/sessions.go
+++ b/internal/telegram/sessions.go
@@ -45,16 +45,55 @@ func (tb *Bot) handleSessions(ctx context.Context, b *bot.Bot, update *models.Up
 
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "*Active Sessions* \\(%d\\)\n\n", len(sessions))
+
+	var rows [][]models.InlineKeyboardButton
 	for _, s := range sessions {
 		status := "🟢"
 		if !s.Active {
 			status = "🔴"
 		}
+		shortID := s.ID[:8]
 		fmt.Fprintf(&sb, "%s `%s`\n  %s \\| %s \\| %d msgs\n\n",
-			status, mdv2.Esc(s.ID[:8]), mdv2.Esc(s.ProjectName), mdv2.Esc(s.Mode), s.Messages)
+			status, mdv2.Esc(shortID), mdv2.Esc(s.ProjectName), mdv2.Esc(s.Mode), s.Messages)
+		rows = append(rows, []models.InlineKeyboardButton{
+			{Text: fmt.Sprintf("💬 %s (%s)", s.ProjectName, shortID), CallbackData: "chat:" + s.ID},
+		})
 	}
-	sb.WriteString("Use `/chat <session_id> <message>` to interact")
-	tb.reply(ctx, b, update, sb.String())
+
+	tb.replyWithKeyboard(ctx, b, update, sb.String(), rows)
+}
+
+// handleChatCallback handles inline button taps from /sessions.
+func (tb *Bot) handleChatCallback(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if update.CallbackQuery == nil {
+		return
+	}
+	sessionID := strings.TrimPrefix(update.CallbackQuery.Data, "chat:")
+
+	// Acknowledge the button tap.
+	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+		CallbackQueryID: update.CallbackQuery.ID,
+		Text:            "Send a message to this session",
+	})
+
+	// Prompt the user to reply with a message.
+	chatID := update.CallbackQuery.Message.Message.Chat.ID
+	shortID := sessionID[:8]
+	_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:    chatID,
+		Text:      fmt.Sprintf("💬 Session `%s` selected.\nReply to this message with your prompt:", shortID),
+		ParseMode: models.ParseModeMarkdown,
+		ReplyMarkup: &models.ForceReply{
+			ForceReply:            true,
+			InputFieldPlaceholder: "Type your message...",
+			Selective:             true,
+		},
+	})
+
+	// Store pending chat session so the reply handler can route it.
+	tb.mu.Lock()
+	tb.pendingChat[chatID] = sessionID
+	tb.mu.Unlock()
 }
 
 // handleChat sends a message to a specific Ghost session.
@@ -104,6 +143,37 @@ func (tb *Bot) handleChat(ctx context.Context, b *bot.Bot, update *models.Update
 
 	tb.reply(ctx, b, update, fmt.Sprintf("📤 Sent to `%s`:\n_%s_",
 		mdv2.Esc(fullID[:8]), mdv2.Esc(message)))
+}
+
+// handlePendingChatReply routes text replies to the pending chat session.
+func (tb *Bot) handlePendingChatReply(ctx context.Context, b *bot.Bot, update *models.Update) bool {
+	chatID := update.Message.Chat.ID
+	tb.mu.Lock()
+	sessionID, ok := tb.pendingChat[chatID]
+	if ok {
+		delete(tb.pendingChat, chatID)
+	}
+	tb.mu.Unlock()
+	if !ok {
+		return false
+	}
+
+	message := update.Message.Text
+	if message == "" {
+		return false
+	}
+
+	tb.sendTyping(ctx, update)
+
+	err := tb.sendChatMessage(sessionID, message)
+	if err != nil {
+		tb.reply(ctx, b, update, "Error: "+mdv2.Esc(err.Error()))
+		return true
+	}
+
+	tb.reply(ctx, b, update, fmt.Sprintf("📤 Sent to `%s`:\n_%s_",
+		mdv2.Esc(sessionID[:8]), mdv2.Esc(message)))
+	return true
 }
 
 func (tb *Bot) fetchSessions() ([]apiSession, error) {


### PR DESCRIPTION
## Summary
- /sessions now shows inline keyboard buttons per session
- Tap a session to get a ForceReply prompt
- Reply routes to the correct Ghost session via pendingChat map
- Adds sync.Mutex + pendingChat map to Bot struct

## Test plan
- [x] go vet clean
- [x] /sessions shows buttons
- [x] Tapping button prompts for reply
- [x] Reply routes message to correct session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct session chat functionality: users can now select sessions using inline buttons and communicate with them through text messages
  * Enhanced multi-step conversation support with improved prompts and success/error feedback
  * Session listings interface now displays identifiers in an optimized, user-friendly format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->