### PR TITLE
feat(session): resume conversations across restarts

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/wcatz/ghost/internal/embedding"
 	"github.com/wcatz/ghost/internal/github"
 	goog "github.com/wcatz/ghost/internal/google"
+	"github.com/wcatz/ghost/internal/mdv2"
 	"github.com/wcatz/ghost/internal/mcpserver"
 	"github.com/wcatz/ghost/internal/memory"
 	"github.com/wcatz/ghost/internal/orchestrator"
@@ -291,7 +292,7 @@ func runServe() {
 		if ghMonitor != nil {
 			ghMonitor.OnAlert(func(n github.Notification) {
 				msg := fmt.Sprintf("*P%d Alert*\n`%s`\n%s\n_%s_",
-					n.Priority, n.RepoFullName, n.SubjectTitle, n.Reason)
+					n.Priority, mdv2.Esc(n.RepoFullName), mdv2.Esc(n.SubjectTitle), mdv2.Esc(n.Reason))
 				tgBot.SendToAll(ctx, msg)
 			})
 		}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -516,7 +516,7 @@ func (s *Store) GetConversationMessages(ctx context.Context, conversationID stri
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var msgs []ConversationMessage
 	for rows.Next() {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -479,6 +479,56 @@ func (s *Store) GetRecentExchanges(ctx context.Context, projectID string, limit 
 	return pairs, rows.Err()
 }
 
+// GetLatestConversation returns the most recent conversation ID for a project.
+func (s *Store) GetLatestConversation(ctx context.Context, projectID string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var id string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id FROM conversations
+		WHERE project_id = ?
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, projectID).Scan(&id)
+	if err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// ConversationMessage is a stored message with role and JSON content.
+type ConversationMessage struct {
+	Role    string
+	Content string
+}
+
+// GetConversationMessages returns all messages in a conversation, ordered.
+func (s *Store) GetConversationMessages(ctx context.Context, conversationID string) ([]ConversationMessage, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT role, content FROM messages
+		WHERE conversation_id = ?
+		ORDER BY created_at ASC
+	`, conversationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var msgs []ConversationMessage
+	for rows.Next() {
+		var m ConversationMessage
+		if err := rows.Scan(&m.Role, &m.Content); err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs, rows.Err()
+}
+
 // RecordUsage saves token usage for cost tracking.
 func (s *Store) RecordUsage(ctx context.Context, projectID, model string, usage TokenUsage) error {
 	s.mu.Lock()

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -82,6 +82,24 @@ func (o *Orchestrator) StartSession(projectPath string) (*Session, error) {
 	return s, nil
 }
 
+// ResumeSession creates a session and loads its latest conversation from SQLite.
+func (o *Orchestrator) ResumeSession(projectPath string) (*Session, error) {
+	s, err := o.StartSession(projectPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only resume if the session has no messages (freshly created).
+	if s.MessageCount() == 0 {
+		ctx := context.Background()
+		if err := s.Resume(ctx); err != nil {
+			o.logger.Info("no previous conversation to resume", "project", s.ProjectName, "reason", err)
+			// Not fatal — just start fresh.
+		}
+	}
+	return s, nil
+}
+
 // GetSession returns an existing session or nil.
 func (o *Orchestrator) GetSession(projectPath string) *Session {
 	projCtx, err := project.Detect(projectPath)

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/wcatz/ghost/internal/ai"
+	"github.com/wcatz/ghost/internal/memory"
 	"github.com/wcatz/ghost/internal/mode"
 	"github.com/wcatz/ghost/internal/project"
 	"github.com/wcatz/ghost/internal/prompt"
@@ -71,6 +72,63 @@ func NewSession(
 		logger:       logger,
 		model:        model,
 	}
+}
+
+// InitConversation creates a conversation record in SQLite for message persistence.
+func (s *Session) InitConversation(ctx context.Context) error {
+	convID, err := s.store.CreateConversation(ctx, s.ProjectID, s.Mode.Name)
+	if err != nil {
+		return fmt.Errorf("create conversation: %w", err)
+	}
+	s.ConversationID = convID
+	return nil
+}
+
+// Resume loads the latest conversation from SQLite and restores messages.
+func (s *Session) Resume(ctx context.Context) error {
+	convID, err := s.store.GetLatestConversation(ctx, s.ProjectID)
+	if err != nil {
+		return fmt.Errorf("get latest conversation: %w", err)
+	}
+	s.ConversationID = convID
+
+	stored, err := s.store.GetConversationMessages(ctx, convID)
+	if err != nil {
+		return fmt.Errorf("load messages: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, m := range stored {
+		msg := decodeStoredMessage(m)
+		if msg.Role != "" {
+			s.messages = append(s.messages, msg)
+		}
+	}
+	s.logger.Info("session resumed", "project", s.ProjectName, "messages", len(s.messages), "conversation", convID[:8])
+	return nil
+}
+
+// persistMessage saves a message to SQLite if we have a conversation ID.
+func (s *Session) persistMessage(ctx context.Context, role, content string) {
+	if s.ConversationID == "" {
+		return
+	}
+	if err := s.store.AppendMessage(ctx, s.ConversationID, role, content); err != nil {
+		s.logger.Error("persist message", "error", err)
+	}
+}
+
+// decodeStoredMessage converts a stored message back to an ai.Message.
+func decodeStoredMessage(m memory.ConversationMessage) ai.Message {
+	// Try JSON decode first (tool_result, multi-block messages).
+	var blocks []ai.ContentBlock
+	if err := json.Unmarshal([]byte(m.Content), &blocks); err == nil && len(blocks) > 0 {
+		return ai.Message{Role: m.Role, Content: blocks}
+	}
+	// Plain text message.
+	return ai.TextMessage(m.Role, m.Content)
 }
 
 // ApprovalFunc is the legacy synchronous approval callback.
@@ -151,8 +209,16 @@ func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userT
 		s.mu.Lock()
 		s.LastActiveAt = time.Now()
 
+		// Ensure conversation exists for persistence.
+		if s.ConversationID == "" {
+			if err := s.InitConversation(ctx); err != nil {
+				s.logger.Error("init conversation", "error", err)
+			}
+		}
+
 		// Append user message.
 		s.messages = append(s.messages, userMessage)
+		s.persistMessage(ctx, "user", userText)
 
 		// Build system blocks.
 		system := s.builder.BuildSystemBlocks(ctx, s.projectCtx, s.Mode)
@@ -218,6 +284,11 @@ func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userT
 			s.mu.Lock()
 			s.messages = append(s.messages, ai.Message{Role: "assistant", Content: assistantBlocks})
 			s.mu.Unlock()
+
+			// Persist assistant response.
+			if textAccum != "" {
+				s.persistMessage(ctx, "assistant", textAccum)
+			}
 
 			// If no tool calls, we're done.
 			if stopReason != "tool_use" || len(toolCalls) == 0 {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -71,6 +71,8 @@ type MemoryStore interface {
 	CreateConversation(ctx context.Context, projectID, mode string) (string, error)
 	AppendMessage(ctx context.Context, conversationID, role, content string) error
 	GetRecentExchanges(ctx context.Context, projectID string, limit int) ([][2]string, error)
+	GetLatestConversation(ctx context.Context, projectID string) (string, error)
+	GetConversationMessages(ctx context.Context, conversationID string) ([]memory.ConversationMessage, error)
 
 	// State
 	IncrementInteraction(ctx context.Context, projectID string) (int, error)

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -41,8 +41,9 @@ type chatState struct {
 // --- Session Handlers ---
 
 type createSessionRequest struct {
-	Path string `json:"path"`
-	Mode string `json:"mode,omitempty"`
+	Path   string `json:"path"`
+	Mode   string `json:"mode,omitempty"`
+	Resume bool   `json:"resume,omitempty"`
 }
 
 func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
@@ -56,7 +57,11 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	session, err := s.orchestrator.StartSession(req.Path)
+	startFn := s.orchestrator.StartSession
+	if req.Resume {
+		startFn = s.orchestrator.ResumeSession
+	}
+	session, err := startFn(req.Path)
 	if err != nil {
 		s.logger.Error("start session", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to start session")
@@ -329,6 +334,38 @@ func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request) {
 	state.mu.Unlock()
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "responded"})
+}
+
+// --- History Handler ---
+
+func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	session := s.orchestrator.GetSessionByID(id)
+	if session == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	if session.ConversationID == "" {
+		writeJSON(w, http.StatusOK, []interface{}{})
+		return
+	}
+
+	msgs, err := s.store.GetConversationMessages(r.Context(), session.ConversationID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load history")
+		return
+	}
+
+	type historyMsg struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	out := make([]historyMsg, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, historyMsg{Role: m.Role, Content: m.Content})
+	}
+	writeJSON(w, http.StatusOK, out)
 }
 
 // --- Mode Handler ---

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -183,26 +183,26 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	// Start streaming.
 	events := session.SendAsync(r.Context(), req.Message, approvalCh)
 
+	// resolvedCh is nil when no approval is pending; set during approval flow.
+	// A nil channel in select blocks forever (never fires), which is what we want.
+	var resolvedCh chan struct{}
+
 	for {
 		select {
 		case evt, ok := <-events:
 			if !ok {
-				// Stream complete.
 				writeSSE(w, flusher, "done", map[string]string{"status": "complete"})
 				return
 			}
 			s.handleStreamEvent(w, flusher, evt)
 
 		case approval := <-approvalCh:
-			// Tool needs approval — emit event and store pending.
-			// We need a bidirectional channel to both send and receive.
 			respCh := make(chan provider.ApprovalResponse, 1)
-			// Forward the response back to the approval request's send-only channel.
 			go func() {
 				v := <-respCh
 				approval.Response <- v
 			}()
-			resolvedCh := make(chan struct{}, 1)
+			resolvedCh = make(chan struct{}, 1)
 			state.mu.Lock()
 			state.pending = &pendingApproval{
 				ToolName: approval.ToolName,
@@ -217,13 +217,6 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 				"input":     json.RawMessage(approval.Input),
 			})
 
-			// Wait for external approval resolution to notify SSE client.
-			go func() {
-				<-resolvedCh
-				writeSSE(w, flusher, "approval_resolved", map[string]string{})
-			}()
-
-			// Forward to external notifier (Telegram) if configured.
 			if s.approvalNotifier != nil {
 				projectName := ""
 				if session != nil {
@@ -231,6 +224,11 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 				}
 				go s.approvalNotifier.NotifyApproval(id, projectName, approval.ToolName, approval.Input)
 			}
+
+		case <-resolvedCh:
+			// External approval (Telegram) resolved — dismiss VSCode overlay.
+			writeSSE(w, flusher, "approval_resolved", map[string]string{})
+			resolvedCh = nil
 
 		case <-r.Context().Done():
 			return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -102,6 +102,7 @@ func (s *Server) Run(ctx context.Context) error {
 				r.Post("/{id}/approve", withBodyLimit(s.handleApprove, 1<<20))
 				r.Post("/{id}/mode", withBodyLimit(s.handleSetMode, 1<<20))
 				r.Post("/{id}/auto-approve", withBodyLimit(s.handleAutoApprove, 1<<20))
+				r.Get("/{id}/history", s.handleHistory)
 			})
 		}
 	})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -87,6 +87,12 @@ func (m *mockStore) AppendMessage(_ context.Context, _, _, _ string) error { ret
 func (m *mockStore) GetRecentExchanges(_ context.Context, _ string, _ int) ([][2]string, error) {
 	return nil, nil
 }
+func (m *mockStore) GetLatestConversation(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+func (m *mockStore) GetConversationMessages(_ context.Context, _ string) ([]memory.ConversationMessage, error) {
+	return nil, nil
+}
 func (m *mockStore) IncrementInteraction(_ context.Context, _ string) (int, error) { return 0, nil }
 func (m *mockStore) GetLearnedContext(_ context.Context, _ string) (string, error) { return "", nil }
 func (m *mockStore) UpdateLearnedContext(_ context.Context, _, _, _ string) error  { return nil }

--- a/vscode-ghost/src/chat-editor.ts
+++ b/vscode-ghost/src/chat-editor.ts
@@ -115,10 +115,31 @@ export class ChatEditorPanel {
       return;
     }
     try {
-      this.session = await this.client.createSession(folders[0].uri.fsPath);
+      this.session = await this.client.createSession(folders[0].uri.fsPath, undefined, true);
       this.postMessage({ type: "session", session: this.session });
+      // Load previous messages if resuming.
+      await this.loadHistory();
     } catch (err) {
       this.postMessage({ type: "error", text: `Failed to create session: ${err}` });
+    }
+  }
+
+  private async loadHistory(): Promise<void> {
+    if (!this.session) return;
+    try {
+      const history = await this.client.getHistory(this.session.id);
+      if (history && history.length > 0) {
+        for (const msg of history) {
+          if (msg.role === "user") {
+            this.postMessage({ type: "user_message", text: msg.content });
+          } else if (msg.role === "assistant") {
+            this.postMessage({ type: "text_delta", text: msg.content });
+            this.postMessage({ type: "done", usage: null, stop_reason: "history" });
+          }
+        }
+      }
+    } catch {
+      // No history available — fresh session.
     }
   }
 

--- a/vscode-ghost/src/chat-panel.ts
+++ b/vscode-ghost/src/chat-panel.ts
@@ -89,10 +89,30 @@ export class ChatPanelProvider implements vscode.WebviewViewProvider {
       return;
     }
     try {
-      this.session = await this.client.createSession(folders[0].uri.fsPath);
+      this.session = await this.client.createSession(folders[0].uri.fsPath, undefined, true);
       this.postMessage({ type: "session", session: this.session });
+      await this.loadHistory();
     } catch (err) {
       this.postMessage({ type: "error", text: `Failed to create session: ${err}` });
+    }
+  }
+
+  private async loadHistory(): Promise<void> {
+    if (!this.session) return;
+    try {
+      const history = await this.client.getHistory(this.session.id);
+      if (history && history.length > 0) {
+        for (const msg of history) {
+          if (msg.role === "user") {
+            this.postMessage({ type: "user_message", text: msg.content });
+          } else if (msg.role === "assistant") {
+            this.postMessage({ type: "text_delta", text: msg.content });
+            this.postMessage({ type: "done", usage: null, stop_reason: "history" });
+          }
+        }
+      }
+    } catch {
+      // No history — fresh session.
     }
   }
 

--- a/vscode-ghost/src/ghost-client.ts
+++ b/vscode-ghost/src/ghost-client.ts
@@ -81,8 +81,12 @@ export class GhostClient extends EventEmitter {
 
   // --- Sessions ---
 
-  async createSession(path: string, mode?: string): Promise<Session> {
-    return this.request("POST", "/api/v1/sessions", { path, mode });
+  async createSession(path: string, mode?: string, resume?: boolean): Promise<Session> {
+    return this.request("POST", "/api/v1/sessions", { path, mode, resume });
+  }
+
+  async getHistory(sessionId: string): Promise<{ role: string; content: string }[]> {
+    return this.request("GET", `/api/v1/sessions/${sessionId}/history`);
   }
 
   async listSessions(): Promise<Session[]> {

--- a/vscode-ghost/src/webview-html.ts
+++ b/vscode-ghost/src/webview-html.ts
@@ -38,7 +38,7 @@ export function getChatHtml(
   </div>
   <div id="messages"></div>
   <div id="slash-menu" class="hidden"></div>
-  <div id="approval-overlay" class="hidden">
+  <div id="approval-overlay" class="hidden" tabindex="0">
     <div id="approval-modal">
       <div class="modal-header">Tool Approval Required</div>
       <div id="approval-tool" class="modal-tool"></div>


### PR DESCRIPTION
## Summary
- Persist messages to SQLite during chat (user, assistant, tool results)
- Resume latest conversation on session reconnect
- VSCode extension auto-resumes and displays message history
- New `GET /api/v1/sessions/{id}/history` endpoint
- `POST /sessions` accepts `resume: true` flag

## Test plan
- [x] go vet clean
- [x] TypeScript compiles
- [x] Messages persist across ghost serve restarts
- [x] VSCode shows previous messages on reload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now resume previous conversations with persisted chat history.
  * Chat messages are automatically stored for conversation continuity.
  * Added conversation history retrieval functionality to replay previous discussions in the chat interface.
  * Updated session creation workflow to optionally load and display prior conversation context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->