### PR TITLE
feat(vscode): inline diff preview for file edits

### DIFF
--- a/internal/ai/models.go
+++ b/internal/ai/models.go
@@ -137,12 +137,13 @@ type TokenUsage struct {
 
 // StreamEvent is emitted during streaming for TUI rendering.
 type StreamEvent struct {
-	Type       string // "text", "thinking", "tool_use_start", "tool_input_delta", "tool_use_end", "done", "error"
+	Type       string // "text", "thinking", "tool_use_start", "tool_input_delta", "tool_use_end", "tool_diff", "done", "error"
 	Text       string // for text deltas and thinking deltas
 	ToolUse    *ToolUseEvent
 	Usage      *TokenUsage
-	StopReason string // on "done": "end_turn" or "tool_use"
+	StopReason string            // on "done": "end_turn" or "tool_use"
 	Error      error
+	Metadata   map[string]string // optional extra data (e.g. diff content)
 }
 
 // ToolUseEvent holds data for tool-related stream events.

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -328,6 +328,15 @@ func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userT
 					Text: fmt.Sprintf("\n<tool_result name=%q duration=%s>\n", tc.Name, result.Duration),
 				}
 
+				// Emit diff metadata for file_edit/file_write tools.
+				if result.Metadata != nil {
+					events <- ai.StreamEvent{
+						Type:     "tool_diff",
+						ToolUse:  &ai.ToolUseEvent{ID: tc.ID, Name: tc.Name},
+						Metadata: result.Metadata,
+					}
+				}
+
 				results = append(results, ai.ToolResult{
 					ToolUseID: tc.ID,
 					Content:   result.Content,

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -263,6 +263,17 @@ func (s *Server) handleStreamEvent(w http.ResponseWriter, flusher http.Flusher, 
 				"name": evt.ToolUse.Name,
 			})
 		}
+	case "tool_diff":
+		if evt.ToolUse != nil && evt.Metadata != nil {
+			data := map[string]string{
+				"id":   evt.ToolUse.ID,
+				"name": evt.ToolUse.Name,
+			}
+			for k, v := range evt.Metadata {
+				data[k] = v
+			}
+			writeSSE(w, flusher, "tool_diff", data)
+		}
 	case "done":
 		data := map[string]interface{}{
 			"stop_reason": evt.StopReason,

--- a/internal/tool/file_edit.go
+++ b/internal/tool/file_edit.go
@@ -67,5 +67,19 @@ func execFileEdit(ctx context.Context, projectPath string, input json.RawMessage
 		return Result{Content: fmt.Sprintf("write failed: %v", err), IsError: true}
 	}
 
-	return Result{Content: fmt.Sprintf("edited %s (replaced %d chars with %d chars)", path, len(in.OldText), len(in.NewText))}
+	// Build unified diff for inline preview.
+	diff := fmt.Sprintf("--- a/%s\n+++ b/%s\n", in.Path, in.Path)
+	oldLines := strings.Split(in.OldText, "\n")
+	newLines := strings.Split(in.NewText, "\n")
+	for _, l := range oldLines {
+		diff += "- " + l + "\n"
+	}
+	for _, l := range newLines {
+		diff += "+ " + l + "\n"
+	}
+
+	return Result{
+		Content:  fmt.Sprintf("edited %s (replaced %d chars with %d chars)", path, len(in.OldText), len(in.NewText)),
+		Metadata: map[string]string{"diff": diff, "path": in.Path},
+	}
 }

--- a/internal/tool/registry.go
+++ b/internal/tool/registry.go
@@ -24,6 +24,7 @@ type Result struct {
 	Content  string
 	IsError  bool
 	Duration time.Duration
+	Metadata map[string]string // optional extra data (e.g. "diff" for file_edit)
 }
 
 // Executor runs a tool and returns the result.

--- a/vscode-ghost/media/chat.css
+++ b/vscode-ghost/media/chat.css
@@ -536,6 +536,44 @@ a { color: var(--ghost-accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
 strong { font-weight: 600; }
 
+/* Diff blocks */
+.diff-block {
+  margin: 8px 0;
+  border: 1px solid var(--ghost-border);
+  border-radius: 6px;
+  overflow: hidden;
+  font-size: 12px;
+}
+.diff-header {
+  padding: 6px 12px;
+  background: rgba(255,255,255,0.05);
+  border-bottom: 1px solid var(--ghost-border);
+  font-weight: 600;
+  color: var(--ghost-accent);
+}
+.diff-content {
+  padding: 8px 12px;
+  margin: 0;
+  overflow-x: auto;
+  line-height: 1.5;
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: var(--vscode-editor-font-size, 13px);
+}
+.diff-add {
+  color: #73c991;
+  display: block;
+  background: rgba(115,201,145,0.08);
+}
+.diff-del {
+  color: #f44747;
+  display: block;
+  background: rgba(244,71,71,0.08);
+}
+.diff-meta {
+  color: var(--ghost-muted);
+  display: block;
+}
+
 /* Scrollbar */
 #messages::-webkit-scrollbar { width: 6px; }
 #messages::-webkit-scrollbar-track { background: transparent; }

--- a/vscode-ghost/src/chat-editor.ts
+++ b/vscode-ghost/src/chat-editor.ts
@@ -162,6 +162,8 @@ export class ChatEditorPanel {
       this.postMessage({ type: "tool_delta", ...data }));
     events.on("tool_end", (data: { id: string; name: string }) =>
       this.postMessage({ type: "tool_end", ...data }));
+    events.on("tool_diff", (data: Record<string, string>) =>
+      this.postMessage({ type: "tool_diff", ...data }));
     events.on("approval", (data: ApprovalRequest) =>
       this.postMessage({ type: "approval_required", tool_name: data.tool_name, input: data.input }));
     events.on("approval_resolved", () =>

--- a/vscode-ghost/src/chat-panel.ts
+++ b/vscode-ghost/src/chat-panel.ts
@@ -139,6 +139,8 @@ export class ChatPanelProvider implements vscode.WebviewViewProvider {
       this.postMessage({ type: "tool_delta", ...data }));
     events.on("tool_end", (data: { id: string; name: string }) =>
       this.postMessage({ type: "tool_end", ...data }));
+    events.on("tool_diff", (data: Record<string, string>) =>
+      this.postMessage({ type: "tool_diff", ...data }));
     events.on("approval", (data: ApprovalRequest) =>
       this.postMessage({ type: "approval_required", tool_name: data.tool_name, input: data.input }));
     events.on("approval_resolved", () =>

--- a/vscode-ghost/src/ghost-client.ts
+++ b/vscode-ghost/src/ghost-client.ts
@@ -206,6 +206,9 @@ export class GhostClient extends EventEmitter {
                 case "tool_use_end":
                   emitter.emit("tool_end", data);
                   break;
+                case "tool_diff":
+                  emitter.emit("tool_diff", data);
+                  break;
                 case "approval_required":
                   emitter.emit("approval", data as ApprovalRequest);
                   break;

--- a/vscode-ghost/src/webview-html.ts
+++ b/vscode-ghost/src/webview-html.ts
@@ -521,6 +521,37 @@ export function getChatHtml(
           break;
         }
 
+        case 'tool_diff': {
+          if (msg.diff) {
+            const diffEl = document.createElement('div');
+            diffEl.className = 'diff-block';
+            const header = document.createElement('div');
+            header.className = 'diff-header';
+            header.textContent = msg.path || msg.name || 'file edit';
+            diffEl.appendChild(header);
+            const pre = document.createElement('pre');
+            pre.className = 'diff-content';
+            const lines = msg.diff.split('\\n');
+            for (const line of lines) {
+              const span = document.createElement('span');
+              if (line.startsWith('+ ')) {
+                span.className = 'diff-add';
+              } else if (line.startsWith('- ')) {
+                span.className = 'diff-del';
+              } else if (line.startsWith('---') || line.startsWith('+++')) {
+                span.className = 'diff-meta';
+              }
+              span.textContent = line;
+              pre.appendChild(span);
+              pre.appendChild(document.createTextNode('\\n'));
+            }
+            diffEl.appendChild(pre);
+            messagesEl.appendChild(diffEl);
+            scrollToBottom();
+          }
+          break;
+        }
+
         case 'approval_required':
           if (autoApprove) {
             vscode.postMessage({ type: 'approve', approved: true });


### PR DESCRIPTION
## Summary
- file_edit tool emits `tool_diff` SSE events with unified diff data
- VSCode webview renders diffs with color-coded add (green) / delete (red) lines
- Adds `Metadata` field to `StreamEvent` and `Result` types
- Full pipeline: tool execution → Result.Metadata → StreamEvent → SSE → webview

## Test plan
- [x] go vet clean
- [x] TypeScript compiles
- [x] file_edit shows diff block in chat