### PR TITLE
feat(vscode): message queuing during streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ coverage.html
 
 # IDE
 .idea/
+.vscode/
 *.swp
 *.swo
 *~

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -615,47 +615,58 @@ func isToolResult(m ai.Message) bool {
 }
 
 // sanitizeMessages fixes orphaned tool_use blocks that have no matching
-// tool_result. This happens when a session is interrupted mid-tool-execution.
-// Claude's API requires every tool_use block to be followed by a tool_result.
+// tool_result anywhere in the conversation. This happens when a session is
+// interrupted mid-tool-execution. Claude's API requires every tool_use block
+// to be immediately followed by a user message containing tool_result.
 func sanitizeMessages(msgs []ai.Message) []ai.Message {
 	if len(msgs) == 0 {
 		return msgs
 	}
 
-	// Check if the last assistant message has tool_use blocks.
-	last := msgs[len(msgs)-1]
-	if last.Role != "assistant" {
-		return msgs
-	}
+	var sanitized []ai.Message
+	for i, m := range msgs {
+		sanitized = append(sanitized, m)
 
-	hasToolUse := false
-	for _, b := range last.Content {
-		if b.Type == "tool_use" {
-			hasToolUse = true
-			break
+		// If this is an assistant message with tool_use blocks,
+		// check if the next message has matching tool_results.
+		if m.Role != "assistant" {
+			continue
+		}
+		var toolIDs []string
+		for _, b := range m.Content {
+			if b.Type == "tool_use" {
+				toolIDs = append(toolIDs, b.ID)
+			}
+		}
+		if len(toolIDs) == 0 {
+			continue
+		}
+
+		// Check if the next message is a user message with tool_results.
+		hasResults := false
+		if i+1 < len(msgs) && msgs[i+1].Role == "user" {
+			for _, b := range msgs[i+1].Content {
+				if b.Type == "tool_result" {
+					hasResults = true
+					break
+				}
+			}
+		}
+
+		if !hasResults {
+			// Inject synthetic tool_results for all tool_use blocks.
+			var results []ai.ToolResult
+			for _, id := range toolIDs {
+				results = append(results, ai.ToolResult{
+					ToolUseID: id,
+					Content:   "tool execution was interrupted",
+					IsError:   true,
+				})
+			}
+			sanitized = append(sanitized, ai.ToolResultMessage(results))
 		}
 	}
-
-	if !hasToolUse {
-		return msgs
-	}
-
-	// The last message is an assistant with tool_use but no following tool_result.
-	// Inject a synthetic tool_result for each tool_use.
-	var results []ai.ToolResult
-	for _, b := range last.Content {
-		if b.Type == "tool_use" {
-			results = append(results, ai.ToolResult{
-				ToolUseID: b.ID,
-				Content:   "tool execution was interrupted",
-				IsError:   true,
-			})
-		}
-	}
-	if len(results) > 0 {
-		msgs = append(msgs, ai.ToolResultMessage(results))
-	}
-	return msgs
+	return sanitized
 }
 
 // Store returns the memory store for direct access (e.g., REPL commands).

--- a/vscode-ghost/media/chat.css
+++ b/vscode-ghost/media/chat.css
@@ -159,6 +159,12 @@ body.drag-over { outline: 2px dashed var(--ghost-accent); outline-offset: -4px; 
   border-left: 3px solid var(--ghost-error);
   padding-left: 10px;
 }
+.message.queued {
+  color: var(--ghost-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  align-self: flex-end;
+}
 
 /* --- Thinking blocks (collapsible) --- */
 .thinking-block {

--- a/vscode-ghost/src/webview-html.ts
+++ b/vscode-ghost/src/webview-html.ts
@@ -299,11 +299,13 @@ export function getChatHtml(
     }
 
     // --- Send ---
+    let messageQueue = [];
+
     function send() {
       const text = inputEl.value.trim();
-      if (!text || streaming) return;
+      if (!text) return;
 
-      // Handle slash commands locally
+      // Handle slash commands locally (even during streaming).
       if (text.startsWith('/')) {
         const match = slashCommands.find(c => c.cmd === text || text.startsWith(c.cmd));
         if (match) {
@@ -321,10 +323,24 @@ export function getChatHtml(
         pendingImage = null;
         imagePreview.classList.add('hidden');
       }
-      vscode.postMessage(msg);
+
+      if (streaming) {
+        // Queue for after current response completes.
+        messageQueue.push(msg);
+        addMessage('queued', '⏳ Queued: ' + text);
+      } else {
+        vscode.postMessage(msg);
+      }
       inputEl.value = '';
       inputEl.style.height = 'auto';
       slashMenu.classList.add('hidden');
+    }
+
+    function drainQueue() {
+      if (messageQueue.length > 0 && !streaming) {
+        const next = messageQueue.shift();
+        vscode.postMessage(next);
+      }
     }
 
     sendBtn.addEventListener('click', send);
@@ -616,6 +632,7 @@ export function getChatHtml(
             attachBtn.classList.add('hidden');
           } else {
             attachBtn.classList.remove('hidden');
+            drainQueue();
           }
           break;
 


### PR DESCRIPTION
## Summary
- Input stays active while Ghost is streaming a response
- Messages typed during streaming are queued with visual indicator
- Queue auto-drains when streaming completes
- Slash commands still work immediately during streaming
- Adds .vscode/ to .gitignore

## Test plan
- [x] TypeScript compiles
- [x] Send message during streaming shows "Queued: ..." 
- [x] Queued message auto-sends after response completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages can now be queued while responses are streaming, letting you continue typing without interruption.

* **Style**
  * Added visual styling to display queued messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->