### PR TITLE
fix(vscode): add clipboard paste for images

### DIFF
--- a/vscode-ghost/src/webview-html.ts
+++ b/vscode-ghost/src/webview-html.ts
@@ -445,6 +445,28 @@ export function getChatHtml(
       imagePreview.classList.add('hidden');
     });
 
+    // Paste image from clipboard
+    document.addEventListener('paste', (e) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      for (const item of items) {
+        if (item.type.startsWith('image/')) {
+          e.preventDefault();
+          const file = item.getAsFile();
+          if (!file) continue;
+          const reader = new FileReader();
+          reader.onload = () => {
+            const base64 = reader.result.split(',')[1];
+            pendingImage = { media_type: file.type, data: base64 };
+            previewImg.src = reader.result;
+            imagePreview.classList.remove('hidden');
+          };
+          reader.readAsDataURL(file);
+          break;
+        }
+      }
+    });
+
     // Drag-drop
     document.body.addEventListener('dragover', (e) => { e.preventDefault(); document.body.classList.add('drag-over'); });
     document.body.addEventListener('dragleave', () => document.body.classList.remove('drag-over'));


### PR DESCRIPTION
## Summary
- Ctrl+V with image in clipboard attaches it to chat
- Shows preview thumbnail, sends as base64 with next message
- Complements existing drag-drop and file picker

## Test plan
- [x] TypeScript compiles
- [x] Paste screenshot attaches to chat