### PR TITLE
feat(api): PDF input, token counting, Haiku summaries, cost tracking

### DIFF
--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -160,7 +160,7 @@ func (c *Client) CountTokens(ctx context.Context, messages []Message, system []S
 	if err != nil {
 		return 0, fmt.Errorf("count tokens request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if err != nil {

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -128,6 +128,58 @@ func (c *Client) ChatStream(
 	return events, nil
 }
 
+// CountTokens returns the exact token count for a set of messages + system blocks.
+// Uses the /v1/messages/count_tokens API endpoint.
+func (c *Client) CountTokens(ctx context.Context, messages []Message, system []SystemBlock, tools []ToolDefinition, model string) (int, error) {
+	reqBody := struct {
+		Model    string           `json:"model"`
+		System   []SystemBlock    `json:"system,omitempty"`
+		Messages []Message        `json:"messages"`
+		Tools    []ToolDefinition `json:"tools,omitempty"`
+	}{
+		Model:    model,
+		System:   system,
+		Messages: messages,
+		Tools:    tools,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return 0, fmt.Errorf("marshal count request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.anthropic.com/v1/messages/count_tokens", bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("create count request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("anthropic-version", APIVersion)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("count tokens request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return 0, fmt.Errorf("read count response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("count tokens API status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		InputTokens int `json:"input_tokens"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return 0, fmt.Errorf("unmarshal count response: %w", err)
+	}
+	return result.InputTokens, nil
+}
+
 // Reflect calls Haiku (non-streaming) for memory extraction/reflection.
 func (c *Client) Reflect(ctx context.Context, prompt string) (string, TokenUsage, error) {
 	reqBody := apiRequest{

--- a/internal/ai/models.go
+++ b/internal/ai/models.go
@@ -107,6 +107,18 @@ func ImageBlock(mediaType, base64Data string) ContentBlock {
 	}
 }
 
+// DocumentBlock creates a content block with an inline PDF document.
+func DocumentBlock(base64Data string) ContentBlock {
+	return ContentBlock{
+		Type: "document",
+		Source: &ImageSource{
+			Type:      "base64",
+			MediaType: "application/pdf",
+			Data:      base64Data,
+		},
+	}
+}
+
 // MultimodalMessage creates a user message with text and images.
 func MultimodalMessage(text string, images []ContentBlock) Message {
 	blocks := make([]ContentBlock, 0, len(images)+1)

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -550,6 +550,44 @@ type TokenUsage struct {
 	CostUSD       float64
 }
 
+// CostSummary holds aggregated cost data.
+type CostSummary struct {
+	TotalCost      float64
+	TotalInput     int
+	TotalOutput    int
+	TotalCacheRead int
+	SessionCount   int
+	Since          string // earliest record
+}
+
+// GetCostSummary returns aggregated cost data, optionally filtered by time range.
+// Pass empty since for all-time, or "24h", "7d", "30d" for recent.
+func (s *Store) GetCostSummary(ctx context.Context, since string) (CostSummary, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	query := `SELECT COALESCE(SUM(cost_usd), 0), COALESCE(SUM(input_tokens), 0),
+		COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cache_read), 0),
+		COUNT(*), COALESCE(MIN(created_at), '') FROM token_usage`
+
+	var args []interface{}
+	switch since {
+	case "24h":
+		query += " WHERE created_at > datetime('now', '-1 day')"
+	case "7d":
+		query += " WHERE created_at > datetime('now', '-7 days')"
+	case "30d":
+		query += " WHERE created_at > datetime('now', '-30 days')"
+	}
+
+	var cs CostSummary
+	err := s.db.QueryRowContext(ctx, query, args...).Scan(
+		&cs.TotalCost, &cs.TotalInput, &cs.TotalOutput,
+		&cs.TotalCacheRead, &cs.SessionCount, &cs.Since,
+	)
+	return cs, err
+}
+
 func scanMemories(rows *sql.Rows) ([]Memory, error) {
 	var memories []Memory
 	for rows.Next() {

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -12,7 +13,7 @@ import (
 	"time"
 
 	"github.com/wcatz/ghost/internal/ai"
-	"github.com/wcatz/ghost/internal/memory"
+	memstore "github.com/wcatz/ghost/internal/memory"
 	"github.com/wcatz/ghost/internal/mode"
 	"github.com/wcatz/ghost/internal/project"
 	"github.com/wcatz/ghost/internal/prompt"
@@ -129,7 +130,7 @@ func (s *Session) persistMessage(ctx context.Context, role, content string) {
 }
 
 // decodeStoredMessage converts a stored message back to an ai.Message.
-func decodeStoredMessage(m memory.ConversationMessage) ai.Message {
+func decodeStoredMessage(m memstore.ConversationMessage) ai.Message {
 	// Try JSON decode first (tool_result, multi-block messages).
 	var blocks []ai.ContentBlock
 	if err := json.Unmarshal([]byte(m.Content), &blocks); err == nil && len(blocks) > 0 {
@@ -203,19 +204,21 @@ func (s *Session) SendImageAsync(ctx context.Context, text, mediaType, base64Dat
 // Send processes a user message through the full agentic loop.
 // It streams events through the returned channel.
 // Expands @file references to inline file contents before sending.
+// PDF files are sent as document content blocks; all other files are inlined as text.
 func (s *Session) Send(ctx context.Context, userMsg string, approvalFn ApprovalFunc) <-chan ai.StreamEvent {
-	expanded := s.expandFileRefs(userMsg)
-	return s.SendMessage(ctx, ai.TextMessage("user", expanded), userMsg, approvalFn)
+	msg := s.buildUserMessage(userMsg)
+	return s.SendMessage(ctx, msg, userMsg, approvalFn)
 }
 
-// expandFileRefs finds @path references in user text and appends file contents.
-// Paths are resolved relative to the project directory.
-func (s *Session) expandFileRefs(text string) string {
+// buildUserMessage creates a user message, expanding @file refs.
+// PDFs become document content blocks; text files are appended inline.
+func (s *Session) buildUserMessage(text string) ai.Message {
 	refs := parseFileRefs(text)
 	if len(refs) == 0 {
-		return text
+		return ai.TextMessage("user", text)
 	}
 
+	var blocks []ai.ContentBlock
 	var sb strings.Builder
 	sb.WriteString(text)
 
@@ -237,15 +240,27 @@ func (s *Session) expandFileRefs(text string) string {
 			continue
 		}
 
-		// Cap at 50KB per file to avoid blowing up context.
+		// PDF files → document content block (base64).
+		if strings.HasSuffix(strings.ToLower(ref), ".pdf") {
+			encoded := base64.StdEncoding.EncodeToString(data)
+			blocks = append(blocks, ai.DocumentBlock(encoded))
+			fmt.Fprintf(&sb, "\n\n[Attached PDF: %s]", ref)
+			continue
+		}
+
+		// All other files → inline text.
 		content := string(data)
 		if len(content) > 50000 {
 			content = content[:50000] + "\n... (truncated at 50KB)"
 		}
-
 		fmt.Fprintf(&sb, "\n\n---\n**File: %s**\n```\n%s\n```\n", ref, content)
 	}
-	return sb.String()
+
+	// Build message: document blocks first, then text.
+	var allBlocks []ai.ContentBlock
+	allBlocks = append(allBlocks, blocks...)
+	allBlocks = append(allBlocks, ai.ContentBlock{Type: "text", Text: sb.String()})
+	return ai.Message{Role: "user", Content: allBlocks}
 }
 
 // parseFileRefs extracts @path references from text.
@@ -335,6 +350,20 @@ func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userT
 					stopReason = evt.StopReason
 					usage = evt.Usage
 					s.Cost.Add(usage)
+					// Persist usage to SQLite for all-time cost tracking.
+					if usage != nil {
+						costUSD := float64(usage.InputTokens)/1e6*ai.SonnetInputPerM +
+							float64(usage.OutputTokens)/1e6*ai.SonnetOutputPerM +
+							float64(usage.CacheCreationInputTokens)/1e6*ai.SonnetCacheWritePerM +
+							float64(usage.CacheReadInputTokens)/1e6*ai.SonnetCacheReadPerM
+						_ = s.store.RecordUsage(ctx, s.ProjectID, s.model, memstore.TokenUsage{
+							InputTokens:   usage.InputTokens,
+							OutputTokens:  usage.OutputTokens,
+							CacheCreation: usage.CacheCreationInputTokens,
+							CacheRead:     usage.CacheReadInputTokens,
+							CostUSD:       costUSD,
+						})
+					}
 				case "error":
 					events <- evt
 					return
@@ -404,9 +433,19 @@ func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userT
 					}
 				}
 
+				// Summarize large tool results with Haiku to save Sonnet input tokens.
+				content := result.Content
+				if !result.IsError && len(content) > 10000 {
+					if summary, _, err := s.client.Reflect(ctx,
+						fmt.Sprintf("Summarize this tool output concisely, preserving all important details (file paths, line numbers, error messages, key values). Do NOT wrap in JSON.\n\nTool: %s\nOutput:\n%s", tc.Name, truncate(content, 30000)),
+					); err == nil && len(summary) > 0 {
+						content = summary + "\n\n[summarized from " + fmt.Sprintf("%d", len(result.Content)) + " chars by Haiku]"
+					}
+				}
+
 				results = append(results, ai.ToolResult{
 					ToolUseID: tc.ID,
-					Content:   result.Content,
+					Content:   content,
 					IsError:   result.IsError,
 				})
 			}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -81,6 +81,7 @@ type MemoryStore interface {
 
 	// Cost tracking
 	RecordUsage(ctx context.Context, projectID, model string, usage memory.TokenUsage) error
+	GetCostSummary(ctx context.Context, since string) (memory.CostSummary, error)
 
 	// Lifecycle
 	Close() error

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -99,6 +99,9 @@ func (m *mockStore) UpdateLearnedContext(_ context.Context, _, _, _ string) erro
 func (m *mockStore) RecordUsage(_ context.Context, _, _ string, _ memory.TokenUsage) error {
 	return nil
 }
+func (m *mockStore) GetCostSummary(_ context.Context, _ string) (memory.CostSummary, error) {
+	return memory.CostSummary{}, nil
+}
 func (m *mockStore) Close() error { return nil }
 
 // newTestServer creates a Server with a mock store and silent logger.

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -95,6 +95,7 @@ func New(cfg Config, store provider.MemoryStore, ghMonitor *gh.Monitor, sched *s
 	b.RegisterHandler(bot.HandlerTypeMessageText, "help", bot.MatchTypeCommand, tb.handleHelp)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "sessions", bot.MatchTypeCommand, tb.handleSessions)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "chat", bot.MatchTypeCommand, tb.handleChat)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "cost", bot.MatchTypeCommand, tb.handleCost)
 
 	// Callback query handlers.
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "approve:", bot.MatchTypePrefix, tb.handleApprovalCallback)
@@ -466,18 +467,71 @@ func (tb *Bot) handleEmails(ctx context.Context, b *bot.Bot, update *models.Upda
 	tb.replyWithKeyboard(ctx, b, update, sb.String(), buttons)
 }
 
+func (tb *Bot) handleCost(ctx context.Context, b *bot.Bot, update *models.Update) {
+	tb.sendTyping(ctx, update)
+
+	var sb strings.Builder
+	sb.WriteString("*Ghost Cost Summary*\n\n")
+
+	periods := []struct {
+		label string
+		since string
+	}{
+		{"Today", "24h"},
+		{"This Week", "7d"},
+		{"This Month", "30d"},
+		{"All Time", ""},
+	}
+
+	for _, p := range periods {
+		cs, err := tb.store.GetCostSummary(ctx, p.since)
+		if err != nil {
+			continue
+		}
+		fmt.Fprintf(&sb, "*%s*\n", mdv2.Esc(p.label))
+		fmt.Fprintf(&sb, "  Cost: $%s\n", mdv2.Esc(fmt.Sprintf("%.2f", cs.TotalCost)))
+		fmt.Fprintf(&sb, "  Tokens: %s in / %s out\n",
+			mdv2.Esc(formatTokens(cs.TotalInput)),
+			mdv2.Esc(formatTokens(cs.TotalOutput)))
+		if cs.TotalCacheRead > 0 {
+			fmt.Fprintf(&sb, "  Cache reads: %s\n", mdv2.Esc(formatTokens(cs.TotalCacheRead)))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Compare to Max subscription.
+	allTime, _ := tb.store.GetCostSummary(ctx, "")
+	monthly, _ := tb.store.GetCostSummary(ctx, "30d")
+	fmt.Fprintf(&sb, "_Max subscription: $200/mo_\n")
+	fmt.Fprintf(&sb, "_Ghost this month: $%s_\n", mdv2.Esc(fmt.Sprintf("%.2f", monthly.TotalCost)))
+	fmt.Fprintf(&sb, "_Ghost all time: $%s_", mdv2.Esc(fmt.Sprintf("%.2f", allTime.TotalCost)))
+
+	tb.reply(ctx, b, update, sb.String())
+}
+
+func formatTokens(n int) string {
+	if n >= 1000000 {
+		return fmt.Sprintf("%.1fM", float64(n)/1e6)
+	}
+	if n >= 1000 {
+		return fmt.Sprintf("%.1fK", float64(n)/1e3)
+	}
+	return fmt.Sprintf("%d", n)
+}
+
 func (tb *Bot) handleHelp(ctx context.Context, b *bot.Bot, update *models.Update) {
 	tb.reply(ctx, b, update, `*Ghost Commands*
 
-/status — System status \+ notification summary
-/notifications — List unread GitHub notifications
-/meetings — Today's calendar with Meet links
+/status — System status
+/notifications — GitHub notifications
+/meetings — Today's calendar
 /emails — Recent unread emails
-/sessions — List active Ghost sessions
+/sessions — Active Ghost sessions
 /chat — Chat with a session
+/cost — Cost tracking vs Max
 /memory search — Search memories
 /remind — Set a reminder
-/briefing — Get your morning briefing
+/briefing — Morning briefing
 /help — This message`)
 }
 


### PR DESCRIPTION
## Summary
- **PDF input**: `@file.pdf` sends PDFs as base64 document blocks via Claude's API
- **Token counting**: `CountTokens()` method for exact input token counts via `/v1/messages/count_tokens`
- **Haiku tool summaries**: tool results >10KB auto-summarized by Haiku before sending to Sonnet (cheaper agentic loops)
- **All-time cost tracking**: every API response persisted to `token_usage` table in SQLite
- **`/cost` Telegram command**: today/week/month/all-time cost breakdown + comparison to Max $200/mo
- **`GetCostSummary()`**: aggregated cost queries with time range filters

## Test plan
- [x] `go vet ./...` clean
- [x] Mock store updated with new interface method
- [x] PDF blocks use correct `type: "document"` with `application/pdf` media type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token counting for API requests.
  * New /cost Telegram command showing cost and token metrics (today, week, month, all-time).
  * PDF documents may be inlined as document content for uploads.
  * Automatic summarization of very large tool outputs for clearer responses.
  * Cost aggregation and persistence with a summary retrieval API.

* **Tests**
  * Mock store extended to support cost-summary behavior for test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->