### PR TITLE
fix(mcp): resolve project_id by name for MCP clients

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -47,6 +47,30 @@ func (s *Server) Run(ctx context.Context) error {
 	return s.mcp.Run(ctx, &mcp.StdioTransport{})
 }
 
+// resolveProjectID resolves a project_id that may be a name (e.g. "ghost")
+// into the actual hash ID (e.g. "6bdc098af7f5") stored in the database.
+// Tries direct ID match first, then falls back to name lookup.
+func (s *Server) resolveProjectID(ctx context.Context, input string) string {
+	// Check if input directly matches a project ID.
+	projects, err := s.store.ListProjects(ctx)
+	if err == nil {
+		for _, p := range projects {
+			if p.ID == input {
+				return input
+			}
+		}
+	}
+
+	// Try name lookup.
+	resolved, err := s.store.ResolveProjectByName(ctx, input)
+	if err == nil && resolved != "" {
+		return resolved
+	}
+
+	// Return as-is if nothing matched — let downstream handle the miss.
+	return input
+}
+
 func (s *Server) registerTools() {
 	// ghost_memory_search — search memories by keyword or semantic query.
 	type searchArgs struct {
@@ -65,6 +89,8 @@ func (s *Server) registerTools() {
 		if args.Limit <= 0 {
 			args.Limit = 10
 		}
+
+		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
 
 		memories, err := s.store.SearchFTS(ctx, args.ProjectID, args.Query, args.Limit)
 		if err != nil {
@@ -118,6 +144,8 @@ func (s *Server) registerTools() {
 			args.Tags = []string{}
 		}
 
+		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
+
 		if err := s.store.EnsureProject(ctx, args.ProjectID, "", args.ProjectID); err != nil {
 			return nil, nil, fmt.Errorf("ensure project: %w", err)
 		}
@@ -154,6 +182,8 @@ func (s *Server) registerTools() {
 		if args.Limit <= 0 {
 			args.Limit = 20
 		}
+
+		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
 
 		var sb strings.Builder
 
@@ -202,6 +232,8 @@ func (s *Server) registerTools() {
 		if args.Limit <= 0 {
 			args.Limit = 30
 		}
+
+		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
 
 		var memories []memory.Memory
 		var err error

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -97,6 +97,23 @@ func (s *Store) EnsureProject(ctx context.Context, id, path, name string) error 
 	return err
 }
 
+// ResolveProjectByName looks up a project by name and returns its hash ID.
+// Returns empty string if no project with that name exists.
+func (s *Store) ResolveProjectByName(ctx context.Context, name string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var id string
+	err := s.db.QueryRowContext(ctx, `SELECT id FROM projects WHERE name = ? LIMIT 1`, name).Scan(&id)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("resolve project by name: %w", err)
+	}
+	return id, nil
+}
+
 // Create inserts a new memory and returns its ID.
 func (s *Store) Create(ctx context.Context, projectID string, m Memory) (string, error) {
 	s.mu.Lock()

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -66,6 +66,7 @@ type MemoryStore interface {
 	// Project management
 	ListProjects(ctx context.Context) ([]memory.Project, error)
 	EnsureProject(ctx context.Context, id, path, name string) error
+	ResolveProjectByName(ctx context.Context, name string) (string, error)
 
 	// Conversation persistence
 	CreateConversation(ctx context.Context, projectID, mode string) (string, error)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -80,6 +80,9 @@ func (m *mockStore) ReplaceNonManual(_ context.Context, _ string, _ []memory.Mem
 }
 func (m *mockStore) ListProjects(_ context.Context) ([]memory.Project, error) { return nil, nil }
 func (m *mockStore) EnsureProject(_ context.Context, _, _, _ string) error    { return nil }
+func (m *mockStore) ResolveProjectByName(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
 func (m *mockStore) CreateConversation(_ context.Context, _, _ string) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
## Summary

- MCP clients (Claude Code, Cursor) pass project name ("ghost") as `project_id`, but Ghost's DB stores project IDs as `sha256(abs_path)[:12]` (e.g. "6bdc098af7f5"). Every MCP query returned empty results.
- Added `ResolveProjectByName` to `memory.Store` — simple `SELECT id FROM projects WHERE name = ?`
- Added `resolveProjectID` helper to MCP server — tries direct ID match first, falls back to name lookup
- All 4 MCP tool handlers (`search`, `save`, `context`, `list`) now resolve before querying

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [ ] Manual: `ghost mcp` → call `ghost_memory_search` with `project_id="ghost"` → returns actual memories
- [ ] Manual: `ghost_memory_save` with project name creates memory under correct hash ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced project identification: projects can now be referenced by name as well as ID. The system automatically resolves project names across memory search, save, context, and listing operations for smoother, more flexible workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->