### PR TITLE
fix(embedding): wire embedding pipeline for hybrid search

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -210,17 +210,18 @@ func runServe() {
 	defer cancel()
 
 	// --- Embedding worker (background vectorization via Ollama) ---
+	var embedClient *embedding.Client
+	var projectCh chan string
 	if cfg.Embedding.Enabled {
-		embedClient := embedding.NewClient(cfg.Embedding.OllamaURL, cfg.Embedding.Model, cfg.Embedding.Dimensions)
+		embedClient = embedding.NewClient(cfg.Embedding.OllamaURL, cfg.Embedding.Model, cfg.Embedding.Dimensions)
 		embedWorker := embedding.NewWorker(embedClient, store, logger, 2*time.Minute)
-		projectCh := make(chan string, 16)
+		projectCh = make(chan string, 16)
 		go embedWorker.Run(ctx, projectCh)
 		if embedClient.Alive(ctx) {
 			logger.Info("embedding worker started", "model", cfg.Embedding.Model, "ollama", cfg.Embedding.OllamaURL)
 		} else {
 			logger.Info("embedding worker started (ollama offline, will retry)", "ollama", cfg.Embedding.OllamaURL)
 		}
-		_ = projectCh // projects get sent here when memories are created
 	}
 
 	// --- Scheduler (cron jobs + reminders) ---
@@ -370,13 +371,24 @@ func runServe() {
 
 // runMCP starts ghost as an MCP server on stdio.
 func runMCP() {
-	_, logger, store, _ := bootstrap()
+	cfg, logger, store, _ := bootstrap()
 	defer store.Close()
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	srv := mcpserver.New(store, logger)
+
+	// Wire embedding for hybrid search if configured.
+	if cfg.Embedding.Enabled {
+		embedClient := embedding.NewClient(cfg.Embedding.OllamaURL, cfg.Embedding.Model, cfg.Embedding.Dimensions)
+		embedWorker := embedding.NewWorker(embedClient, store, logger, 2*time.Minute)
+		projectCh := make(chan string, 16)
+		go embedWorker.Run(ctx, projectCh)
+		srv.SetEmbedder(embedClient, projectCh)
+		logger.Info("mcp: embedding enabled", "model", cfg.Embedding.Model)
+	}
+
 	if err := srv.Run(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -15,11 +15,18 @@ import (
 	"github.com/wcatz/ghost/internal/provider"
 )
 
+// Embedder generates vector embeddings for text. Optional — when nil, search falls back to FTS only.
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+}
+
 // Server wraps the MCP server with Ghost's memory store.
 type Server struct {
-	store  provider.MemoryStore
-	logger *slog.Logger
-	mcp    *mcp.Server
+	store     provider.MemoryStore
+	logger    *slog.Logger
+	mcp       *mcp.Server
+	embedder  Embedder
+	projectCh chan<- string // notify embedding worker of new memories
 }
 
 // New creates and configures the MCP server with all Ghost tools.
@@ -39,6 +46,12 @@ func New(store provider.MemoryStore, logger *slog.Logger) *Server {
 
 	s.registerTools()
 	return s
+}
+
+// SetEmbedder configures optional vector embedding for hybrid search.
+func (s *Server) SetEmbedder(e Embedder, projectCh chan<- string) {
+	s.embedder = e
+	s.projectCh = projectCh
 }
 
 // Run starts the MCP server on stdio transport. Blocks until done.
@@ -91,7 +104,14 @@ func (s *Server) registerTools() {
 		}
 		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
 
-		memories, err := s.store.SearchFTS(ctx, args.ProjectID, args.Query, args.Limit)
+		// Use hybrid search (FTS5 + vector) when embedder is available.
+		var queryVec []float32
+		if s.embedder != nil {
+			if vec, err := s.embedder.Embed(ctx, args.Query); err == nil {
+				queryVec = vec
+			}
+		}
+		memories, err := s.store.SearchHybrid(ctx, args.ProjectID, args.Query, queryVec, args.Limit)
 		if err != nil {
 			return nil, nil, fmt.Errorf("search failed: %w", err)
 		}
@@ -151,6 +171,14 @@ func (s *Server) registerTools() {
 		id, merged, err := s.store.Upsert(ctx, args.ProjectID, args.Category, args.Content, "mcp", args.Importance, args.Tags)
 		if err != nil {
 			return nil, nil, fmt.Errorf("save failed: %w", err)
+		}
+
+		// Notify embedding worker of new/updated memory.
+		if s.projectCh != nil {
+			select {
+			case s.projectCh <- args.ProjectID:
+			default: // non-blocking
+			}
 		}
 
 		action := "saved"


### PR DESCRIPTION
## Summary

The embedding worker and hybrid search existed but were never connected:
- `projectCh` was created but never written to (comment: "projects get sent here when memories are created")
- `SearchHybrid` existed but every consumer called `SearchFTS` instead

**Fixes:**
- MCP `ghost_memory_search`: now calls `SearchHybrid` with embedded query vector when Ollama is available, graceful FTS-only fallback
- MCP `ghost_memory_save`: sends project ID to `projectCh` after saves, triggering immediate embedding
- `ghost mcp`: starts its own embedding worker when `embedding.enabled = true`
- `ghost serve`: hoists `embedClient`/`projectCh` to function scope for downstream wiring

## Test plan
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [ ] Manual: save memory via MCP, verify embedding appears in `memory_embeddings` table
- [ ] Manual: search via MCP, verify hybrid results when Ollama running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated hybrid search capability combining full-text and vector-based search when embedding is enabled.
  * Added embedding support to the MCP server with automatic worker initialization at startup.
  * Memories now trigger embedding processing updates when created or modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->