### PR TITLE
fix(api): thinking block preservation, stream errors, per-model cost

### DIFF
--- a/internal/ai/cost.go
+++ b/internal/ai/cost.go
@@ -2,63 +2,105 @@ package ai
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 )
 
-// Pricing per million tokens (USD) — Claude Sonnet 4.5 / Haiku 4.5.
+// Pricing per million tokens (USD).
 const (
-	SonnetInputPerM       = 3.00
-	SonnetOutputPerM      = 15.00
-	SonnetCacheWritePerM  = 3.75
-	SonnetCacheReadPerM   = 0.30
-	HaikuInputPerM        = 0.80
-	HaikuOutputPerM       = 4.00
-	HaikuCacheWritePerM   = 1.00
-	HaikuCacheReadPerM    = 0.08
+	SonnetInputPerM      = 3.00
+	SonnetOutputPerM     = 15.00
+	SonnetCacheWritePerM = 3.75
+	SonnetCacheReadPerM  = 0.30
+
+	HaikuInputPerM      = 1.00
+	HaikuOutputPerM     = 5.00
+	HaikuCacheWritePerM = 1.25
+	HaikuCacheReadPerM  = 0.10
+
+	OpusInputPerM      = 5.00
+	OpusOutputPerM     = 25.00
+	OpusCacheWritePerM = 6.25
+	OpusCacheReadPerM  = 0.50
 )
 
-// CostTracker accumulates token usage and computes costs.
-// Safe for concurrent use.
-type CostTracker struct {
-	mu                       sync.Mutex
-	InputTokens              int
-	OutputTokens             int
-	CacheCreationInputTokens int
-	CacheReadInputTokens     int
+// modelPricing returns (inputPerM, outputPerM, cacheWritePerM, cacheReadPerM) for a model.
+func modelPricing(model string) (float64, float64, float64, float64) {
+	switch {
+	case strings.Contains(model, "haiku"):
+		return HaikuInputPerM, HaikuOutputPerM, HaikuCacheWritePerM, HaikuCacheReadPerM
+	case strings.Contains(model, "opus"):
+		return OpusInputPerM, OpusOutputPerM, OpusCacheWritePerM, OpusCacheReadPerM
+	default: // sonnet or unknown
+		return SonnetInputPerM, SonnetOutputPerM, SonnetCacheWritePerM, SonnetCacheReadPerM
+	}
 }
 
-// Add accumulates token usage from a response.
+// CostTracker accumulates token usage and computes costs per model.
+// Safe for concurrent use.
+type CostTracker struct {
+	mu      sync.Mutex
+	entries []usageEntry
+}
+
+type usageEntry struct {
+	model string
+	usage TokenUsage
+}
+
+// Add accumulates token usage from a response with model context.
 func (ct *CostTracker) Add(u *TokenUsage) {
+	ct.AddWithModel(u, "")
+}
+
+// AddWithModel accumulates token usage tagged with the model that produced it.
+func (ct *CostTracker) AddWithModel(u *TokenUsage, model string) {
 	if u == nil {
 		return
 	}
 	ct.mu.Lock()
-	ct.InputTokens += u.InputTokens
-	ct.OutputTokens += u.OutputTokens
-	ct.CacheCreationInputTokens += u.CacheCreationInputTokens
-	ct.CacheReadInputTokens += u.CacheReadInputTokens
+	ct.entries = append(ct.entries, usageEntry{model: model, usage: *u})
 	ct.mu.Unlock()
 }
 
-// Cost returns the total cost in USD for Sonnet pricing.
+// totals returns aggregate token counts across all entries.
+func (ct *CostTracker) totals() (input, output, cacheWrite, cacheRead int) {
+	for _, e := range ct.entries {
+		input += e.usage.InputTokens
+		output += e.usage.OutputTokens
+		cacheWrite += e.usage.CacheCreationInputTokens
+		cacheRead += e.usage.CacheReadInputTokens
+	}
+	return
+}
+
+// Cost returns the total cost in USD using per-model pricing.
 func (ct *CostTracker) Cost() float64 {
 	ct.mu.Lock()
 	defer ct.mu.Unlock()
-	input := float64(ct.InputTokens) / 1e6 * SonnetInputPerM
-	output := float64(ct.OutputTokens) / 1e6 * SonnetOutputPerM
-	cacheWrite := float64(ct.CacheCreationInputTokens) / 1e6 * SonnetCacheWritePerM
-	cacheRead := float64(ct.CacheReadInputTokens) / 1e6 * SonnetCacheReadPerM
-	return input + output + cacheWrite + cacheRead
+	var total float64
+	for _, e := range ct.entries {
+		inP, outP, cwP, crP := modelPricing(e.model)
+		total += float64(e.usage.InputTokens) / 1e6 * inP
+		total += float64(e.usage.OutputTokens) / 1e6 * outP
+		total += float64(e.usage.CacheCreationInputTokens) / 1e6 * cwP
+		total += float64(e.usage.CacheReadInputTokens) / 1e6 * crP
+	}
+	return total
 }
 
 // CostWithoutCache returns what the cost would have been without caching.
 func (ct *CostTracker) CostWithoutCache() float64 {
 	ct.mu.Lock()
 	defer ct.mu.Unlock()
-	allInput := ct.InputTokens + ct.CacheCreationInputTokens + ct.CacheReadInputTokens
-	input := float64(allInput) / 1e6 * SonnetInputPerM
-	output := float64(ct.OutputTokens) / 1e6 * SonnetOutputPerM
-	return input + output
+	var total float64
+	for _, e := range ct.entries {
+		inP, outP, _, _ := modelPricing(e.model)
+		allInput := e.usage.InputTokens + e.usage.CacheCreationInputTokens + e.usage.CacheReadInputTokens
+		total += float64(allInput) / 1e6 * inP
+		total += float64(e.usage.OutputTokens) / 1e6 * outP
+	}
+	return total
 }
 
 // Savings returns the dollar amount saved by caching.
@@ -70,11 +112,12 @@ func (ct *CostTracker) Savings() float64 {
 func (ct *CostTracker) CacheHitRate() float64 {
 	ct.mu.Lock()
 	defer ct.mu.Unlock()
-	total := ct.InputTokens + ct.CacheCreationInputTokens + ct.CacheReadInputTokens
+	input, _, cacheWrite, cacheRead := ct.totals()
+	total := input + cacheWrite + cacheRead
 	if total == 0 {
 		return 0
 	}
-	return float64(ct.CacheReadInputTokens) / float64(total) * 100
+	return float64(cacheRead) / float64(total) * 100
 }
 
 // Summary returns a formatted cost summary string.

--- a/internal/ai/stream.go
+++ b/internal/ai/stream.go
@@ -121,6 +121,21 @@ func parseStream(r io.Reader, events chan<- StreamEvent) error {
 					Usage:      &usage,
 				}
 			}
+
+		case "error":
+			// API can emit errors mid-stream (context overflow, internal errors).
+			var apiErr struct {
+				Error struct {
+					Type    string `json:"type"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			msg := "unknown API error"
+			if json.Unmarshal([]byte(data), &apiErr) == nil && apiErr.Error.Message != "" {
+				msg = fmt.Sprintf("%s: %s", apiErr.Error.Type, apiErr.Error.Message)
+			}
+			events <- StreamEvent{Type: "error", Error: fmt.Errorf("api stream error: %s", msg)}
+			return nil
 		}
 	}
 

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -308,6 +308,7 @@ func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userT
 
 			// Collect response.
 			var textAccum string
+			var thinkingAccum string
 			var toolCalls []ai.ContentBlock
 			var stopReason string
 			var usage *ai.TokenUsage
@@ -315,7 +316,8 @@ func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userT
 			for evt := range stream {
 				switch evt.Type {
 				case "thinking":
-					events <- evt // pass thinking to TUI but don't accumulate
+					thinkingAccum += evt.Text
+					events <- evt
 				case "text":
 					textAccum += evt.Text
 					events <- evt
@@ -334,7 +336,7 @@ func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userT
 				case "done":
 					stopReason = evt.StopReason
 					usage = evt.Usage
-					s.Cost.Add(usage)
+					s.Cost.AddWithModel(usage, s.model)
 				case "error":
 					events <- evt
 					return
@@ -342,7 +344,12 @@ func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userT
 			}
 
 			// Build assistant message from accumulated content.
+			// Thinking blocks must be preserved — the API requires them
+			// in message history when extended thinking is enabled.
 			var assistantBlocks []ai.ContentBlock
+			if thinkingAccum != "" {
+				assistantBlocks = append(assistantBlocks, ai.ContentBlock{Type: "thinking", Text: thinkingAccum})
+			}
 			if textAccum != "" {
 				assistantBlocks = append(assistantBlocks, ai.ContentBlock{Type: "text", Text: textAccum})
 				fullResponse += textAccum


### PR DESCRIPTION
## Summary

Three critical API fixes found by the Anthropic API audit agent:

**1. Thinking blocks preserved in message history**
The Anthropic API requires thinking blocks in prior assistant messages when extended thinking is enabled. Ghost was stripping them at `session.go:345`, sending malformed conversations after turn 1. Now accumulates `thinkingAccum` and prepends a `thinking` content block to the assistant message.

**2. Mid-stream API error handling**
`stream.go` had no `case "error"` — API errors mid-stream (context overflow, internal errors) were silently ignored, causing Ghost to hang. Now parses the error JSON and emits a proper error event.

**3. Per-model cost tracking**
`CostTracker` always used Sonnet pricing. Haiku reflection calls (potentially dozens per session) were reported at 3.75x actual cost. Now tracks entries per-model with correct Haiku ($1/$5) and Opus ($5/$25) pricing.

## Test plan
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass (including ai package)
- [ ] Manual: multi-turn conversation with thinking enabled — verify no API errors
- [ ] Manual: trigger context overflow — verify error message instead of hang

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-model pricing support for accurate cost calculation across different AI models.
  * Enhanced error handling for API stream events with detailed error information.
  * Added support for accumulating and preserving thinking content in conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->