### PR TITLE
feat(tui): restore collapsible toolbar with thinking and tool output

### DIFF
--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -398,8 +398,13 @@ func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userT
 
 				result := s.registry.Execute(ctx, tc.Name, s.ProjectPath, tc.Input)
 				events <- ai.StreamEvent{
-					Type: "text",
-					Text: fmt.Sprintf("\n<tool_result name=%q duration=%s>\n", tc.Name, result.Duration),
+					Type: "tool_result",
+					Text: result.Content,
+					ToolUse: &ai.ToolUseEvent{ID: tc.ID, Name: tc.Name},
+					Metadata: map[string]string{
+						"is_error": fmt.Sprintf("%v", result.IsError),
+						"duration": result.Duration.String(),
+					},
 				}
 
 				// Emit diff metadata for file_edit/file_write tools.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -229,6 +229,7 @@ func (a App) handleStreamEvent(msg streamEventMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case "thinking":
 		a.toolbar.setThinking(true)
+		a.toolbar.appendThinking(msg.Text)
 	case "text":
 		a.toolbar.setThinking(false)
 		a.chatView.appendToLastAssistant(msg.Text)
@@ -244,6 +245,11 @@ func (a App) handleStreamEvent(msg streamEventMsg) (tea.Model, tea.Cmd) {
 	case "tool_use_end":
 		if msg.ToolUse != nil {
 			a.toolbar.completeTool(msg.ToolUse.ID)
+		}
+	case "tool_result":
+		if msg.ToolUse != nil {
+			isError := msg.Metadata != nil && msg.Metadata["is_error"] == "true"
+			a.toolbar.setToolOutput(msg.ToolUse.ID, msg.Text, isError)
 		}
 	case "done":
 		a.isProcessing = false
@@ -339,6 +345,18 @@ func (a App) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		a.chatView, cmd = a.chatView.update(msg)
 		return a, cmd
+
+	case key.Matches(msg, keys.ToolNext):
+		a.toolbar.selectNext()
+		return a, nil
+	case key.Matches(msg, keys.ToolPrev):
+		a.toolbar.selectPrev()
+		return a, nil
+	case key.Matches(msg, keys.ToolToggle):
+		if a.input.value() == "" {
+			a.toolbar.toggleSelected()
+			return a, nil
+		}
 	}
 
 	// Default: pass to input area.

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -15,13 +15,16 @@ type keyMap struct {
 	PageDown    key.Binding
 	Home        key.Binding
 	End         key.Binding
-	HistoryUp   key.Binding
-	HistoryDown key.Binding
-	Approve     key.Binding
-	Deny        key.Binding
-	ApproveAll  key.Binding
-	Cancel      key.Binding
-	PushToTalk  key.Binding // Phase C — reserved
+	HistoryUp    key.Binding
+	HistoryDown  key.Binding
+	Approve      key.Binding
+	Deny         key.Binding
+	ApproveAll   key.Binding
+	Cancel       key.Binding
+	PushToTalk   key.Binding // Phase C — reserved
+	ToolNext     key.Binding
+	ToolPrev     key.Binding
+	ToolToggle   key.Binding
 }
 
 var keys = keyMap{
@@ -96,5 +99,17 @@ var keys = keyMap{
 	PushToTalk: key.NewBinding(
 		key.WithKeys("ctrl+space"),
 		key.WithHelp("ctrl+space", "push to talk"),
+	),
+	ToolNext: key.NewBinding(
+		key.WithKeys("ctrl+j"),
+		key.WithHelp("ctrl+j", "next tool/thinking"),
+	),
+	ToolPrev: key.NewBinding(
+		key.WithKeys("ctrl+h"),
+		key.WithHelp("ctrl+h", "prev tool/thinking"),
+	),
+	ToolToggle: key.NewBinding(
+		key.WithKeys("space"),
+		key.WithHelp("space", "expand/collapse tool"),
 	),
 }

--- a/internal/tui/toolbar.go
+++ b/internal/tui/toolbar.go
@@ -18,20 +18,29 @@ type activeTool struct {
 	denied       bool
 	duration     time.Duration
 	inputPreview string
+	output       string // tool result output
+	isError      bool   // whether tool execution failed
+	expanded     bool   // whether output is visible
 }
 
 // toolbar manages active tool progress spinners and thinking state.
 type toolbar struct {
-	tools    []activeTool
-	spinner  spinner.Model
-	thinking bool // true while extended thinking is active
+	tools           []activeTool
+	spinner         spinner.Model
+	thinking        bool   // true while extended thinking is active
+	thinkingText    string // accumulated thinking content
+	thinkingExpanded bool   // whether thinking is visible
+	selectedIndex   int    // -1 = thinking, 0+ = tool index (-2 = none)
 }
 
 func newToolbar() toolbar {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = toolSpinnerStyle
-	return toolbar{spinner: s}
+	return toolbar{
+		spinner:       s,
+		selectedIndex: -2, // nothing selected initially
+	}
 }
 
 func (t *toolbar) addTool(id, name string) {
@@ -75,11 +84,66 @@ func (t *toolbar) denyTool(id string) {
 
 func (t *toolbar) setThinking(active bool) {
 	t.thinking = active
+	if !active {
+		t.thinkingText = ""
+	}
+}
+
+func (t *toolbar) appendThinking(text string) {
+	t.thinkingText += text
+}
+
+func (t *toolbar) setToolOutput(id, output string, isError bool) {
+	for i := range t.tools {
+		if t.tools[i].id == id {
+			t.tools[i].output = output
+			t.tools[i].isError = isError
+			return
+		}
+	}
 }
 
 func (t *toolbar) clear() {
 	t.tools = nil
 	t.thinking = false
+	t.thinkingText = ""
+	t.thinkingExpanded = false
+	t.selectedIndex = -2
+}
+
+func (t *toolbar) toggleSelected() {
+	if t.selectedIndex == -1 && t.thinking {
+		t.thinkingExpanded = !t.thinkingExpanded
+	} else if t.selectedIndex >= 0 && t.selectedIndex < len(t.tools) {
+		t.tools[t.selectedIndex].expanded = !t.tools[t.selectedIndex].expanded
+	}
+}
+
+func (t *toolbar) selectNext() {
+	maxIdx := len(t.tools) - 1
+	if t.thinking {
+		// Can select thinking (-1) or tools (0..maxIdx)
+		if t.selectedIndex < maxIdx {
+			t.selectedIndex++
+		}
+	} else {
+		// Only tools
+		if t.selectedIndex < maxIdx {
+			t.selectedIndex++
+		}
+	}
+}
+
+func (t *toolbar) selectPrev() {
+	minIdx := -2
+	if t.thinking {
+		minIdx = -1
+	} else if len(t.tools) > 0 {
+		minIdx = 0
+	}
+	if t.selectedIndex > minIdx {
+		t.selectedIndex--
+	}
 }
 
 func (t *toolbar) hasActive() bool {
@@ -106,28 +170,72 @@ func (t toolbar) view() string {
 	}
 
 	var lines []string
+	itemIdx := -1
+
+	// Thinking block
 	if t.thinking {
-		lines = append(lines, fmt.Sprintf("  %s %s",
+		itemIdx = -1
+		selected := t.selectedIndex == itemIdx
+		arrow := "▶"
+		if t.thinkingExpanded {
+			arrow = "▼"
+		}
+		prefix := "  "
+		if selected {
+			prefix = "> "
+		}
+		line := fmt.Sprintf("%s%s %s %s",
+			prefix,
+			arrow,
 			t.spinner.View(),
 			toolNameStyle.Render("thinking..."),
-		))
+		)
+		lines = append(lines, line)
+
+		// Show thinking content if expanded
+		if t.thinkingExpanded && t.thinkingText != "" {
+			contentLines := strings.Split(strings.TrimSpace(t.thinkingText), "\n")
+			for _, cLine := range contentLines {
+				if len(cLine) > 100 {
+					cLine = cLine[:100] + "..."
+				}
+				lines = append(lines, "    "+toolDurationStyle.Render(cLine))
+			}
+		}
 	}
-	for _, tool := range t.tools {
+
+	// Tool blocks
+	for i, tool := range t.tools {
+		itemIdx = i
+		selected := t.selectedIndex == itemIdx
+		arrow := "▶"
+		if tool.expanded {
+			arrow = "▼"
+		}
+		prefix := "  "
+		if selected {
+			prefix = "> "
+		}
+
 		var line string
 		if tool.denied {
-			line = fmt.Sprintf("  %s %s %s",
-				toolDeniedStyle.Render("✗"),
-				toolNameStyle.Render(tool.name),
+			line = fmt.Sprintf("%s%s %s %s",
+				prefix,
+				arrow,
+				toolDeniedStyle.Render("✗ "+tool.name),
 				toolDeniedStyle.Render("denied"),
 			)
 		} else if tool.done {
-			line = fmt.Sprintf("  %s %s %s",
-				toolDoneStyle.Render("✓"),
-				toolNameStyle.Render(tool.name),
+			line = fmt.Sprintf("%s%s %s %s",
+				prefix,
+				arrow,
+				toolDoneStyle.Render("✓ "+tool.name),
 				toolDurationStyle.Render(tool.duration.Round(time.Millisecond).String()),
 			)
 		} else {
-			line = fmt.Sprintf("  %s %s",
+			line = fmt.Sprintf("%s%s %s %s",
+				prefix,
+				arrow,
 				t.spinner.View(),
 				toolNameStyle.Render(tool.name),
 			)
@@ -136,6 +244,26 @@ func (t toolbar) view() string {
 			}
 		}
 		lines = append(lines, line)
+
+		// Show tool output if expanded and available
+		if tool.expanded && tool.output != "" {
+			outputStyle := toolDurationStyle
+			if tool.isError {
+				outputStyle = toolDeniedStyle
+			}
+			contentLines := strings.Split(strings.TrimSpace(tool.output), "\n")
+			maxLines := 10
+			for i, cLine := range contentLines {
+				if i >= maxLines {
+					lines = append(lines, "    "+toolDurationStyle.Render(fmt.Sprintf("... (%d more lines)", len(contentLines)-maxLines)))
+					break
+				}
+				if len(cLine) > 100 {
+					cLine = cLine[:100] + "..."
+				}
+				lines = append(lines, "    "+outputStyle.Render(cLine))
+			}
+		}
 	}
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
## Summary

Restores the peak TUI toolbar from commit `3d0b656`, lost in PR #53 revert:

- **Collapsible thinking**: `▶/▼` arrows, streaming thinking content viewable inline
- **Collapsible tool output**: memory_save/memory_search results displayed with expand/collapse
- **Keyboard navigation**: `ctrl+j` next, `ctrl+h` prev, `space` toggle expand
- **Selection indicator**: `>` prefix on focused item
- **Orchestrator**: emits proper `tool_result` events instead of XML-in-text

## Test plan
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [ ] Manual: send message with thinking enabled — verify thinking content visible
- [ ] Manual: trigger memory_save — verify tool output collapsible
- [ ] Manual: ctrl+j/h/space navigation works