### PR TITLE
perf(tui): cache rendered messages for streaming performance

### DIFF
--- a/internal/tui/viewport.go
+++ b/internal/tui/viewport.go
@@ -12,6 +12,7 @@ import (
 type chatViewport struct {
 	viewport   viewport.Model
 	messages   []chatMessage
+	rendered   []string // cached rendered output per message
 	renderer   *messageRenderer
 	autoScroll bool
 	width      int
@@ -40,60 +41,83 @@ func (cv *chatViewport) setSize(width, height int) {
 	cv.viewport.SetWidth(width)
 	cv.viewport.SetHeight(height)
 	cv.renderer.setWidth(width)
-	cv.rerender()
+	// Invalidate all caches on resize.
+	cv.rendered = nil
+	cv.rerenderAll()
 }
 
-// addMessage appends a new message and re-renders.
+// addMessage appends a new message and renders it.
 func (cv *chatViewport) addMessage(msg chatMessage) {
+	// If the last message was streaming, finalize its cache.
+	if len(cv.messages) > 0 && len(cv.rendered) == len(cv.messages)-1 {
+		last := cv.messages[len(cv.messages)-1]
+		cv.rendered = append(cv.rendered, cv.renderer.render(last))
+	}
 	cv.messages = append(cv.messages, msg)
-	cv.rerender()
-}
-
-// updateLastAssistant updates the last assistant message's raw text
-// (used during streaming to accumulate deltas).
-func (cv *chatViewport) updateLastAssistant(text string) {
-	if len(cv.messages) == 0 {
-		cv.messages = append(cv.messages, chatMessage{kind: msgAssistant})
-	}
-	last := &cv.messages[len(cv.messages)-1]
-	if last.kind != msgAssistant {
-		cv.messages = append(cv.messages, chatMessage{kind: msgAssistant})
-		last = &cv.messages[len(cv.messages)-1]
-	}
-	last.raw = text
-	cv.rerender()
+	cv.rendered = append(cv.rendered, cv.renderer.render(msg))
+	cv.rebuildContent()
 }
 
 // appendToLastAssistant appends a text delta to the last assistant message.
+// Only re-renders the last message (not the entire history).
 func (cv *chatViewport) appendToLastAssistant(delta string) {
 	if len(cv.messages) == 0 || cv.messages[len(cv.messages)-1].kind != msgAssistant {
 		cv.messages = append(cv.messages, chatMessage{kind: msgAssistant})
 	}
 	last := &cv.messages[len(cv.messages)-1]
 	last.raw += delta
-	cv.rerender()
+	cv.rebuildContent()
 }
 
 // startNewAssistantMessage begins a fresh assistant message.
 func (cv *chatViewport) startNewAssistantMessage() {
+	// Cache the previous last message if needed.
+	if len(cv.messages) > 0 && len(cv.rendered) < len(cv.messages) {
+		last := cv.messages[len(cv.messages)-1]
+		cv.rendered = append(cv.rendered, cv.renderer.render(last))
+	}
 	cv.messages = append(cv.messages, chatMessage{kind: msgAssistant})
 }
 
-func (cv *chatViewport) rerender() {
+// rebuildContent assembles the viewport from cached renders + live last message.
+func (cv *chatViewport) rebuildContent() {
 	var b strings.Builder
 
-	for _, msg := range cv.messages {
-		b.WriteString(cv.renderer.render(msg))
+	// Use cached renders for all but the last message.
+	limit := len(cv.messages) - 1
+	if limit > len(cv.rendered) {
+		limit = len(cv.rendered)
+	}
+	for i := 0; i < limit; i++ {
+		b.WriteString(cv.rendered[i])
 		b.WriteString("\n")
 	}
+
+	// Render the last message live (it may be streaming).
+	if len(cv.messages) > 0 {
+		last := cv.messages[len(cv.messages)-1]
+		b.WriteString(cv.renderer.render(last))
+		b.WriteString("\n")
+	}
+
 	cv.viewport.SetContent(b.String())
 	if cv.autoScroll {
 		cv.viewport.GotoBottom()
 	}
 }
 
+// rerenderAll re-renders everything (used after resize).
+func (cv *chatViewport) rerenderAll() {
+	cv.rendered = make([]string, len(cv.messages))
+	for i, msg := range cv.messages {
+		cv.rendered[i] = cv.renderer.render(msg)
+	}
+	cv.rebuildContent()
+}
+
 func (cv *chatViewport) clear() {
 	cv.messages = nil
+	cv.rendered = nil
 	cv.viewport.SetContent("")
 }
 
@@ -121,7 +145,7 @@ func (cv chatViewport) welcomeView() string {
 
 	tips := lipgloss.NewStyle().
 		Foreground(colorSubtle).
-		Render("enter send · shift+enter newline · ctrl+k commands")
+		Render("enter send · shift+enter newline · ctrl+k commands · ? help")
 
 	content := lipgloss.JoinVertical(lipgloss.Center,
 		title,


### PR DESCRIPTION
## Summary

Viewport was re-rendering ALL messages on every text delta — O(n*m). For long conversations this causes visible jank.

Now caches rendered output for completed messages in a parallel `rendered []string` slice. Only the last (streaming) message is re-rendered on each delta. Cache invalidated on window resize.

## Test plan
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [ ] Manual: long conversation — verify no jank during streaming
- [ ] Manual: resize window — verify messages re-render correctly