### PR TITLE
fix(telegram): restore P0 alerts with emoji+links, fix chat rendering

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/wcatz/ghost/internal/embedding"
 	"github.com/wcatz/ghost/internal/github"
 	goog "github.com/wcatz/ghost/internal/google"
-	"github.com/wcatz/ghost/internal/mdv2"
 	"github.com/wcatz/ghost/internal/mcpserver"
 	"github.com/wcatz/ghost/internal/memory"
 	"github.com/wcatz/ghost/internal/orchestrator"
@@ -303,9 +302,7 @@ func runServe() {
 		// Wire P0/P1 GitHub alerts to Telegram.
 		if ghMonitor != nil {
 			ghMonitor.OnAlert(func(n github.Notification) {
-				msg := fmt.Sprintf("*P%d Alert*\n`%s`\n%s\n_%s_",
-					n.Priority, mdv2.Esc(n.RepoFullName), mdv2.Esc(n.SubjectTitle), mdv2.Esc(n.Reason))
-				tgBot.SendToAll(ctx, msg)
+				tgBot.SendAlertToAll(ctx, n)
 			})
 		}
 

--- a/internal/briefing/briefing.go
+++ b/internal/briefing/briefing.go
@@ -167,7 +167,8 @@ func writeGoogleCalendar(ctx context.Context, sb *strings.Builder, g GoogleProvi
 			fmt.Fprintf(sb, "     📍 %s\n", mdv2.Esc(e.Location))
 		}
 		if e.MeetLink != "" {
-			fmt.Fprintf(sb, "     🔗 [Join Meet](%s)\n", mdv2.Esc(e.MeetLink))
+			// URL part of a MarkdownV2 link needs only ) and \ escaped — not all 18 chars.
+			fmt.Fprintf(sb, "     🔗 [Join Meet](%s)\n", e.MeetLink)
 		}
 	}
 	sb.WriteString("\n")

--- a/internal/telegram/approval.go
+++ b/internal/telegram/approval.go
@@ -226,6 +226,36 @@ func formatToolInput(toolName string, input json.RawMessage) string {
 	}
 
 	switch toolName {
+	case "bash":
+		desc, _ := m["description"].(string)
+		cmd, _ := m["command"].(string)
+		if desc != "" && cmd != "" {
+			if len(cmd) > 80 {
+				cmd = cmd[:80] + "..."
+			}
+			return desc + "\n$ " + cmd
+		}
+		if desc != "" {
+			return desc
+		}
+		if cmd != "" {
+			return cmd
+		}
+	case "file_write":
+		if path, ok := m["path"].(string); ok && path != "" {
+			return path
+		}
+	case "file_edit":
+		if path, ok := m["path"].(string); ok && path != "" {
+			old, _ := m["old_string"].(string)
+			if len(old) > 60 {
+				old = old[:60] + "..."
+			}
+			if old != "" {
+				return path + "\n- " + old
+			}
+			return path
+		}
 	case "memory_save":
 		if content, ok := m["content"].(string); ok {
 			return content

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -538,6 +538,70 @@ func (tb *Bot) reply(ctx context.Context, b *bot.Bot, update *models.Update, tex
 	}
 }
 
+// replyText sends plain text with no parse mode — safe for unescaped content such
+// as raw Claude responses that contain standard Markdown but are not MarkdownV2-escaped.
+func (tb *Bot) replyText(ctx context.Context, b *bot.Bot, update *models.Update, text string) {
+	if update.Message == nil {
+		return
+	}
+	chatID := update.Message.Chat.ID
+	for _, chunk := range mdv2.Split(text, telegramMsgMax) {
+		_, err := b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: chatID,
+			Text:   chunk,
+			LinkPreviewOptions: &models.LinkPreviewOptions{
+				IsDisabled: bot.True(),
+			},
+		})
+		if err != nil {
+			tb.logger.Error("telegram send (plain)", "error", err, "chat_id", chatID)
+			return
+		}
+	}
+}
+
+// SendAlertToAll sends a formatted P0/P1 GitHub notification alert to all allowed users.
+// Includes the priority emoji, repo/title, reason, and an inline button linking to the PR/issue.
+func (tb *Bot) SendAlertToAll(ctx context.Context, n gh.Notification) {
+	emoji := priorityEmoji(n.Priority)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s *P%d Alert*\n", emoji, n.Priority)
+	fmt.Fprintf(&sb, "`%s`\n", mdv2.Esc(n.RepoFullName))
+	fmt.Fprintf(&sb, "%s\n", mdv2.Esc(n.SubjectTitle))
+	fmt.Fprintf(&sb, "_%s_", mdv2.Esc(n.Reason))
+	text := sb.String()
+
+	var markup *models.InlineKeyboardMarkup
+	if htmlURL := ghAPIToHTML(n.SubjectURL, n.SubjectType); htmlURL != "" {
+		label := truncate(n.SubjectTitle, 35)
+		if label == "" {
+			label = "Open"
+		}
+		markup = &models.InlineKeyboardMarkup{
+			InlineKeyboard: [][]models.InlineKeyboardButton{
+				{{Text: emoji + " " + label, URL: htmlURL}},
+			},
+		}
+	}
+
+	for id := range tb.allowedIDs {
+		params := &bot.SendMessageParams{
+			ChatID:    id,
+			Text:      text,
+			ParseMode: models.ParseModeMarkdown,
+			LinkPreviewOptions: &models.LinkPreviewOptions{
+				IsDisabled: bot.True(),
+			},
+		}
+		if markup != nil {
+			params.ReplyMarkup = markup
+		}
+		if _, err := tb.bot.SendMessage(ctx, params); err != nil {
+			tb.logger.Error("telegram alert", "error", err, "user_id", id)
+		}
+	}
+}
+
 func (tb *Bot) replyWithKeyboard(ctx context.Context, b *bot.Bot, update *models.Update, text string, buttons [][]models.InlineKeyboardButton) {
 	if update.Message == nil {
 		return

--- a/internal/telegram/sessions.go
+++ b/internal/telegram/sessions.go
@@ -144,9 +144,8 @@ func (tb *Bot) handleChat(ctx context.Context, b *bot.Bot, update *models.Update
 	if response == "" {
 		response = "(no response)"
 	}
-	for _, chunk := range mdv2.Split(response, 4000) {
-		tb.reply(ctx, b, update, chunk)
-	}
+	// Claude's response is standard Markdown, not MarkdownV2-escaped — use plain text.
+	tb.replyText(ctx, b, update, response)
 }
 
 // handlePendingChatReply routes text replies to the pending chat session.
@@ -178,9 +177,8 @@ func (tb *Bot) handlePendingChatReply(ctx context.Context, b *bot.Bot, update *m
 	if response == "" {
 		response = "(no response)"
 	}
-	for _, chunk := range mdv2.Split(response, 4000) {
-		tb.reply(ctx, b, update, chunk)
-	}
+	// Claude's response is standard Markdown, not MarkdownV2-escaped — use plain text.
+	tb.replyText(ctx, b, update, response)
 	return true
 }
 


### PR DESCRIPTION
## Summary

- **P0/P1 alerts**: `SendAlertToAll()` now includes priority emoji (🔴🟠🟡) and an inline button linking directly to the PR/issue — the refactor had stripped both
- **Chat responses**: added `replyText()` (no ParseMode) — Claude's raw Markdown was being sent as MarkdownV2 causing Telegram to silently drop messages with unescaped special chars
- **Approval display**: `formatToolInput` now shows useful context for `bash` (description + command), `file_edit` (path + old_string), `file_write` (path) instead of raw JSON blob
- **Meet links**: removed `mdv2.Esc()` from the URL portion of briefing Meet links — it was backslashing dots and dashes, breaking the hyperlink

## Test plan

- [ ] Trigger a P0/P1 GitHub notification — verify emoji prefix and inline URL button appear
- [ ] `/chat <session> <message>` — verify Claude's response arrives (code blocks, backticks, dots no longer cause silent failure)
- [ ] Trigger a `bash` tool approval — verify dialog shows description and `$ command`
- [ ] `/briefing` with a Meet event — verify [Join Meet] link is clickable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bash command execution tool with built-in safety controls and timeouts
  * Added file writing and editing tools for project file modifications
  * Enhanced GitHub alert notifications with priority indicators, repository information, and action URLs

* **Improvements**
  * Improved message formatting and display clarity across chat responses
  * Enhanced tool information visibility in approval workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->