### PR TITLE
fix(server): forward tool_result events to SSE clients

### DIFF
--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -270,6 +270,23 @@ func (s *Server) handleStreamEvent(w http.ResponseWriter, flusher http.Flusher, 
 				"name": evt.ToolUse.Name,
 			})
 		}
+	case "tool_result":
+		if evt.ToolUse != nil {
+			data := map[string]interface{}{
+				"id":     evt.ToolUse.ID,
+				"name":   evt.ToolUse.Name,
+				"output": evt.Text,
+			}
+			if evt.Metadata != nil {
+				if v, ok := evt.Metadata["is_error"]; ok {
+					data["is_error"] = v
+				}
+				if v, ok := evt.Metadata["duration"]; ok {
+					data["duration"] = v
+				}
+			}
+			writeSSE(w, flusher, "tool_result", data)
+		}
 	case "tool_diff":
 		if evt.ToolUse != nil && evt.Metadata != nil {
 			data := map[string]string{


### PR DESCRIPTION
## Summary
- Add `case "tool_result":` to `handleStreamEvent()` in `chat.go`
- Emits SSE event with id, name, output, is_error, duration fields
- VSCode extension webview already has `addToolResult()` handler — events were silently dropped until now

## Context
v0.1 stabilization plan PR V1. Unblocks tool output visibility in VSCode extension.

## Test plan
- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes
- [ ] VSCode extension shows tool results after connecting to `ghost serve`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat streams now display tool execution results with optional error status and duration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->