### PR TITLE
fix(tui): lighter borders, tighter message layout

### DIFF
--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -111,17 +111,17 @@ func (mr *messageRenderer) renderUser(text string) string {
 func (mr *messageRenderer) renderAssistant(text string) string {
 	if mr.renderer == nil || text == "" {
 		return assistantLabelStyle.Render("ghost") + "\n" +
-			text + "\n"
+			assistantMsgStyle.Render(text) + "\n"
 	}
 
 	rendered, err := mr.renderer.Render(text)
 	if err != nil {
 		return assistantLabelStyle.Render("ghost") + "\n" +
-			text + "\n"
+			assistantMsgStyle.Render(text) + "\n"
 	}
 
 	return assistantLabelStyle.Render("ghost") + "\n" +
-		strings.TrimRight(rendered, "\n") + "\n"
+		assistantMsgStyle.Render(strings.TrimRight(rendered, "\n")) + "\n"
 }
 
 func (mr *messageRenderer) renderError(text string) string {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -53,12 +53,22 @@ var (
 var (
 	userMsgStyle = lipgloss.NewStyle().
 			Foreground(colorText).
-			PaddingLeft(2)
+			PaddingLeft(1).
+			BorderLeft(true).
+			BorderStyle(lipgloss.NormalBorder()).
+			BorderForeground(colorAccent)
 
 	userLabelStyle = lipgloss.NewStyle().
 			Foreground(colorAccent).
 			Bold(true).
 			PaddingLeft(1)
+
+	assistantMsgStyle = lipgloss.NewStyle().
+				Foreground(colorText).
+				PaddingLeft(1).
+				BorderLeft(true).
+				BorderStyle(lipgloss.NormalBorder()).
+				BorderForeground(colorGhost)
 
 	assistantLabelStyle = lipgloss.NewStyle().
 				Foreground(colorGhost).

--- a/internal/tui/toolbar.go
+++ b/internal/tui/toolbar.go
@@ -122,14 +122,14 @@ func (t toolbar) view() string {
 	if t.thinking && t.current == nil {
 		elapsed := time.Since(t.thinkingStart).Seconds()
 		tokens := formatTokens(t.thinkingTokens)
-		return fmt.Sprintf("  %s %s %s",
+		return fmt.Sprintf("   %s %s %s",
 			t.spinner.View(),
 			toolNameStyle.Render("thinking..."),
 			toolDurationStyle.Render(fmt.Sprintf("%.1fs (%s tokens)", elapsed, tokens)),
 		)
 	}
 	if t.current != nil {
-		line := fmt.Sprintf("  %s %s",
+		line := fmt.Sprintf("   %s %s",
 			t.spinner.View(),
 			toolNameStyle.Render(t.current.name),
 		)


### PR DESCRIPTION
## Summary
- Change user/assistant message borders from ThickBorder to NormalBorder
- Reduce message padding from PaddingLeft(2) to PaddingLeft(1)
- Add explicit assistantMsgStyle with left border in ghost/cyan color
- Align toolbar indent with message content offset

## Context
v0.1 stabilization plan PR T1. Visual-only — no behavior changes.

## Test plan
- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes
- [ ] Visual inspection: messages render lighter and less indented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual consistency in chat messages with refined styling and left border indicators for better visual hierarchy.
  * Enhanced toolbar output alignment and spacing for improved interface readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->