### PR TITLE
feat(telegram): add /mode and /cost commands

### DIFF
--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -47,6 +47,7 @@ type Bot struct {
 	approval        approvalState // pending approval tracking
 	mu              sync.Mutex
 	pendingChat     map[int64]string // chatID → sessionID for reply routing
+	sessionCosts    map[string]string // sessionID → last known cost string
 }
 
 // GoogleProvider is the interface for Google Calendar/Gmail access.
@@ -72,7 +73,8 @@ func New(cfg Config, store provider.MemoryStore, ghMonitor *gh.Monitor, sched *s
 		logger:     logger,
 		token:      cfg.Token,
 		allowedIDs:  make(map[int64]bool, len(cfg.AllowedIDs)),
-		pendingChat: make(map[int64]string),
+		pendingChat:  make(map[int64]string),
+		sessionCosts: make(map[string]string),
 	}
 
 	for _, id := range cfg.AllowedIDs {
@@ -99,6 +101,8 @@ func New(cfg Config, store provider.MemoryStore, ghMonitor *gh.Monitor, sched *s
 	b.RegisterHandler(bot.HandlerTypeMessageText, "help", bot.MatchTypeCommand, tb.handleHelp)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "sessions", bot.MatchTypeCommand, tb.handleSessions)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "chat", bot.MatchTypeCommand, tb.handleChat)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "mode", bot.MatchTypeCommand, tb.handleMode)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "cost", bot.MatchTypeCommand, tb.handleCost)
 
 	// Callback query handlers.
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "approve:", bot.MatchTypePrefix, tb.handleApprovalCallback)
@@ -133,6 +137,8 @@ func (tb *Bot) registerCommands(ctx context.Context) {
 		{Command: "emails", Description: "Recent unread emails"},
 		{Command: "sessions", Description: "List active Ghost sessions"},
 		{Command: "chat", Description: "Chat with a session: /chat <id> <msg>"},
+		{Command: "mode", Description: "List or switch mode: /mode [name]"},
+		{Command: "cost", Description: "Show session cost: /cost <id>"},
 		{Command: "memory", Description: "Manage memories: search, add, delete"},
 		{Command: "remind", Description: "Set a reminder: /remind <message>"},
 		{Command: "briefing", Description: "Get your morning briefing"},
@@ -559,6 +565,8 @@ func (tb *Bot) handleHelp(ctx context.Context, b *bot.Bot, update *models.Update
 /emails — Recent unread emails
 /sessions — List active Ghost sessions
 /chat — Chat with a session
+/mode — List modes or switch: /mode \<id\> \<name\>
+/cost — Show session cost: /cost \<id\>
 /memory — Search, add, or delete memories
 /remind — Set a reminder
 /briefing — Get your morning briefing

--- a/internal/telegram/sessions.go
+++ b/internal/telegram/sessions.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
 	"github.com/wcatz/ghost/internal/mdv2"
+	"github.com/wcatz/ghost/internal/mode"
 )
 
 type apiSession struct {
@@ -242,13 +244,26 @@ func (tb *Bot) sendChatMessage(sessionID, message string) (string, error) {
 			eventType = strings.TrimPrefix(line, "event: ")
 			continue
 		}
-		if strings.HasPrefix(line, "data: ") && eventType == "text" {
-			data := strings.TrimPrefix(line, "data: ")
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		switch eventType {
+		case "text":
 			var payload struct {
 				Text string `json:"text"`
 			}
 			if json.Unmarshal([]byte(data), &payload) == nil {
 				response.WriteString(payload.Text)
+			}
+		case "done":
+			var payload struct {
+				SessionCost string `json:"session_cost"`
+			}
+			if json.Unmarshal([]byte(data), &payload) == nil && payload.SessionCost != "" {
+				tb.mu.Lock()
+				tb.sessionCosts[sessionID] = payload.SessionCost
+				tb.mu.Unlock()
 			}
 		}
 	}
@@ -293,6 +308,189 @@ func (tb *Bot) createMemory(projectID, content string) (id string, merged bool, 
 		return "", false, err
 	}
 	return result.ID, result.Merged, nil
+}
+
+// resolveSessionID resolves a short session ID prefix to a full ID.
+func (tb *Bot) resolveSessionID(prefix string) (string, error) {
+	sessions, err := tb.fetchSessions()
+	if err != nil {
+		return "", err
+	}
+	for _, s := range sessions {
+		if strings.HasPrefix(s.ID, prefix) {
+			return s.ID, nil
+		}
+	}
+	return "", fmt.Errorf("session not found")
+}
+
+// setSessionMode calls the server API to change a session's mode.
+func (tb *Bot) setSessionMode(sessionID, modeName string) (string, error) {
+	payload, _ := json.Marshal(map[string]string{"mode": modeName})
+	url := fmt.Sprintf("http://%s/api/v1/sessions/%s/mode", tb.serverAddr, sessionID)
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("create mode request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if tb.serverToken != "" {
+		req.Header.Set("Authorization", "Bearer "+tb.serverToken)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("server returned %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Mode string `json:"mode"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	return result.Mode, nil
+}
+
+// handleMode lists available modes or switches a session's mode.
+func (tb *Bot) handleMode(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if tb.serverAddr == "" {
+		tb.reply(ctx, b, update, "Ghost server not configured\\.")
+		return
+	}
+
+	text := update.Message.Text
+	parts := strings.Fields(text)
+
+	// /mode — list available modes
+	if len(parts) == 1 {
+		tb.sendTyping(ctx, update)
+
+		// Show available modes with current session modes.
+		sessions, _ := tb.fetchSessions()
+		var sb strings.Builder
+		sb.WriteString("*Available Modes*\n\n")
+		names := make([]string, 0, len(mode.Modes))
+		for name := range mode.Modes {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			m := mode.Modes[name]
+			model := "Sonnet"
+			if m.UseQualityModel {
+				model = "Opus"
+			}
+			sb.WriteString(fmt.Sprintf("• `%s` — %s\n", mdv2.Esc(name), mdv2.Esc(model)))
+		}
+		if len(sessions) > 0 {
+			sb.WriteString("\n*Session Modes*\n\n")
+			for _, s := range sessions {
+				shortID := s.ID[:8]
+				sb.WriteString(fmt.Sprintf("• `%s` %s → `%s`\n",
+					mdv2.Esc(shortID), mdv2.Esc(s.ProjectName), mdv2.Esc(s.Mode)))
+			}
+		}
+		sb.WriteString("\nSwitch: `/mode <session_id> <mode_name>`")
+		tb.reply(ctx, b, update, sb.String())
+		return
+	}
+
+	// /mode <session_id> <mode_name>
+	if len(parts) < 3 {
+		tb.reply(ctx, b, update, "Usage: `/mode <session_id> <mode_name>`")
+		return
+	}
+
+	sessionPrefix := parts[1]
+	modeName := parts[2]
+
+	tb.sendTyping(ctx, update)
+
+	fullID, err := tb.resolveSessionID(sessionPrefix)
+	if err != nil {
+		tb.reply(ctx, b, update, "Session not found\\. Use /sessions to list\\.")
+		return
+	}
+
+	newMode, err := tb.setSessionMode(fullID, modeName)
+	if err != nil {
+		tb.reply(ctx, b, update, "Error: "+mdv2.Esc(err.Error()))
+		return
+	}
+
+	tb.reply(ctx, b, update, fmt.Sprintf("✅ Mode set to `%s`", mdv2.Esc(newMode)))
+}
+
+// handleCost shows the cumulative cost for a session.
+func (tb *Bot) handleCost(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if tb.serverAddr == "" {
+		tb.reply(ctx, b, update, "Ghost server not configured\\.")
+		return
+	}
+
+	text := update.Message.Text
+	parts := strings.Fields(text)
+
+	// /cost — show costs for all sessions
+	if len(parts) == 1 {
+		tb.sendTyping(ctx, update)
+
+		sessions, err := tb.fetchSessions()
+		if err != nil {
+			tb.reply(ctx, b, update, "Error: "+mdv2.Esc(err.Error()))
+			return
+		}
+		if len(sessions) == 0 {
+			tb.reply(ctx, b, update, "No active sessions\\.")
+			return
+		}
+
+		var sb strings.Builder
+		sb.WriteString("*Session Costs*\n\n")
+		tb.mu.Lock()
+		for _, s := range sessions {
+			shortID := s.ID[:8]
+			cost, ok := tb.sessionCosts[s.ID]
+			if !ok {
+				cost = "no data yet"
+			}
+			sb.WriteString(fmt.Sprintf("• `%s` %s — %s\n",
+				mdv2.Esc(shortID), mdv2.Esc(s.ProjectName), mdv2.Esc(cost)))
+		}
+		tb.mu.Unlock()
+		sb.WriteString("\n_Costs update after each chat message\\._")
+		tb.reply(ctx, b, update, sb.String())
+		return
+	}
+
+	// /cost <session_id>
+	sessionPrefix := parts[1]
+
+	tb.sendTyping(ctx, update)
+
+	fullID, err := tb.resolveSessionID(sessionPrefix)
+	if err != nil {
+		tb.reply(ctx, b, update, "Session not found\\. Use /sessions to list\\.")
+		return
+	}
+
+	tb.mu.Lock()
+	cost, ok := tb.sessionCosts[fullID]
+	tb.mu.Unlock()
+
+	if !ok {
+		tb.reply(ctx, b, update, "No cost data yet\\. Send a /chat message first\\.")
+		return
+	}
+
+	shortID := fullID[:8]
+	tb.reply(ctx, b, update, fmt.Sprintf("💰 Session `%s`: %s", mdv2.Esc(shortID), mdv2.Esc(cost)))
 }
 
 // deleteMemory sends a DELETE request to remove a memory by ID.

--- a/internal/telegram/sessions.go
+++ b/internal/telegram/sessions.go
@@ -386,14 +386,14 @@ func (tb *Bot) handleMode(ctx context.Context, b *bot.Bot, update *models.Update
 			if m.UseQualityModel {
 				model = "Opus"
 			}
-			sb.WriteString(fmt.Sprintf("• `%s` — %s\n", mdv2.Esc(name), mdv2.Esc(model)))
+			fmt.Fprintf(&sb, "• `%s` — %s\n", mdv2.Esc(name), mdv2.Esc(model))
 		}
 		if len(sessions) > 0 {
 			sb.WriteString("\n*Session Modes*\n\n")
 			for _, s := range sessions {
 				shortID := s.ID[:8]
-				sb.WriteString(fmt.Sprintf("• `%s` %s → `%s`\n",
-					mdv2.Esc(shortID), mdv2.Esc(s.ProjectName), mdv2.Esc(s.Mode)))
+				fmt.Fprintf(&sb, "• `%s` %s → `%s`\n",
+					mdv2.Esc(shortID), mdv2.Esc(s.ProjectName), mdv2.Esc(s.Mode))
 			}
 		}
 		sb.WriteString("\nSwitch: `/mode <session_id> <mode_name>`")
@@ -460,8 +460,8 @@ func (tb *Bot) handleCost(ctx context.Context, b *bot.Bot, update *models.Update
 			if !ok {
 				cost = "no data yet"
 			}
-			sb.WriteString(fmt.Sprintf("• `%s` %s — %s\n",
-				mdv2.Esc(shortID), mdv2.Esc(s.ProjectName), mdv2.Esc(cost)))
+			fmt.Fprintf(&sb, "• `%s` %s — %s\n",
+				mdv2.Esc(shortID), mdv2.Esc(s.ProjectName), mdv2.Esc(cost))
 		}
 		tb.mu.Unlock()
 		sb.WriteString("\n_Costs update after each chat message\\._")


### PR DESCRIPTION
## Summary
- Add `/mode` command: lists available modes (chat, code, debug, review, refactor, plan) or switches a session's mode via `POST /api/v1/sessions/{id}/mode`
- Add `/cost` command: shows cumulative session cost captured from SSE "done" events during `/chat` interactions
- Update `/help` text and Telegram command menu to include both new commands

## Test plan
- [ ] `/mode` with no args lists all available modes with model type (Sonnet/Opus) and current session modes
- [ ] `/mode <session_id> <name>` switches the session mode and confirms
- [ ] `/mode <session_id>` without mode name shows usage hint
- [ ] `/cost` with no args lists costs for all active sessions
- [ ] `/cost <session_id>` shows cost for a specific session
- [ ] After `/chat` interaction, cost data is captured from SSE done event
- [ ] `/help` shows the new commands
- [ ] `go vet ./...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "mode" command to view available modes and switch active sessions to a different mode using short session identifiers.
  * Added "cost" command to display operation costs for all sessions or view costs for a specific session.
  * Implemented session ID resolution to allow users to reference sessions using short identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->