### PR TITLE
fix(telegram): fix 7 bugs found in bot audit

### DIFF
--- a/internal/google/notifier.go
+++ b/internal/google/notifier.go
@@ -128,7 +128,7 @@ func (n *MeetingNotifier) formatAlert(ev Event, until time.Duration) string {
 		fmt.Fprintf(&sb, "  📍 %s\n", mdv2.Esc(ev.Location))
 	}
 	if ev.MeetLink != "" {
-		fmt.Fprintf(&sb, "  🔗 [Join Meet](%s)\n", mdv2.Esc(ev.MeetLink))
+		fmt.Fprintf(&sb, "  🔗 [Join Meet](%s)\n", ev.MeetLink)
 	}
 	return sb.String()
 }

--- a/internal/telegram/approval.go
+++ b/internal/telegram/approval.go
@@ -206,7 +206,7 @@ func (tb *Bot) callApproveAPI(sessionID string, approved bool, instructions stri
 	if tb.serverToken != "" {
 		req.Header.Set("Authorization", "Bearer "+tb.serverToken)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("approve API call: %w", err)
 	}

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -438,18 +438,14 @@ func (tb *Bot) handleBriefing(ctx context.Context, b *bot.Bot, update *models.Up
 
 	msg := briefing.Generate(ctx, tb.briefingSources)
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	// Delete the "Loading..." placeholder before sending the actual briefing,
+	// since reply() handles splitting long messages into multiple sends.
+	_, _ = b.DeleteMessage(ctx, &bot.DeleteMessageParams{
 		ChatID:    chatID,
 		MessageID: sent.ID,
-		Text:      msg,
-		ParseMode: models.ParseModeMarkdown,
-		LinkPreviewOptions: &models.LinkPreviewOptions{
-			IsDisabled: bot.True(),
-		},
 	})
-	if err != nil {
-		tb.logger.Error("telegram edit", "error", err)
-	}
+
+	tb.reply(ctx, b, update, msg)
 }
 
 // SetBriefingSources configures the data sources for on-demand briefings.
@@ -674,6 +670,11 @@ func (tb *Bot) SendAlertToAll(ctx context.Context, n gh.Notification) {
 				{{Text: emoji + " " + label, URL: htmlURL}},
 			},
 		}
+	}
+
+	// Truncate if text exceeds Telegram's message limit (unlikely for alerts).
+	if len(text) > telegramMsgMax {
+		text = text[:telegramMsgMax-3] + "\\.\\.\\."
 	}
 
 	for id := range tb.allowedIDs {

--- a/internal/telegram/sessions.go
+++ b/internal/telegram/sessions.go
@@ -10,12 +10,16 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
 	"github.com/wcatz/ghost/internal/mdv2"
 	"github.com/wcatz/ghost/internal/mode"
 )
+
+// httpClient is used for all outbound API calls to the Ghost server.
+var httpClient = &http.Client{Timeout: 30 * time.Second}
 
 type apiSession struct {
 	ID          string `json:"id"`
@@ -80,6 +84,9 @@ func (tb *Bot) handleChatCallback(ctx context.Context, b *bot.Bot, update *model
 	})
 
 	// Prompt the user to reply with a message.
+	if update.CallbackQuery.Message.Message == nil {
+		return
+	}
 	chatID := update.CallbackQuery.Message.Message.Chat.ID
 	shortID := sessionID[:8]
 	_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
@@ -193,7 +200,7 @@ func (tb *Bot) fetchSessions() ([]apiSession, error) {
 	if tb.serverToken != "" {
 		req.Header.Set("Authorization", "Bearer "+tb.serverToken)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +230,7 @@ func (tb *Bot) sendChatMessage(sessionID, message string) (string, error) {
 	if tb.serverToken != "" {
 		req.Header.Set("Authorization", "Bearer "+tb.serverToken)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -267,6 +274,9 @@ func (tb *Bot) sendChatMessage(sessionID, message string) (string, error) {
 			}
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		return response.String(), fmt.Errorf("stream read: %w", err)
+	}
 	return response.String(), nil
 }
 
@@ -289,7 +299,7 @@ func (tb *Bot) createMemory(projectID, content string) (id string, merged bool, 
 	if tb.serverToken != "" {
 		req.Header.Set("Authorization", "Bearer "+tb.serverToken)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", false, err
 	}
@@ -337,7 +347,7 @@ func (tb *Bot) setSessionMode(sessionID, modeName string) (string, error) {
 	if tb.serverToken != "" {
 		req.Header.Set("Authorization", "Bearer "+tb.serverToken)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -504,7 +514,7 @@ func (tb *Bot) deleteMemory(memoryID string) error {
 	if tb.serverToken != "" {
 		req.Header.Set("Authorization", "Bearer "+tb.serverToken)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/internal/telegram/voice.go
+++ b/internal/telegram/voice.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
+	"github.com/wcatz/ghost/internal/mdv2"
 	"github.com/wcatz/ghost/internal/voice"
 )
 
@@ -107,7 +108,7 @@ func (tb *Bot) handleVoice(ctx context.Context, b *bot.Bot, update *models.Updat
 	// Reply with the transcription.
 	b.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID: update.Message.Chat.ID,
-		Text:   fmt.Sprintf("🎤 *Transcription:*\n%s", text),
+		Text:   fmt.Sprintf("🎤 *Transcription:*\n%s", mdv2.Esc(text)),
 		ParseMode: models.ParseModeMarkdown,
 	})
 


### PR DESCRIPTION
## Summary
- **Nil pointer panic**: Guard `CallbackQuery.Message.Message` before access in session callback handler
- **Broken Meet links**: Remove `mdv2.Esc()` from URL inside markdown `[text](url)` syntax in Google notifier
- **Silent stream errors**: Add `scanner.Err()` check after SSE stream read in chat message handler
- **Voice escaping**: Apply `mdv2.Esc()` to transcription text before sending as MarkdownV2
- **Briefing overflow**: Replace `EditMessageText` (can't handle >4096 chars) with `DeleteMessage` + `reply()` which splits
- **Alert overflow**: Add truncation guard in `SendAlertToAll` for 4096 char Telegram limit
- **HTTP timeouts**: Replace all `http.DefaultClient` usage with 30s timeout client (6 call sites)

Bug 7 (context.Background in approval) deferred — current behavior is correct for goroutine-spawned notifications.

## Test plan
- [ ] `go vet ./...` — passes
- [ ] `go test ./...` — all pass
- [ ] `grep -rn 'http.DefaultClient' internal/telegram/` — zero results
- [ ] `grep -rn 'mdv2.Esc.*MeetLink' internal/` — zero results
- [ ] Manual: `/briefing` in Telegram with long briefing — renders correctly
- [ ] Manual: Meeting reminder with Meet link — link is clickable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential crash when processing Telegram callback queries without associated messages
  * Improved error handling during message streaming operations

* **Improvements**
  * Telegram messages now automatically truncate when exceeding platform size limits
  * Added network timeout protection for improved connection reliability
  * Updated message text formatting for better compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->