### PR TITLE
fix(memory): fix 4 bugs in store layer

### DIFF
--- a/internal/memory/decisions.go
+++ b/internal/memory/decisions.go
@@ -41,10 +41,12 @@ func (s *Store) RecordDecision(ctx context.Context, projectID, title, decision, 
 
 	// Also save as a memory so it shows up in search and prompt context.
 	content := fmt.Sprintf("%s: %s. Rationale: %s", title, decision, rationale)
-	s.db.ExecContext(ctx, `
+	if _, err := s.db.ExecContext(ctx, `
 		INSERT INTO memories (project_id, category, content, source, importance, tags)
 		VALUES (?, 'decision', ?, 'decision_log', 0.9, ?)
-	`, projectID, content, string(tagJSON))
+	`, projectID, content, string(tagJSON)); err != nil {
+		return id, fmt.Errorf("record decision memory: %w", err)
+	}
 
 	if s.onSave != nil {
 		s.onSave(projectID)

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -293,7 +293,7 @@ func (s *Store) GetByCategory(ctx context.Context, projectID, category string, l
 		SELECT id, project_id, category, content, importance, access_count,
 		       last_accessed, source, tags, pinned, created_at, updated_at
 		FROM memories
-		WHERE project_id = ? AND category = ?
+		WHERE (project_id = ? OR project_id = '_global') AND category = ?
 		ORDER BY importance DESC, created_at DESC
 		LIMIT ?
 	`, projectID, category, limit)
@@ -502,12 +502,14 @@ func (s *Store) GetRecentExchanges(ctx context.Context, projectID string, limit 
 	defer s.mu.RUnlock()
 
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT m.role, m.content
-		FROM messages m
-		JOIN conversations c ON c.id = m.conversation_id
-		WHERE c.project_id = ? AND m.role IN ('user', 'assistant')
-		ORDER BY m.created_at DESC
-		LIMIT ?
+		SELECT role, content FROM (
+			SELECT m.role, m.content, m.created_at
+			FROM messages m
+			JOIN conversations c ON c.id = m.conversation_id
+			WHERE c.project_id = ? AND m.role IN ('user', 'assistant')
+			ORDER BY m.created_at DESC
+			LIMIT ?
+		) ORDER BY created_at ASC
 	`, projectID, limit*2)
 	if err != nil {
 		return nil, err
@@ -521,11 +523,11 @@ func (s *Store) GetRecentExchanges(ctx context.Context, projectID string, limit 
 		if err := rows.Scan(&role, &content); err != nil {
 			return nil, err
 		}
-		if role == "assistant" {
-			current[1] = content
-		} else {
+		if role == "user" {
 			current[0] = content
-			if current[1] != "" {
+		} else {
+			current[1] = content
+			if current[0] != "" {
 				pairs = append(pairs, current)
 			}
 			current = [2]string{}
@@ -648,7 +650,7 @@ func sanitizeFTS(text string) string {
 		clean := strings.TrimFunc(word, func(r rune) bool {
 			return !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'))
 		})
-		if len(clean) >= 2 {
+		if len(clean) >= 1 {
 			// Quote each word to treat as literal.
 			words = append(words, `"`+clean+`"`)
 		}

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -352,9 +352,9 @@ func TestSanitizeFTS(t *testing.T) {
 			want:  `"hello" OR "world"`,
 		},
 		{
-			name:  "strips short words",
+			name:  "keeps single-char words",
 			input: "a Go is great",
-			want:  `"Go" OR "is" OR "great"`,
+			want:  `"a" OR "Go" OR "is" OR "great"`,
 		},
 		{
 			name:  "strips punctuation from edges",


### PR DESCRIPTION
## Summary
- **RecordDecision** now checks the error from the secondary memory INSERT instead of silently discarding it
- **GetRecentExchanges** fixed ordering: subquery fetches most recent DESC then re-sorts ASC for correct user→assistant pairing
- **sanitizeFTS** keeps single-char words (was silently dropping "a", "i", etc.)
- **GetByCategory** includes `_global` project memories (matches `GetTopMemories` and `SearchFTS`)

Issue 3 (SearchVector loads all embeddings) left as-is — already project-filtered via JOIN, fine at current scale.

## Test plan
- [x] `go test ./internal/memory/...` — passes (updated test expectation for sanitizeFTS)
- [x] `go vet ./...` — clean
- [x] `go build ./cmd/ghost/` — compiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global memories now appear alongside project-specific memories
  * Enhanced search functionality to include single-character terms

* **Bug Fixes**
  * Improved error handling for decision memory recording with clearer error messages
  * Recent exchanges now correctly displayed in chronological order

<!-- end of auto-generated comment: release notes by coderabbit.ai -->