### PR TITLE
feat(cost): persist token usage, monthly cost view + Telegram report

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -349,6 +349,20 @@ func runServe() {
 		}
 	}
 
+	// --- Monthly cost report cron (reports previous month on 1st) ---
+	if cfg.CostReport.Enabled && tgBot != nil {
+		err := sched.AddCronJob(ctx, "monthly-cost-report", cfg.CostReport.Schedule, nil, func() {
+			report := generateCostReport(ctx, store, logger)
+			tgBot.SendToAll(ctx, report)
+			logger.Info("monthly cost report sent")
+		})
+		if err != nil {
+			logger.Error("failed to schedule cost report", "error", err)
+		} else {
+			logger.Info("monthly cost report scheduled", "cron", cfg.CostReport.Schedule)
+		}
+	}
+
 	// --- Orchestrator for chat API (optional — requires API key) ---
 	var orch *orchestrator.Orchestrator
 	if cfg.API.Key != "" {
@@ -443,6 +457,64 @@ func bootstrap() (*config.Config, *slog.Logger, *memory.Store, *sql.DB) {
 
 	store := memory.NewStore(db, logger)
 	return cfg, logger, store, db
+}
+
+// generateCostReport builds a Telegram-formatted monthly cost summary
+// comparing API spend against Claude subscription tiers.
+func generateCostReport(ctx context.Context, store *memory.Store, logger *slog.Logger) string {
+	// Report on previous month.
+	now := time.Now()
+	year, month := now.Year(), int(now.Month())-1
+	if month == 0 {
+		month = 12
+		year--
+	}
+
+	mc, err := store.GetMonthlyCost(ctx, year, month)
+	if err != nil {
+		logger.Error("cost report query failed", "error", err)
+		return fmt.Sprintf("Failed to generate cost report: %v", err)
+	}
+
+	monthName := time.Month(mc.Month).String()
+	noCacheCost := mc.TotalCost + mc.TotalSavings
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "📊 *Ghost Cost Report — %s %d*\n\n", monthName, mc.Year)
+	fmt.Fprintf(&b, "API Spend:      $%.2f\n", mc.TotalCost)
+	fmt.Fprintf(&b, "Without cache:  $%.2f\n", noCacheCost)
+	fmt.Fprintf(&b, "Cache savings:  $%.2f\n\n", mc.TotalSavings)
+
+	if len(mc.ByModel) > 0 {
+		b.WriteString("By model:\n")
+		for _, m := range mc.ByModel {
+			short := m.Model
+			if i := strings.LastIndex(short, "-"); i > 10 {
+				short = short[:i] // strip date suffix
+			}
+			fmt.Fprintf(&b, "  %s:  $%.2f\n", short, m.Cost)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("vs Claude Subscription:\n")
+	tiers := []struct {
+		name  string
+		price float64
+	}{
+		{"Pro ($20/mo)", 20},
+		{"Max 5x ($100/mo)", 100},
+		{"Max 20x ($200/mo)", 200},
+	}
+	for _, t := range tiers {
+		if mc.TotalCost < t.price {
+			fmt.Fprintf(&b, "  %s:  API is cheaper ✓\n", t.name)
+		} else {
+			fmt.Fprintf(&b, "  %s:  subscription cheaper ✗\n", t.name)
+		}
+	}
+
+	return b.String()
 }
 
 // expandHome replaces a leading ~ with the user's home directory.

--- a/internal/ai/cost.go
+++ b/internal/ai/cost.go
@@ -134,3 +134,25 @@ func (ct *CostTracker) Summary() string {
 	rate := ct.CacheHitRate()
 	return fmt.Sprintf("$%.2f (saved $%.2f, %.0f%% cache)", cost, savings, rate)
 }
+
+// CostForUsage computes the USD cost for a single usage entry with model-specific pricing.
+func CostForUsage(u *TokenUsage, model string) float64 {
+	if u == nil {
+		return 0
+	}
+	inP, outP, cwP, crP := modelPricing(model)
+	var total float64
+	total += float64(u.InputTokens) / 1e6 * inP
+	total += float64(u.OutputTokens) / 1e6 * outP
+	total += float64(u.CacheCreationInputTokens) / 1e6 * cwP
+	total += float64(u.CacheReadInputTokens) / 1e6 * crP
+	return total
+}
+
+// CostWithoutCacheForUsage computes what the cost would have been without caching
+// for the given raw token counts and model. Used for monthly savings calculations.
+func CostWithoutCacheForUsage(input, output, cacheWrite, cacheRead int, model string) float64 {
+	inP, outP, _, _ := modelPricing(model)
+	allInput := input + cacheWrite + cacheRead
+	return float64(allInput)/1e6*inP + float64(output)/1e6*outP
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,8 +37,9 @@ type Config struct {
 	Telegram  TelegramConfig  `koanf:"telegram"`
 	Calendar  CalendarConfig  `koanf:"calendar"`
 	Google    GoogleConfig    `koanf:"google"`
-	Briefing  BriefingConfig  `koanf:"briefing"`
-	Voice     VoiceConfig     `koanf:"voice"`
+	Briefing   BriefingConfig   `koanf:"briefing"`
+	CostReport CostReportConfig `koanf:"cost_report"`
+	Voice      VoiceConfig      `koanf:"voice"`
 }
 
 // APIConfig holds Claude API settings.
@@ -131,6 +132,12 @@ type BriefingConfig struct {
 	Schedule string `koanf:"schedule"` // cron expression, e.g. "0 8 * * *"
 }
 
+// CostReportConfig holds monthly cost report settings.
+type CostReportConfig struct {
+	Enabled  bool   `koanf:"enabled"`
+	Schedule string `koanf:"schedule"` // cron expression, default "0 9 1 * *"
+}
+
 // defaults is the base layer — always loaded first.
 var defaults = map[string]interface{}{
 	"api.model_quality":          "claude-opus-4-6-20250514",
@@ -163,6 +170,8 @@ var defaults = map[string]interface{}{
 	"github.interval":            60,
 	"briefing.enabled":           false,
 	"briefing.schedule":          "0 8 * * 1-5",
+	"cost_report.enabled":        false,
+	"cost_report.schedule":       "0 9 1 * *",
 	"google.credentials_file":   "~/.config/ghost/google-credentials.json",
 	"google.token_file":          "~/.config/ghost/google-token.json",
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -607,6 +607,85 @@ type TokenUsage struct {
 	CostUSD       float64
 }
 
+// ModelCost holds cost for a single model within a monthly summary.
+type ModelCost struct {
+	Model string  `json:"model"`
+	Cost  float64 `json:"cost"`
+}
+
+// MonthlyCost holds aggregated cost data for a calendar month.
+type MonthlyCost struct {
+	Year         int         `json:"year"`
+	Month        int         `json:"month"`
+	TotalCost    float64     `json:"total_cost"`
+	TotalSavings float64     `json:"total_savings"`
+	ByModel      []ModelCost `json:"by_model"`
+}
+
+// GetMonthlyCost returns aggregated cost data for the given month across all projects,
+// including per-model breakdown and cache savings.
+func (s *Store) GetMonthlyCost(ctx context.Context, year, month int) (MonthlyCost, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	start := fmt.Sprintf("%04d-%02d-01", year, month)
+	var end string
+	if month == 12 {
+		end = fmt.Sprintf("%04d-01-01", year+1)
+	} else {
+		end = fmt.Sprintf("%04d-%02d-01", year, month+1)
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT model,
+		       COALESCE(SUM(cost_usd), 0),
+		       COALESCE(SUM(input_tokens), 0),
+		       COALESCE(SUM(output_tokens), 0),
+		       COALESCE(SUM(cache_creation), 0),
+		       COALESCE(SUM(cache_read), 0)
+		FROM token_usage
+		WHERE created_at >= ? AND created_at < ?
+		GROUP BY model
+	`, start, end)
+	if err != nil {
+		return MonthlyCost{}, err
+	}
+	defer rows.Close()
+
+	mc := MonthlyCost{Year: year, Month: month}
+	for rows.Next() {
+		var model string
+		var cost float64
+		var input, output, cacheWrite, cacheRead int
+		if err := rows.Scan(&model, &cost, &input, &output, &cacheWrite, &cacheRead); err != nil {
+			return MonthlyCost{}, err
+		}
+		mc.TotalCost += cost
+		mc.ByModel = append(mc.ByModel, ModelCost{Model: model, Cost: cost})
+
+		// Compute what cost would have been without caching for this model.
+		noCacheCost := noCacheCostForModel(model, input, output, cacheWrite, cacheRead)
+		mc.TotalSavings += noCacheCost - cost
+	}
+	return mc, rows.Err()
+}
+
+// noCacheCostForModel computes hypothetical cost if all cached tokens were charged at base input rate.
+func noCacheCostForModel(model string, input, output, cacheWrite, cacheRead int) float64 {
+	// Use simple model-family pricing lookup.
+	var inP, outP float64
+	switch {
+	case strings.Contains(model, "haiku"):
+		inP, outP = 1.00, 5.00
+	case strings.Contains(model, "opus"):
+		inP, outP = 5.00, 25.00
+	default:
+		inP, outP = 3.00, 15.00
+	}
+	allInput := input + cacheWrite + cacheRead
+	return float64(allInput)/1e6*inP + float64(output)/1e6*outP
+}
+
 func scanMemories(rows *sql.Rows) ([]Memory, error) {
 	var memories []Memory
 	for rows.Next() {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -650,7 +650,7 @@ func (s *Store) GetMonthlyCost(ctx context.Context, year, month int) (MonthlyCos
 	if err != nil {
 		return MonthlyCost{}, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	mc := MonthlyCost{Year: year, Month: month}
 	for rows.Next() {

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -358,6 +358,19 @@ func (s *Session) SendMessage(ctx context.Context, userMessage ai.Message, userT
 					stopReason = evt.StopReason
 					usage = evt.Usage
 					s.Cost.AddWithModel(usage, s.Model())
+					// Persist usage to SQLite for historical cost tracking.
+					if usage != nil {
+						go func(u *ai.TokenUsage, model string) {
+							costUSD := ai.CostForUsage(u, model)
+							_ = s.store.RecordUsage(context.Background(), s.ProjectID, model, memory.TokenUsage{
+								InputTokens:   u.InputTokens,
+								OutputTokens:  u.OutputTokens,
+								CacheCreation: u.CacheCreationInputTokens,
+								CacheRead:     u.CacheReadInputTokens,
+								CostUSD:       costUSD,
+							})
+						}(usage, s.Model())
+					}
 				case "error":
 					events <- evt
 					return

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -93,6 +93,7 @@ type MemoryStore interface {
 
 	// Cost tracking
 	RecordUsage(ctx context.Context, projectID, model string, usage memory.TokenUsage) error
+	GetMonthlyCost(ctx context.Context, year, month int) (memory.MonthlyCost, error)
 
 	// Lifecycle
 	Close() error

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -93,6 +93,7 @@ func (s *Server) Run(ctx context.Context) error {
 			r.Delete("/{memoryID}", s.handleDelete)
 		})
 		r.Get("/api/v1/projects", s.handleListProjects)
+		r.Get("/api/v1/costs/monthly", s.handleMonthlyCost)
 
 		// Transcription token proxy (requires AssemblyAI key).
 		if s.assemblyAIKey != "" {
@@ -289,6 +290,17 @@ func (s *Server) handleListProjects(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, projects)
+}
+
+func (s *Server) handleMonthlyCost(w http.ResponseWriter, r *http.Request) {
+	now := time.Now()
+	mc, err := s.store.GetMonthlyCost(r.Context(), now.Year(), int(now.Month()))
+	if err != nil {
+		s.logger.Error("monthly cost", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get monthly cost")
+		return
+	}
+	writeJSON(w, http.StatusOK, mc)
 }
 
 // handleTranscribeToken proxies a temporary AssemblyAI streaming token

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -119,6 +119,9 @@ func (m *mockStore) UpdateLearnedContext(_ context.Context, _, _, _ string) erro
 func (m *mockStore) RecordUsage(_ context.Context, _, _ string, _ memory.TokenUsage) error {
 	return nil
 }
+func (m *mockStore) GetMonthlyCost(_ context.Context, year, month int) (memory.MonthlyCost, error) {
+	return memory.MonthlyCost{Year: year, Month: month}, nil
+}
 func (m *mockStore) Close() error { return nil }
 
 // newTestServer creates a Server with a mock store and silent logger.

--- a/vscode-ghost/src/chat-webview.ts
+++ b/vscode-ghost/src/chat-webview.ts
@@ -193,6 +193,7 @@ export class ChatWebview implements vscode.Disposable {
         if (sessionCost) {
           this.statusBar.setCost(sessionCost);
         }
+        this.refreshMonthlyCost();
       });
       emitter.on("error", (err: Error) => {
         this.postMessage({ type: "error", text: err.message ?? "Unknown error" });
@@ -483,9 +484,29 @@ export class ChatWebview implements vscode.Disposable {
         this.postMessage({ type: "session", session: this.session });
         this.statusBar.setMode(this.session.mode);
         this.onModeChanged?.(this.session.mode);
+        this.refreshMonthlyCost();
       }
     } catch {
       // Server not available -- will retry on next send
+    }
+  }
+
+  private async refreshMonthlyCost(): Promise<void> {
+    try {
+      const mc = await this.client.getMonthlyCost();
+      const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+      const monthLabel = monthNames[mc.month - 1] ?? `M${mc.month}`;
+      let text = `${monthLabel}: $${mc.total_cost.toFixed(2)}`;
+      if (mc.by_model && mc.by_model.length > 0) {
+        const parts = mc.by_model.map((m) => {
+          const short = m.model.replace(/^claude-/, "").replace(/-\d{8}$/, "");
+          return `${short} $${m.cost.toFixed(2)}`;
+        });
+        text += ` (${parts.join(" · ")})`;
+      }
+      this.postMessage({ type: "monthly_cost", text });
+    } catch {
+      // Server may not support this endpoint yet
     }
   }
 

--- a/vscode-ghost/src/ghost-client.ts
+++ b/vscode-ghost/src/ghost-client.ts
@@ -308,6 +308,12 @@ export class GhostClient extends EventEmitter {
     return this.request("GET", "/api/v1/projects");
   }
 
+  // --- Costs ---
+
+  async getMonthlyCost(): Promise<{ year: number; month: number; total_cost: number; total_savings: number; by_model: { model: string; cost: number }[] }> {
+    return this.request("GET", "/api/v1/costs/monthly");
+  }
+
   // --- Transcription ---
 
   async getTranscribeToken(): Promise<{ token: string; ws_url: string }> {

--- a/vscode-ghost/src/protocol.ts
+++ b/vscode-ghost/src/protocol.ts
@@ -33,7 +33,8 @@ export type ExtToWebviewMessage =
   | { type: "voice_stopped" }
   | { type: "voice_triggered" }
   | { type: "voice_partial"; text: string }
-  | { type: "voice_final"; text: string };
+  | { type: "voice_final"; text: string }
+  | { type: "monthly_cost"; text: string };
 
 // --- Webview -> Extension ---
 

--- a/vscode-ghost/src/webview/chat-main.ts
+++ b/vscode-ghost/src/webview/chat-main.ts
@@ -518,7 +518,6 @@ window.addEventListener("message", (event) => {
       }
       if (msg.session_cost) {
         footerCost.textContent = msg.session_cost;
-        sessionCostEl.textContent = msg.session_cost;
       }
       if (msg.stop_reason === "max_tokens") {
         addTruncationWarning();
@@ -539,6 +538,9 @@ window.addEventListener("message", (event) => {
       sessionInfoEl.textContent = msg.session.project_name;
       modeBadge.textContent = msg.session.mode;
       modeBadge.className = "mode-badge mode-" + msg.session.mode;
+      break;
+    case "monthly_cost":
+      sessionCostEl.textContent = msg.text;
       break;
     case "mode_changed":
       modeBadge.textContent = msg.mode;


### PR DESCRIPTION
## Summary
- Wire `store.RecordUsage()` on every agentic turn — token usage now persists to SQLite instead of being lost on session end
- Add `GET /api/v1/costs/monthly` endpoint with per-model breakdown and cache savings
- Split VSCode extension: header shows monthly cost with model breakdown, footer shows session cost/savings/cache
- Add monthly cost report cron job that sends Telegram message comparing API spend vs Claude subscription tiers

## Test plan
- [ ] Send a message via VSCode, verify `token_usage` table has rows: `sqlite3 ~/.local/share/ghost/ghost.db "SELECT * FROM token_usage ORDER BY created_at DESC LIMIT 5"`
- [ ] Check monthly endpoint: `curl http://127.0.0.1:2187/api/v1/costs/monthly`
- [ ] Verify VSCode header shows monthly cost, footer shows session cost
- [ ] Enable cost report in config and verify cron registers on startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monthly cost reports with per-model breakdown, cache-savings, Claude-tier comparisons; scheduled delivery via Telegram and a GET /api/v1/costs/monthly API.
  * VS Code extension shows monthly cost in the chat UI; client can fetch monthly cost.

* **Tests**
  * Added tests for project-context resources and monthly-cost retrieval.

* **Documentation**
  * Updated architecture docs to document MCP resource support (project context and global memories).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->