### PR TITLE
fix(approval): stream ID correlation, cross-client cleanup, voice guard

### DIFF
--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -36,9 +38,17 @@ type pendingApproval struct {
 // chatState holds per-session streaming state for HTTP clients.
 type chatState struct {
 	mu               sync.Mutex
+	streamID         string // unique per-stream, used to correlate approvals
 	cancel           context.CancelFunc
 	pending          *pendingApproval
 	approvalResolved chan struct{} // signals external approval to SSE stream
+}
+
+// newStreamID returns a short random hex string for stream correlation.
+func newStreamID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
 }
 
 // --- Session Handlers ---
@@ -151,13 +161,14 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Supersede any active stream for this session.
+	streamID := newStreamID()
 	s.chatMu.Lock()
 	if old, active := s.chatStates[id]; active {
 		old.cancel()
-		s.logger.Info("superseding active stream", "session", id)
+		s.logger.Info("superseding active stream", "session", id, "old_stream", old.streamID, "new_stream", streamID)
 	}
 	ctx, cancel := context.WithCancel(r.Context())
-	state := &chatState{cancel: cancel}
+	state := &chatState{cancel: cancel, streamID: streamID}
 	s.chatStates[id] = state
 	s.chatMu.Unlock()
 
@@ -257,6 +268,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			state.mu.Unlock()
 
 			writeSSE(w, flusher, "approval_required", map[string]interface{}{
+				"stream_id": streamID,
 				"tool_name": approval.ToolName,
 				"input":     json.RawMessage(approval.Input),
 			})
@@ -275,6 +287,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			resolvedCh = nil
 
 		case <-ctx.Done():
+			writeSSE(w, flusher, "aborted", map[string]string{"reason": "superseded"})
 			return
 		}
 	}
@@ -358,6 +371,7 @@ func (s *Server) handleStreamEvent(w http.ResponseWriter, flusher http.Flusher, 
 type approvalResponse struct {
 	Approved     bool   `json:"approved"`
 	Instructions string `json:"instructions,omitempty"`
+	StreamID     string `json:"stream_id,omitempty"`
 }
 
 func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request) {
@@ -375,6 +389,12 @@ func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request) {
 
 	if !ok {
 		writeError(w, http.StatusNotFound, "no active stream for session")
+		return
+	}
+
+	// Validate stream_id if provided — reject stale approvals from superseded streams.
+	if req.StreamID != "" && req.StreamID != state.streamID {
+		writeError(w, http.StatusConflict, "approval is for a superseded stream")
 		return
 	}
 
@@ -403,6 +423,11 @@ func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request) {
 		state.approvalResolved = nil
 	}
 	state.mu.Unlock()
+
+	// Notify external channels (Telegram) so they can clean up approval messages.
+	if s.approvalNotifier != nil {
+		go s.approvalNotifier.ApprovalResolved(id, req.Approved)
+	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "responded"})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,6 +25,15 @@ import (
 // The Telegram bot implements this to forward approvals to the user's phone.
 type ApprovalNotifier interface {
 	NotifyApproval(sessionID, projectName, toolName string, input json.RawMessage)
+	ApprovalResolved(sessionID string, approved bool)
+}
+
+// HasActiveStream reports whether a session currently has a live SSE stream.
+func (s *Server) HasActiveStream(sessionID string) bool {
+	s.chatMu.RLock()
+	_, ok := s.chatStates[sessionID]
+	s.chatMu.RUnlock()
+	return ok
 }
 
 // Server is the ghost HTTP daemon.

--- a/internal/telegram/approval.go
+++ b/internal/telegram/approval.go
@@ -16,9 +16,10 @@ import (
 
 // approvalState tracks which session has a pending approval for instruction replies.
 type approvalState struct {
-	mu        sync.Mutex
-	sessionID string // session with pending approval
-	toolName  string
+	mu         sync.Mutex
+	sessionID  string // session with pending approval
+	toolName   string
+	messageIDs map[int64]int // chatID → Telegram message ID for cleanup
 }
 
 // SetServerAddr configures the Ghost server address for API calls.
@@ -61,10 +62,11 @@ func (tb *Bot) NotifyApproval(sessionID, projectName, toolName string, input jso
 	tb.approval.mu.Lock()
 	tb.approval.sessionID = sessionID
 	tb.approval.toolName = toolName
+	tb.approval.messageIDs = make(map[int64]int)
 	tb.approval.mu.Unlock()
 
 	for id := range tb.allowedIDs {
-		_, err := tb.bot.SendMessage(context.Background(), &bot.SendMessageParams{
+		msg, err := tb.bot.SendMessage(context.Background(), &bot.SendMessageParams{
 			ChatID:    id,
 			Text:      text,
 			ParseMode: models.ParseModeMarkdown,
@@ -75,6 +77,10 @@ func (tb *Bot) NotifyApproval(sessionID, projectName, toolName string, input jso
 		})
 		if err != nil {
 			tb.logger.Error("telegram approval notify", "error", err, "user_id", id)
+		} else if msg != nil {
+			tb.approval.mu.Lock()
+			tb.approval.messageIDs[id] = msg.ID
+			tb.approval.mu.Unlock()
 		}
 	}
 }
@@ -111,7 +117,7 @@ func (tb *Bot) handleApprovalCallback(ctx context.Context, b *bot.Bot, update *m
 		return
 	}
 
-	// Answer callback and edit the message.
+	// Answer callback with toast.
 	action := "✅ Approved"
 	if !approved {
 		action = "❌ Denied"
@@ -122,15 +128,8 @@ func (tb *Bot) handleApprovalCallback(ctx context.Context, b *bot.Bot, update *m
 		Text:            action,
 	})
 
-	// Edit the approval message to show the result.
-	if update.CallbackQuery.Message.Message != nil {
-		_, _ = b.EditMessageText(ctx, &bot.EditMessageTextParams{
-			ChatID:    update.CallbackQuery.Message.Message.Chat.ID,
-			MessageID: update.CallbackQuery.Message.Message.ID,
-			Text:      update.CallbackQuery.Message.Message.Text + "\n\n" + action,
-			ParseMode: models.ParseModeMarkdown,
-		})
-	}
+	// Delete all approval messages (clean up chat).
+	tb.deleteApprovalMessages()
 
 	tb.approval.mu.Lock()
 	tb.approval.sessionID = ""
@@ -170,6 +169,8 @@ func (tb *Bot) handleInstructionReply(ctx context.Context, b *bot.Bot, update *m
 	} else {
 		tb.reply(ctx, b, update, fmt.Sprintf("❌ Denied with instructions:\n_%s_", mdv2.Esc(instructions)))
 	}
+
+	tb.deleteApprovalMessages()
 
 	tb.approval.mu.Lock()
 	tb.approval.sessionID = ""
@@ -216,6 +217,43 @@ func (tb *Bot) callApproveAPI(sessionID string, approved bool, instructions stri
 		return fmt.Errorf("approve API returned %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// deleteApprovalMessages removes all tracked approval messages from Telegram chats.
+func (tb *Bot) deleteApprovalMessages() {
+	tb.approval.mu.Lock()
+	msgs := tb.approval.messageIDs
+	tb.approval.messageIDs = nil
+	tb.approval.mu.Unlock()
+
+	for chatID, msgID := range msgs {
+		_, err := tb.bot.DeleteMessage(context.Background(), &bot.DeleteMessageParams{
+			ChatID: chatID,
+			MessageID: msgID,
+		})
+		if err != nil {
+			tb.logger.Warn("delete approval message", "error", err, "chat_id", chatID)
+		}
+	}
+}
+
+// ApprovalResolved is called by the server when an approval is resolved from
+// any client (VSCode, TUI, etc). Deletes the Telegram approval messages so
+// they don't pile up. Implements server.ApprovalNotifier.
+func (tb *Bot) ApprovalResolved(sessionID string, approved bool) {
+	tb.approval.mu.Lock()
+	if tb.approval.sessionID != sessionID {
+		tb.approval.mu.Unlock()
+		return
+	}
+	tb.approval.mu.Unlock()
+
+	tb.deleteApprovalMessages()
+
+	tb.approval.mu.Lock()
+	tb.approval.sessionID = ""
+	tb.approval.toolName = ""
+	tb.approval.mu.Unlock()
 }
 
 // formatToolInput extracts the most relevant info from tool input for display.

--- a/vscode-ghost/src/chat-webview.ts
+++ b/vscode-ghost/src/chat-webview.ts
@@ -21,6 +21,8 @@ export class ChatWebview implements vscode.Disposable {
   private statusBar: GhostStatusBar;
   private session?: SessionInfo;
   private abortFn?: () => void;
+  private currentStreamId?: string;
+  private streaming = false;
   private disposables: vscode.Disposable[] = [];
   private onModeChanged?: (mode: string) => void;
 
@@ -124,6 +126,11 @@ export class ChatWebview implements vscode.Disposable {
     // Abort any in-flight stream — server handles the race, this minimizes waste.
     this.abortFn?.();
 
+    // Dismiss any stale approval overlay from the previous stream.
+    this.postMessage({ type: "approval_resolved" });
+    this.currentStreamId = undefined;
+
+    this.streaming = true;
     this.postMessage({ type: "streaming", active: true });
 
     try {
@@ -168,14 +175,22 @@ export class ChatWebview implements vscode.Disposable {
         }
       });
       emitter.on("approval", (data: Record<string, unknown>) => {
+        this.currentStreamId = (data.stream_id as string) ?? undefined;
         this.postMessage({
           type: "approval_required",
+          stream_id: this.currentStreamId ?? "",
           tool_name: data.tool_name as string,
           input: data.input,
         });
       });
       emitter.on("approval_resolved", () => {
         this.postMessage({ type: "approval_resolved" });
+      });
+      emitter.on("aborted", (data: Record<string, string>) => {
+        this.postMessage({ type: "aborted", reason: data.reason ?? "unknown" });
+        this.postMessage({ type: "approval_resolved" }); // dismiss stale overlay
+        this.streaming = false;
+        this.postMessage({ type: "streaming", active: false });
       });
       emitter.on("done", (data: Record<string, unknown>) => {
         const sessionCost = (data.session_cost as string) ?? null;
@@ -188,6 +203,7 @@ export class ChatWebview implements vscode.Disposable {
         });
         // Only mark streaming complete on final done, not mid-turn tool_use.
         if (stopReason !== "tool_use") {
+          this.streaming = false;
           this.postMessage({ type: "streaming", active: false });
         }
         if (sessionCost) {
@@ -197,9 +213,11 @@ export class ChatWebview implements vscode.Disposable {
       });
       emitter.on("error", (err: Error) => {
         this.postMessage({ type: "error", text: err.message ?? "Unknown error" });
+        this.streaming = false;
         this.postMessage({ type: "streaming", active: false });
       });
       emitter.on("close", () => {
+        this.streaming = false;
         this.postMessage({ type: "streaming", active: false });
       });
     } catch (err) {
@@ -211,7 +229,7 @@ export class ChatWebview implements vscode.Disposable {
   private async handleApprove(approved: boolean, instructions?: string): Promise<void> {
     if (!this.session) return;
     try {
-      await this.client.approve(this.session.id, approved, instructions);
+      await this.client.approve(this.session.id, approved, instructions, this.currentStreamId);
     } catch (err) {
       this.postMessage({ type: "error", text: `Approval failed: ${err}` });
     }
@@ -412,6 +430,16 @@ export class ChatWebview implements vscode.Disposable {
     this.activateTrigger();
 
     this.postMessage({ type: "voice_final", text: cleanText });
+
+    // Guard: if a stream is already active, queue the message instead of superseding.
+    if (this.streaming) {
+      this.postMessage({ type: "system_message", text: "Queued voice message (waiting for current response)" });
+      // The webview's send() function already queues when streaming=true,
+      // so we send it as a user-initiated message which will be queued.
+      this.postMessage({ type: "send_from_command", text: cleanText });
+      return;
+    }
+
     this.handleSend(cleanText).catch((err) => {
       this.postMessage({ type: "error", text: `Voice send failed: ${err}` });
     });

--- a/vscode-ghost/src/ghost-client.ts
+++ b/vscode-ghost/src/ghost-client.ts
@@ -109,10 +109,14 @@ export class GhostClient extends EventEmitter {
     sessionId: string,
     approved: boolean,
     instructions?: string,
+    streamId?: string,
   ): Promise<{ status: string }> {
     const body: Record<string, unknown> = { approved };
     if (instructions) {
       body.instructions = instructions;
+    }
+    if (streamId) {
+      body.stream_id = streamId;
     }
     return this.request(
       "POST",
@@ -220,6 +224,9 @@ export class GhostClient extends EventEmitter {
                   break;
                 case "approval_resolved":
                   emitter.emit("approval_resolved", {});
+                  break;
+                case "aborted":
+                  emitter.emit("aborted", data);
                   break;
                 case "done":
                   emitter.emit("done", data);

--- a/vscode-ghost/src/protocol.ts
+++ b/vscode-ghost/src/protocol.ts
@@ -13,8 +13,9 @@ export type ExtToWebviewMessage =
   | { type: "tool_delta"; id: string; delta: string }
   | { type: "tool_end"; id: string; name: string }
   | { type: "tool_result"; id: string; name: string; output: string; is_error: boolean }
-  | { type: "approval_required"; tool_name: string; input: unknown }
+  | { type: "approval_required"; stream_id: string; tool_name: string; input: unknown }
   | { type: "approval_resolved" }
+  | { type: "aborted"; reason: string }
   | {
       type: "done";
       session_cost: string | null;

--- a/vscode-ghost/src/webview/chat-main.ts
+++ b/vscode-ghost/src/webview/chat-main.ts
@@ -528,7 +528,15 @@ window.addEventListener("message", (event) => {
       setStreaming(false);
       break;
     case "streaming":
+      if (msg.active) {
+        hideApproval(); // safety net: dismiss stale overlays on new stream
+      }
       setStreaming(msg.active);
+      break;
+    case "aborted":
+      addSystemMessage("Stream aborted: " + msg.reason);
+      hideApproval();
+      setStreaming(false);
       break;
     case "status":
       connectionDot.className = msg.connected ? "dot connected" : "dot disconnected";


### PR DESCRIPTION
## Summary
- Add unique `stream_id` to each SSE stream for approval correlation — stale approvals now return 409 instead of 404
- Server sends explicit `event: aborted` SSE on stream supersession (no more silent close)
- Extend `ApprovalNotifier` with `ApprovalResolved()` — Telegram deletes approval messages when resolved from any client (VSCode, TUI)
- Guard voice auto-send: queues message when a stream is active instead of superseding and orphaning tool approvals
- VSCode dismisses stale approval overlays on new stream start and on abort

## Test plan
- [ ] Send a message requiring tool approval, approve from VSCode — Telegram message should disappear
- [ ] Send a message, click mic while streaming — voice message should be queued, not supersede
- [ ] Open approval overlay, send a new message — overlay should dismiss automatically
- [ ] Approve a stale approval after stream ends — should get 409 not 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stream-scoped approval mechanism prevents approval conflicts when handling concurrent requests
  * Automatic request supersession detection with conflict responses

* **Improvements**
  * Enhanced approval notification synchronization across all connected clients
  * Improved cleanup of approval messages in messaging platforms
  * More consistent streaming state tracking and termination signaling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->