### PR TITLE
feat(ux): repo:branch display, silent Telegram notifications

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ internal/
     approval.go            Pending approval state
     sse.go                 SSE write helpers
   mcpserver/               MCP server
-    mcpserver.go           stdio transport, 13 tools + 2 resources
+    mcpserver.go           stdio transport, 12 tools + 2 resources
   telegram/                Telegram bot
     bot.go                 Commands, whitelist auth, alerts
     approval.go            Approval forwarding with inline keyboards
@@ -150,7 +150,7 @@ Claude Code / Cursor → stdio JSON-RPC → mcpserver
                                  ghost_memory_save → store.Upsert()
                                  ghost_project_context → store.GetTopMemories()
                                  ghost_save_global → store.Upsert("_global")
-                                 ... 9 more tools
+                                 ... 8 more tools
                                           ↓
                           Resources (push-based, pinnable by client):
                                  ghost://project/{project_id}/context

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -227,6 +227,8 @@ func Load() (*Config, error) {
 		"GHOST_VOICE_INPUT_DEVICE":       "voice.input_device",
 		"GHOST_VOICE_SAMPLE_RATE":        "voice.sample_rate",
 		"GHOST_VOICE_SILENCE_MS":         "voice.silence_ms",
+		"GHOST_COST_REPORT_ENABLED":      "cost_report.enabled",
+		"GHOST_COST_REPORT_SCHEDULE":     "cost_report.schedule",
 	}
 	for envKey, koanfKey := range envOverrides {
 		if val := os.Getenv(envKey); val != "" {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/wcatz/ghost/internal/ai"
 )
 
 // Memory represents a single discrete memory.
@@ -664,26 +666,10 @@ func (s *Store) GetMonthlyCost(ctx context.Context, year, month int) (MonthlyCos
 		mc.ByModel = append(mc.ByModel, ModelCost{Model: model, Cost: cost})
 
 		// Compute what cost would have been without caching for this model.
-		noCacheCost := noCacheCostForModel(model, input, output, cacheWrite, cacheRead)
+		noCacheCost := ai.CostWithoutCacheForUsage(input, output, cacheWrite, cacheRead, model)
 		mc.TotalSavings += noCacheCost - cost
 	}
 	return mc, rows.Err()
-}
-
-// noCacheCostForModel computes hypothetical cost if all cached tokens were charged at base input rate.
-func noCacheCostForModel(model string, input, output, cacheWrite, cacheRead int) float64 {
-	// Use simple model-family pricing lookup.
-	var inP, outP float64
-	switch {
-	case strings.Contains(model, "haiku"):
-		inP, outP = 1.00, 5.00
-	case strings.Contains(model, "opus"):
-		inP, outP = 5.00, 25.00
-	default:
-		inP, outP = 3.00, 15.00
-	}
-	allInput := input + cacheWrite + cacheRead
-	return float64(allInput)/1e6*inP + float64(output)/1e6*outP
 }
 
 func scanMemories(rows *sql.Rows) ([]Memory, error) {

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -525,6 +525,16 @@ func (s *Session) Refresh() error {
 	return nil
 }
 
+// GitBranch returns the current git branch for the session's project.
+func (s *Session) GitBranch() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.projectCtx != nil {
+		return s.projectCtx.GitBranch
+	}
+	return ""
+}
+
 // ClearMessages resets the conversation (keeps memories).
 func (s *Session) ClearMessages() {
 	s.mu.Lock()

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -525,7 +525,8 @@ func (s *Session) Refresh() error {
 	return nil
 }
 
-// GitBranch returns the current git branch for the session's project.
+// GitBranch returns the git branch from the last project context refresh.
+// It may be stale if the user switched branches without triggering Refresh().
 func (s *Session) GitBranch() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -177,6 +177,10 @@ func (s *Scheduler) AddCronJob(ctx context.Context, name, cronExpr string, paylo
 		return fmt.Errorf("generate id: %w", err)
 	}
 
+	// Remove any existing job with the same name to prevent row
+	// accumulation across daemon restarts.
+	_, _ = s.db.ExecContext(ctx, `DELETE FROM scheduled_jobs WHERE name = ?`, name)
+
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO scheduled_jobs (id, name, schedule, payload) VALUES (?, ?, ?, ?)
 	`, id, name, cronExpr, string(payloadJSON))

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -286,9 +286,9 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 						projectLabel += ":" + branch
 					}
 				}
-				// Send silently if there's an active VSCode/SSE stream — user is at the keyboard.
-				silent := s.HasActiveStream(id)
-				go s.approvalNotifier.NotifyApproval(id, streamID, projectLabel, approval.ToolName, approval.Input, silent)
+				// This handler serves SSE clients (VSCode), so the user is at the
+				// keyboard — send Telegram notification silently.
+				go s.approvalNotifier.NotifyApproval(id, streamID, projectLabel, approval.ToolName, approval.Input, true)
 			}
 
 		case <-resolvedCh:

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -41,6 +41,7 @@ type chatState struct {
 	mu               sync.Mutex
 	streamID         string // unique per-stream, used to correlate approvals
 	cancel           context.CancelFunc
+	superseded       chan struct{}      // closed when this stream is replaced by a newer one
 	pending          *pendingApproval
 	approvalResolved chan struct{} // signals external approval to SSE stream
 }
@@ -167,11 +168,12 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	streamID := newStreamID()
 	s.chatMu.Lock()
 	if old, active := s.chatStates[id]; active {
+		close(old.superseded) // signal the old stream it was superseded
 		old.cancel()
 		s.logger.Info("superseding active stream", "session", id, "old_stream", old.streamID, "new_stream", streamID)
 	}
 	ctx, cancel := context.WithCancel(r.Context())
-	state := &chatState{cancel: cancel, streamID: streamID}
+	state := &chatState{cancel: cancel, streamID: streamID, superseded: make(chan struct{})}
 	s.chatStates[id] = state
 	s.chatMu.Unlock()
 
@@ -286,7 +288,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 				}
 				// Send silently if there's an active VSCode/SSE stream — user is at the keyboard.
 				silent := s.HasActiveStream(id)
-				go s.approvalNotifier.NotifyApproval(id, projectLabel, approval.ToolName, approval.Input, silent)
+				go s.approvalNotifier.NotifyApproval(id, streamID, projectLabel, approval.ToolName, approval.Input, silent)
 			}
 
 		case <-resolvedCh:
@@ -295,7 +297,17 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			resolvedCh = nil
 
 		case <-ctx.Done():
-			writeSSE(w, flusher, "aborted", map[string]string{"reason": "superseded"})
+			// Determine why the context was cancelled.
+			reason := "client_disconnected"
+			select {
+			case <-state.superseded:
+				reason = "superseded"
+			default:
+				if ctx.Err() == context.DeadlineExceeded {
+					reason = "timeout"
+				}
+			}
+			writeSSE(w, flusher, "aborted", map[string]string{"reason": reason})
 			return
 		}
 	}

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -21,6 +21,7 @@ type sessionInfo struct {
 	ID          string    `json:"id"`
 	ProjectPath string    `json:"project_path"`
 	ProjectName string    `json:"project_name"`
+	GitBranch   string    `json:"git_branch,omitempty"`
 	Mode        string    `json:"mode"`
 	Active      bool      `json:"active"`
 	Messages    int       `json:"messages"`
@@ -89,6 +90,7 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 		ID:          session.ProjectID,
 		ProjectPath: session.ProjectPath,
 		ProjectName: session.ProjectName,
+		GitBranch:   session.GitBranch(),
 		Mode:        session.Mode.Name,
 		Active:      session.Active,
 		Messages:    session.MessageCount(),
@@ -105,6 +107,7 @@ func (s *Server) handleListSessions(w http.ResponseWriter, _ *http.Request) {
 			ID:          sess.ProjectID,
 			ProjectPath: sess.ProjectPath,
 			ProjectName: sess.ProjectName,
+			GitBranch:   sess.GitBranch(),
 			Mode:        sess.Mode.Name,
 			Active:      sess.Active,
 			Messages:    sess.MessageCount(),
@@ -274,11 +277,16 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			})
 
 			if s.approvalNotifier != nil {
-				projectName := ""
+				projectLabel := ""
 				if session != nil {
-					projectName = session.ProjectName
+					projectLabel = session.ProjectName
+					if branch := session.GitBranch(); branch != "" {
+						projectLabel += ":" + branch
+					}
 				}
-				go s.approvalNotifier.NotifyApproval(id, projectName, approval.ToolName, approval.Input)
+				// Send silently if there's an active VSCode/SSE stream — user is at the keyboard.
+				silent := s.HasActiveStream(id)
+				go s.approvalNotifier.NotifyApproval(id, projectLabel, approval.ToolName, approval.Input, silent)
 			}
 
 		case <-resolvedCh:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,7 +24,7 @@ import (
 // ApprovalNotifier is called when a tool needs approval.
 // The Telegram bot implements this to forward approvals to the user's phone.
 type ApprovalNotifier interface {
-	NotifyApproval(sessionID, projectName, toolName string, input json.RawMessage)
+	NotifyApproval(sessionID, projectName, toolName string, input json.RawMessage, silent bool)
 	ApprovalResolved(sessionID string, approved bool)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,7 +24,7 @@ import (
 // ApprovalNotifier is called when a tool needs approval.
 // The Telegram bot implements this to forward approvals to the user's phone.
 type ApprovalNotifier interface {
-	NotifyApproval(sessionID, projectName, toolName string, input json.RawMessage, silent bool)
+	NotifyApproval(sessionID, streamID, projectName, toolName string, input json.RawMessage, silent bool)
 	ApprovalResolved(sessionID string, approved bool)
 }
 

--- a/internal/telegram/approval.go
+++ b/internal/telegram/approval.go
@@ -18,6 +18,7 @@ import (
 type approvalState struct {
 	mu         sync.Mutex
 	sessionID  string // session with pending approval
+	streamID   string // stream that owns this approval (detects supersession)
 	toolName   string
 	messageIDs map[int64]int // chatID → Telegram message ID for cleanup
 }
@@ -35,7 +36,11 @@ func (tb *Bot) SetServerToken(token string) {
 // NotifyApproval sends an approval request to all allowed Telegram users
 // with Allow / Deny inline buttons. When silent is true (VSCode has an active
 // stream), the notification is sent without sound. Implements server.ApprovalNotifier.
-func (tb *Bot) NotifyApproval(sessionID, projectName, toolName string, input json.RawMessage, silent bool) {
+func (tb *Bot) NotifyApproval(sessionID, streamID, projectName, toolName string, input json.RawMessage, silent bool) {
+	// Clean up any stale approval messages from a previous (superseded) approval
+	// before posting new ones. This prevents orphaned buttons in the chat.
+	tb.deleteApprovalMessages()
+
 	// Format the input for display.
 	inputStr := formatToolInput(toolName, input)
 
@@ -62,6 +67,7 @@ func (tb *Bot) NotifyApproval(sessionID, projectName, toolName string, input jso
 
 	tb.approval.mu.Lock()
 	tb.approval.sessionID = sessionID
+	tb.approval.streamID = streamID
 	tb.approval.toolName = toolName
 	tb.approval.messageIDs = make(map[int64]int)
 	tb.approval.mu.Unlock()

--- a/internal/telegram/approval.go
+++ b/internal/telegram/approval.go
@@ -33,8 +33,9 @@ func (tb *Bot) SetServerToken(token string) {
 }
 
 // NotifyApproval sends an approval request to all allowed Telegram users
-// with Allow / Deny inline buttons. Implements server.ApprovalNotifier.
-func (tb *Bot) NotifyApproval(sessionID, projectName, toolName string, input json.RawMessage) {
+// with Allow / Deny inline buttons. When silent is true (VSCode has an active
+// stream), the notification is sent without sound. Implements server.ApprovalNotifier.
+func (tb *Bot) NotifyApproval(sessionID, projectName, toolName string, input json.RawMessage, silent bool) {
 	// Format the input for display.
 	inputStr := formatToolInput(toolName, input)
 
@@ -67,10 +68,11 @@ func (tb *Bot) NotifyApproval(sessionID, projectName, toolName string, input jso
 
 	for id := range tb.allowedIDs {
 		msg, err := tb.bot.SendMessage(context.Background(), &bot.SendMessageParams{
-			ChatID:    id,
-			Text:      text,
-			ParseMode: models.ParseModeMarkdown,
-			ReplyMarkup: keyboard,
+			ChatID:              id,
+			Text:                text,
+			ParseMode:           models.ParseModeMarkdown,
+			ReplyMarkup:         keyboard,
+			DisableNotification: silent,
 			LinkPreviewOptions: &models.LinkPreviewOptions{
 				IsDisabled: bot.True(),
 			},

--- a/vscode-ghost/src/ghost-client.ts
+++ b/vscode-ghost/src/ghost-client.ts
@@ -9,6 +9,7 @@ export interface Session {
   id: string;
   project_path: string;
   project_name: string;
+  git_branch?: string;
   mode: string;
   active: boolean;
   messages: number;

--- a/vscode-ghost/src/protocol.ts
+++ b/vscode-ghost/src/protocol.ts
@@ -58,6 +58,7 @@ export interface SessionInfo {
   id: string;
   project_path: string;
   project_name: string;
+  git_branch?: string;
   mode: string;
   active: boolean;
   messages: number;

--- a/vscode-ghost/src/webview/chat-main.ts
+++ b/vscode-ghost/src/webview/chat-main.ts
@@ -534,6 +534,7 @@ window.addEventListener("message", (event) => {
       setStreaming(msg.active);
       break;
     case "aborted":
+      finalizeAssistant();
       addSystemMessage("Stream aborted: " + msg.reason);
       hideApproval();
       setStreaming(false);

--- a/vscode-ghost/src/webview/chat-main.ts
+++ b/vscode-ghost/src/webview/chat-main.ts
@@ -542,11 +542,15 @@ window.addEventListener("message", (event) => {
       connectionDot.className = msg.connected ? "dot connected" : "dot disconnected";
       connectionDot.setAttribute("aria-label", msg.connected ? "Connected" : "Disconnected");
       break;
-    case "session":
-      sessionInfoEl.textContent = msg.session.project_name;
+    case "session": {
+      const branch = msg.session.git_branch;
+      sessionInfoEl.textContent = branch
+        ? `${msg.session.project_name}:${branch}`
+        : msg.session.project_name;
       modeBadge.textContent = msg.session.mode;
       modeBadge.className = "mode-badge mode-" + msg.session.mode;
       break;
+    }
     case "monthly_cost":
       sessionCostEl.textContent = msg.text;
       break;


### PR DESCRIPTION
## Summary
- Expose `git_branch` in session API responses — VSCode header shows `ghost:feat/my-branch` instead of just `ghost`
- Telegram approval messages show `project:branch` label (e.g., `ghost:main`)
- When VSCode has an active SSE stream, Telegram sends approval notifications silently (`DisableNotification: true`) — message still appears but phone doesn't buzz

Depends on #86.

## Test plan
- [ ] Open Ghost in VSCode — header should show `project:branch` (e.g., `ghost:feat/session-display-tg-intelligence`)
- [ ] Trigger a tool approval while VSCode is open — Telegram message should arrive silently
- [ ] Trigger a tool approval with no VSCode stream — Telegram should notify normally
- [ ] Verify `curl http://127.0.0.1:2187/api/v1/sessions` returns `git_branch` field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Git branch information is now displayed in session details.
  * Approval notifications are sent silently when an active stream is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->