### PR TITLE
chore(release): Docker, Homebrew, .vsix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  extension:
+    runs-on: ubuntu-latest
+    needs: release
+    defaults:
+      run:
+        working-directory: vscode-ghost
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: vscode-ghost/package-lock.json
+
+      - run: npm ci
+
+      - name: Sync version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm version "$VERSION" --no-git-tag-version
+
+      - name: Package .vsix
+        run: npx @vscode/vsce package --no-dependencies
+
+      - name: Attach .vsix to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          gh release upload "$GITHUB_REF_NAME" "ghost-${VERSION}.vsix" --clobber

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,8 @@
 version: 2
 
 builds:
-  - main: ./cmd/ghost
+  - id: ghost
+    main: ./cmd/ghost
     binary: ghost
     env:
       - CGO_ENABLED=0
@@ -15,7 +16,8 @@ builds:
       - -s -w -X main.version={{.Version}}
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
@@ -28,3 +30,25 @@ changelog:
       - "^docs:"
       - "^chore:"
       - "^ci:"
+
+dockers_v2:
+  - ids: ["ghost"]
+    images:
+      - "ghcr.io/wcatz/ghost"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    tags:
+      - "{{ .Version }}"
+      - latest
+    dockerfile: Dockerfile
+
+homebrew_casks:
+  - repository:
+      owner: wcatz
+      name: homebrew-tap
+    homepage: "https://github.com/wcatz/ghost"
+    description: "Memory-first personal assistant powered by Claude"
+    license: "MIT"
+    binaries:
+      - ghost

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates tzdata
+COPY ghost /usr/local/bin/ghost
+ENTRYPOINT ["ghost"]
+CMD ["serve"]


### PR DESCRIPTION
## Summary
- Add `release.yml` workflow triggered on `v*` tag push
- GoReleaser builds 4 binaries (linux/darwin x amd64/arm64) + checksums
- Multi-arch Docker image → `ghcr.io/wcatz/ghost:{version}` and `:latest`
- Homebrew formula auto-published to `wcatz/homebrew-tap` (`brew install wcatz/tap/ghost`)
- VSCode `.vsix` built with synced version and attached to GitHub Release
- Update `.goreleaser.yml` to v2 syntax (`dockers_v2`, `homebrew_casks`)
- Add minimal alpine Dockerfile

## Release flow
```
git tag v0.3.0 && git push origin v0.3.0
  → goreleaser: 4 binaries + checksums → GitHub Release
  → docker: multi-arch image → ghcr.io
  → homebrew: formula → wcatz/homebrew-tap
  → vsce: .vsix attached to release
```

## Test plan
- [ ] CI passes (no release artifacts produced on PR)
- [ ] `goreleaser check` passes locally ✅
- [ ] Cut `v0.3.0` tag after merge to validate full pipeline