### PR TITLE
fix(schema): sync migration file with runtime schema

### DIFF
--- a/internal/config/config.example.yaml
+++ b/internal/config/config.example.yaml
@@ -15,8 +15,8 @@
 # --- Claude API ---
 # api:
 #   key: ""                          # or set ANTHROPIC_API_KEY env var
-#   model_quality: "claude-sonnet-4-5-20250929"
-#   model_fast: "claude-haiku-4-5-20251001"
+#   model_quality: "claude-opus-4-6-20250514"
+#   model_fast: "claude-sonnet-4-5-20250929"
 
 # --- Daemon defaults ---
 # defaults:
@@ -89,3 +89,8 @@
 # briefing:
 #   enabled: false
 #   schedule: "0 8 * * 1-5"         # cron: 8am weekdays
+
+# --- Monthly Cost Report ---
+# cost_report:
+#   enabled: false
+#   schedule: "0 9 1 * *"           # cron: 9am on 1st of month

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,4 +1,5 @@
--- Ghost: Memory-First Coding Agent — Initial Schema
+-- Ghost — Memory-First Personal Assistant — Initial Schema
+-- Reference copy. Runtime source of truth is internal/memory/schema.go:initSQL.
 
 CREATE TABLE IF NOT EXISTS projects (
     id          TEXT PRIMARY KEY,
@@ -21,7 +22,7 @@ CREATE TABLE IF NOT EXISTS memories (
     access_count  INTEGER NOT NULL DEFAULT 0,
     last_accessed TEXT,
     source        TEXT NOT NULL DEFAULT 'reflection'
-                  CHECK (source IN ('reflection', 'chat', 'manual', 'tool')),
+                  CHECK (source IN ('reflection', 'chat', 'manual', 'tool', 'mcp', 'onboarding', 'decision_log')),
     tags          TEXT DEFAULT '[]',
     pinned        INTEGER NOT NULL DEFAULT 0,
     created_at    TEXT NOT NULL DEFAULT (datetime('now')),
@@ -55,7 +56,7 @@ CREATE INDEX IF NOT EXISTS idx_memories_project_source ON memories(project_id, s
 CREATE TABLE IF NOT EXISTS conversations (
     id          TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
     project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-    mode        TEXT NOT NULL DEFAULT 'code',
+    mode        TEXT NOT NULL DEFAULT 'chat',
     title       TEXT DEFAULT '',
     created_at  TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
@@ -96,3 +97,100 @@ CREATE TABLE IF NOT EXISTS token_usage (
 );
 
 CREATE INDEX IF NOT EXISTS idx_usage_project ON token_usage(project_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id          TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    timestamp   TEXT NOT NULL DEFAULT (datetime('now')),
+    action      TEXT NOT NULL,
+    project_id  TEXT,
+    user        TEXT DEFAULT '',
+    details     TEXT DEFAULT '{}',
+    tokens      INTEGER DEFAULT 0,
+    cost_usd    REAL DEFAULT 0,
+    duration_ms INTEGER DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_project ON audit_log(project_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_log(action, timestamp DESC);
+
+CREATE TABLE IF NOT EXISTS memory_embeddings (
+    memory_id   TEXT PRIMARY KEY REFERENCES memories(id) ON DELETE CASCADE,
+    embedding   BLOB NOT NULL,
+    model       TEXT NOT NULL DEFAULT 'nomic-embed-text',
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id              TEXT PRIMARY KEY,
+    github_id       TEXT NOT NULL UNIQUE,
+    repo_full_name  TEXT NOT NULL,
+    subject_title   TEXT NOT NULL,
+    subject_type    TEXT NOT NULL,
+    subject_url     TEXT DEFAULT '',
+    reason          TEXT NOT NULL,
+    priority        INTEGER NOT NULL DEFAULT 4,
+    unread          INTEGER NOT NULL DEFAULT 1,
+    updated_at      TEXT NOT NULL,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    dismissed_at    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_notif_priority ON notifications(priority, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notif_repo ON notifications(repo_full_name, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notif_unread ON notifications(unread, priority);
+
+CREATE TABLE IF NOT EXISTS scheduled_jobs (
+    id          TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    name        TEXT NOT NULL,
+    schedule    TEXT NOT NULL,
+    payload     TEXT DEFAULT '{}',
+    enabled     INTEGER NOT NULL DEFAULT 1,
+    last_run    TEXT,
+    next_run    TEXT,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS reminders (
+    id          TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    message     TEXT NOT NULL,
+    due_at      TEXT NOT NULL,
+    fired       INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_reminders_due ON reminders(fired, due_at);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id            TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    title         TEXT NOT NULL,
+    description   TEXT DEFAULT '',
+    status        TEXT NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending', 'active', 'done', 'blocked')),
+    priority      INTEGER NOT NULL DEFAULT 2
+                  CHECK (priority BETWEEN 0 AND 4),
+    blocked_by    TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+    branch        TEXT DEFAULT '',
+    pr_number     INTEGER,
+    notes         TEXT DEFAULT '',
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    completed_at  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_tasks_project_status ON tasks(project_id, status);
+
+CREATE TABLE IF NOT EXISTS decisions (
+    id                TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    project_id        TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    title             TEXT NOT NULL,
+    decision          TEXT NOT NULL,
+    alternatives      TEXT DEFAULT '[]',
+    rationale         TEXT NOT NULL,
+    status            TEXT NOT NULL DEFAULT 'active'
+                      CHECK (status IN ('active', 'superseded', 'revisit')),
+    superseded_by     TEXT REFERENCES decisions(id) ON DELETE SET NULL,
+    tags              TEXT DEFAULT '[]',
+    created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_decisions_project ON decisions(project_id, status);


### PR DESCRIPTION
## Summary
- Sync `migrations/001_init.sql` with `internal/memory/schema.go` — adds 7 missing tables, fixes source CHECK constraint, fixes conversation mode default
- Update `config.example.yaml` — correct model defaults (opus-4-6/sonnet-4-5), add missing `cost_report` section

## Details
The migration file is reference-only (runtime uses the Go constant in schema.go), but was significantly drifted:
- Missing tables: audit_log, memory_embeddings, notifications, scheduled_jobs, reminders, tasks, decisions
- Wrong source types: missing mcp, onboarding, decision_log
- Wrong default: conversations.mode was 'code', should be 'chat'

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Schema files are now identical in structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added cost tracking with automated monthly cost reports
  - Introduced task management system with priority levels
  - Added reminders and notification system
  - Implemented decision logging with tracking capabilities

* **Chores**
  - Updated default configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->