### PR TITLE
feat(mcp): auto-import Claude memories, upgrade server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Pure Go. No CGO. Single binary.
 
 - **Agentic tool loop** — Claude's tool_use drives a read-act-reflect cycle with configurable approval gates
 - **Persistent memory** across sessions — Ghost knows what you worked on last week
+- **Claude Code memory import** — auto-imports Claude Code's memory files on first project contact, no manual migration
 - **3-block prompt caching** — 90%+ cache hit rates, ~76% savings on input tokens
 - **Hybrid search** — FTS5 keyword + vector cosine similarity via Reciprocal Rank Fusion
 - **Free embeddings** — `nomic-embed-text:v1.5` runs locally through Ollama, no API costs
@@ -165,7 +166,7 @@ Connects Claude Code, Cursor, or any MCP client to Ghost's memory via stdio.
 }
 ```
 
-**MCP Tools (12):**
+**MCP Tools (13):**
 
 | Tool | Description |
 |------|-------------|
@@ -174,6 +175,7 @@ Connects Claude Code, Cursor, or any MCP client to Ghost's memory via stdio.
 | `ghost_memories_list` | List with optional category filter |
 | `ghost_memory_delete` | Delete by ID |
 | `ghost_project_context` | Top memories ranked by importance + recency |
+| `ghost_list_projects` | Discover all known projects with memory counts |
 | `ghost_search_all` | Cross-project memory search |
 | `ghost_save_global` | Save memory accessible to all projects |
 | `ghost_task_create` | Create a task with priority and status |
@@ -181,6 +183,8 @@ Connects Claude Code, Cursor, or any MCP client to Ghost's memory via stdio.
 | `ghost_task_complete` | Mark a task as done |
 | `ghost_decision_record` | Record an architectural decision with rationale |
 | `ghost_health` | System stats (memory count, embeddings, costs) |
+
+The MCP server ships with comprehensive instructions that teach Claude when and how to save memories proactively, which categories to use, and how to leverage cross-project search. No CLAUDE.md configuration required.
 
 **MCP Resources:**
 
@@ -326,8 +330,9 @@ cmd/ghost/main.go          CLI + daemon bootstrap
 internal/
   ai/                      Claude API client, streaming, tool_use, cost tracking
   memory/                  SQLite + FTS5 + vector search + time-decay
-  tool/                    Tool registry + 9 built-in executors
+  tool/                    Tool registry + built-in executors (file, grep, glob, git, bash, memory)
   orchestrator/            Multi-project sessions, context compression, multi-turn caching
+  claudeimport/            Auto-import Claude Code memory files on first project contact
   reflection/              Haiku memory consolidation + auto-extraction
   prompt/                  3-block cached system prompt
   mode/                    Operating modes (chat, code, debug, review, plan, refactor)
@@ -335,7 +340,7 @@ internal/
   config/                  Layered YAML/env/flag config (koanf)
   tui/                     Terminal REPL (bubbletea)
   server/                  HTTP REST API (chi)
-  mcpserver/               MCP server (stdio, 12 tools + resources)
+  mcpserver/               MCP server (stdio, 13 tools + resources)
   telegram/                Bot, approvals, session management
   google/                  Calendar + Gmail OAuth2
   calendar/                CalDAV client

--- a/internal/claudeimport/import.go
+++ b/internal/claudeimport/import.go
@@ -1,0 +1,246 @@
+// Package claudeimport reads Claude Code's auto-memory files and imports
+// them into Ghost's memory store. This is a read-only operation — Claude's
+// files are never modified or deleted.
+package claudeimport
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wcatz/ghost/internal/provider"
+)
+
+const (
+	maxContentLen = 4000
+	minContentLen = 20
+	source        = "onboarding"
+)
+
+var importTags = []string{"claude-code", "auto-import"}
+
+// categoryMap converts Claude Code memory types to Ghost categories.
+var categoryMap = map[string]string{
+	"feedback":  "preference",
+	"project":   "architecture",
+	"reference": "fact",
+	"pattern":   "pattern",
+	"decision":  "decision",
+	"gotcha":    "gotcha",
+	"user":      "preference",
+}
+
+// importanceMap returns importance scores by Claude type.
+var importanceMap = map[string]float32{
+	"feedback": 0.9,
+	"project":  0.8,
+	"user":     0.9,
+}
+
+const defaultImportance float32 = 0.7
+
+// encodeProjectPath converts an absolute path to Claude's directory name format.
+// E.g., "/home/wayne/git/ghost" → "-home-wayne-git-ghost".
+func encodeProjectPath(projectPath string) string {
+	return strings.ReplaceAll(projectPath, "/", "-")
+}
+
+// ClaudeMemoryDir returns the path to Claude Code's memory directory for the
+// given absolute project path. Returns "" if the directory does not exist.
+func ClaudeMemoryDir(projectPath string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	encoded := encodeProjectPath(projectPath)
+	dir := filepath.Join(home, ".claude", "projects", encoded, "memory")
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return ""
+	}
+	return dir
+}
+
+// skipFile returns true if the filename should not be imported.
+func skipFile(name string) bool {
+	lower := strings.ToLower(name)
+	switch {
+	case lower == "memory.md":
+		return true
+	case strings.HasPrefix(lower, "plan_"):
+		return true
+	case strings.HasPrefix(lower, "research_"):
+		return true
+	}
+	return false
+}
+
+// isStub returns true if the content looks like a migration stub.
+func isStub(content string) bool {
+	if len(content) < minContentLen {
+		return true
+	}
+	lower := strings.ToLower(content)
+	return strings.Contains(lower, "migrated to ghost")
+}
+
+// ParseMemoryFile reads a Claude Code memory file and extracts its content,
+// Ghost category, and importance. Returns skip=true for files that should
+// not be imported.
+func ParseMemoryFile(path string) (content, category string, importance float32, skip bool, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", 0, false, err
+	}
+
+	name := filepath.Base(path)
+	if skipFile(name) {
+		return "", "", 0, true, nil
+	}
+
+	raw := string(data)
+	fmName, fmDesc, fmType, body := parseFrontmatter(raw)
+
+	// Build content: prepend name/description as header if available.
+	var sb strings.Builder
+	if fmName != "" {
+		sb.WriteString(fmName)
+		if fmDesc != "" {
+			sb.WriteString(" — ")
+			sb.WriteString(fmDesc)
+		}
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString(strings.TrimSpace(body))
+	content = sb.String()
+
+	if isStub(content) {
+		return "", "", 0, true, nil
+	}
+
+	// Truncate if too long.
+	if len(content) > maxContentLen {
+		content = content[:maxContentLen]
+	}
+
+	// Map type to category.
+	category = mapCategory(fmType)
+	importance = importanceForType(fmType)
+
+	return content, category, importance, false, nil
+}
+
+// parseFrontmatter extracts YAML frontmatter fields from markdown content.
+// Returns the body without frontmatter.
+func parseFrontmatter(raw string) (name, description, fileType, body string) {
+	if !strings.HasPrefix(raw, "---\n") {
+		return "", "", "", raw
+	}
+
+	end := strings.Index(raw[4:], "\n---")
+	if end < 0 {
+		return "", "", "", raw
+	}
+
+	fm := raw[4 : 4+end]
+	body = raw[4+end+4:] // skip closing "---\n"
+
+	scanner := bufio.NewScanner(strings.NewReader(fm))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if k, v, ok := parseYAMLLine(line); ok {
+			switch k {
+			case "name":
+				name = v
+			case "description":
+				description = v
+			case "type":
+				fileType = v
+			}
+		}
+	}
+	return name, description, fileType, body
+}
+
+// parseYAMLLine extracts a simple key: value pair from a YAML line.
+func parseYAMLLine(line string) (key, value string, ok bool) {
+	idx := strings.Index(line, ":")
+	if idx < 0 {
+		return "", "", false
+	}
+	key = strings.TrimSpace(line[:idx])
+	value = strings.TrimSpace(line[idx+1:])
+	// Strip surrounding quotes.
+	if len(value) >= 2 && (value[0] == '"' || value[0] == '\'') && value[len(value)-1] == value[0] {
+		value = value[1 : len(value)-1]
+	}
+	return key, value, true
+}
+
+// mapCategory converts a Claude memory type to a Ghost category.
+func mapCategory(claudeType string) string {
+	if cat, ok := categoryMap[strings.ToLower(claudeType)]; ok {
+		return cat
+	}
+	return "fact"
+}
+
+// importanceForType returns the importance score for a Claude memory type.
+func importanceForType(claudeType string) float32 {
+	if imp, ok := importanceMap[strings.ToLower(claudeType)]; ok {
+		return imp
+	}
+	return defaultImportance
+}
+
+// Import discovers and imports all Claude Code memories for a project.
+// Returns the number of memories imported. Read-only — never modifies
+// Claude's files. Uses store.Upsert for dedup.
+func Import(ctx context.Context, store provider.MemoryStore, projectID, projectPath string, logger *slog.Logger) (int, error) {
+	dir := ClaudeMemoryDir(projectPath)
+	if dir == "" {
+		return 0, nil
+	}
+	return importFromDir(ctx, store, projectID, dir, logger)
+}
+
+// importFromDir imports all Claude Code memories from a specific directory.
+func importFromDir(ctx context.Context, store provider.MemoryStore, projectID, dir string, logger *slog.Logger) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, fmt.Errorf("read claude memory dir: %w", err)
+	}
+
+	var imported int
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		content, category, importance, skip, err := ParseMemoryFile(path)
+		if err != nil {
+			logger.Warn("claude import: file read failed", "file", entry.Name(), "error", err)
+			continue
+		}
+		if skip {
+			continue
+		}
+
+		_, _, err = store.Upsert(ctx, projectID, category, content, source, importance, importTags)
+		if err != nil {
+			logger.Warn("claude import: upsert failed", "file", entry.Name(), "error", err)
+			continue
+		}
+		imported++
+	}
+
+	if imported > 0 {
+		logger.Info("claude memory import complete", "project", projectID, "memories", imported)
+	}
+
+	return imported, nil
+}

--- a/internal/claudeimport/import_test.go
+++ b/internal/claudeimport/import_test.go
@@ -1,0 +1,344 @@
+package claudeimport
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+func TestClaudeMemoryDir(t *testing.T) {
+	t.Run("encoding", func(t *testing.T) {
+		got := encodeProjectPath("/home/wayne/git/ghost")
+		want := "-home-wayne-git-ghost"
+		if got != want {
+			t.Errorf("encodeProjectPath = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns_empty_for_missing_dir", func(t *testing.T) {
+		got := ClaudeMemoryDir("/nonexistent/project/path")
+		if got != "" {
+			t.Errorf("expected empty for missing dir, got %q", got)
+		}
+	})
+}
+
+func TestParseFrontmatter(t *testing.T) {
+	t.Run("with_frontmatter", func(t *testing.T) {
+		raw := "---\nname: Work autonomously\ndescription: Keep pushing forward\ntype: feedback\n---\nStop asking for approval."
+		name, desc, ftype, body := parseFrontmatter(raw)
+		if name != "Work autonomously" {
+			t.Errorf("name = %q", name)
+		}
+		if desc != "Keep pushing forward" {
+			t.Errorf("desc = %q", desc)
+		}
+		if ftype != "feedback" {
+			t.Errorf("type = %q", ftype)
+		}
+		if body != "\nStop asking for approval." {
+			t.Errorf("body = %q", body)
+		}
+	})
+
+	t.Run("without_frontmatter", func(t *testing.T) {
+		raw := "# Just plain markdown\n\nSome content here."
+		name, desc, ftype, body := parseFrontmatter(raw)
+		if name != "" || desc != "" || ftype != "" {
+			t.Errorf("expected empty fields, got name=%q desc=%q type=%q", name, desc, ftype)
+		}
+		if body != raw {
+			t.Errorf("body should equal raw input")
+		}
+	})
+
+	t.Run("quoted_values", func(t *testing.T) {
+		raw := "---\nname: \"Quoted name\"\ntype: 'single'\n---\nBody."
+		name, _, ftype, _ := parseFrontmatter(raw)
+		if name != "Quoted name" {
+			t.Errorf("name = %q, want Quoted name", name)
+		}
+		if ftype != "single" {
+			t.Errorf("type = %q, want single", ftype)
+		}
+	})
+}
+
+func TestSkipFile(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"MEMORY.md", true},
+		{"memory.md", true},
+		{"plan_unified.md", true},
+		{"plan_something.md", true},
+		{"research_01_sqlite.md", true},
+		{"feedback_autonomous.md", false},
+		{"project_architecture.md", false},
+		{"reference_services.md", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := skipFile(tc.name)
+			if got != tc.want {
+				t.Errorf("skipFile(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsStub(t *testing.T) {
+	if !isStub("short") {
+		t.Error("expected short content to be stub")
+	}
+	if !isStub("Migrated to Ghost MCP. Run ghost_project_context.") {
+		t.Error("expected migration stub to be detected")
+	}
+	if isStub("This is a real memory with substantial content about the project architecture.") {
+		t.Error("expected real content to not be stub")
+	}
+}
+
+func TestMapCategory(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"feedback", "preference"},
+		{"Feedback", "preference"},
+		{"project", "architecture"},
+		{"reference", "fact"},
+		{"pattern", "pattern"},
+		{"decision", "decision"},
+		{"gotcha", "gotcha"},
+		{"user", "preference"},
+		{"unknown", "fact"},
+		{"", "fact"},
+	}
+	for _, tc := range cases {
+		got := mapCategory(tc.in)
+		if got != tc.want {
+			t.Errorf("mapCategory(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestImportanceForType(t *testing.T) {
+	if got := importanceForType("feedback"); got != 0.9 {
+		t.Errorf("feedback importance = %v, want 0.9", got)
+	}
+	if got := importanceForType("project"); got != 0.8 {
+		t.Errorf("project importance = %v, want 0.8", got)
+	}
+	if got := importanceForType("unknown"); got != defaultImportance {
+		t.Errorf("unknown importance = %v, want %v", got, defaultImportance)
+	}
+}
+
+func TestParseMemoryFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Feedback file with frontmatter.
+	writeTempFile(t, dir, "feedback_autonomous.md", `---
+name: Work autonomously
+description: Keep pushing forward without asking permission
+type: feedback
+---
+Stop asking for approval. Pick the next task and do it.
+
+**Why:** User finds it disruptive when pausing to ask.
+**How to apply:** After completing a task, start the next one.`)
+
+	// Plain markdown without frontmatter.
+	writeTempFile(t, dir, "ghost-capabilities.md", `# Ghost Capabilities Reference
+
+## 9 Modes
+Ghost supports 9 operating modes for different tasks.`)
+
+	// MEMORY.md should be skipped.
+	writeTempFile(t, dir, "MEMORY.md", `# Memory Index
+- [feedback_autonomous.md](feedback_autonomous.md)`)
+
+	// Plan file should be skipped.
+	writeTempFile(t, dir, "plan_unified.md", `# Unified Plan
+Step 1: do things.`)
+
+	// Research file should be skipped.
+	writeTempFile(t, dir, "research_01_sqlite.md", `# SQLite Research
+Lots of content here.`)
+
+	// Stub file should be skipped.
+	writeTempFile(t, dir, "code-review.md", `Migrated to Ghost MCP.`)
+
+	t.Run("feedback_with_frontmatter", func(t *testing.T) {
+		content, cat, imp, skip, err := ParseMemoryFile(filepath.Join(dir, "feedback_autonomous.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if skip {
+			t.Fatal("should not skip")
+		}
+		if cat != "preference" {
+			t.Errorf("category = %q, want preference", cat)
+		}
+		if imp != 0.9 {
+			t.Errorf("importance = %v, want 0.9", imp)
+		}
+		if !strings.Contains(content, "Work autonomously") {
+			t.Errorf("content missing name header: %q", content[:80])
+		}
+		if !strings.Contains(content, "Stop asking for approval") {
+			t.Errorf("content missing body")
+		}
+	})
+
+	t.Run("plain_markdown", func(t *testing.T) {
+		content, cat, imp, skip, err := ParseMemoryFile(filepath.Join(dir, "ghost-capabilities.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if skip {
+			t.Fatal("should not skip")
+		}
+		if cat != "fact" {
+			t.Errorf("category = %q, want fact", cat)
+		}
+		if imp != defaultImportance {
+			t.Errorf("importance = %v, want %v", imp, defaultImportance)
+		}
+		if !strings.Contains(content, "9 Modes") {
+			t.Error("content missing body")
+		}
+	})
+
+	t.Run("skip_memory_md", func(t *testing.T) {
+		_, _, _, skip, err := ParseMemoryFile(filepath.Join(dir, "MEMORY.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !skip {
+			t.Error("MEMORY.md should be skipped")
+		}
+	})
+
+	t.Run("skip_plan", func(t *testing.T) {
+		_, _, _, skip, err := ParseMemoryFile(filepath.Join(dir, "plan_unified.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !skip {
+			t.Error("plan file should be skipped")
+		}
+	})
+
+	t.Run("skip_research", func(t *testing.T) {
+		_, _, _, skip, err := ParseMemoryFile(filepath.Join(dir, "research_01_sqlite.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !skip {
+			t.Error("research file should be skipped")
+		}
+	})
+
+	t.Run("skip_stub", func(t *testing.T) {
+		_, _, _, skip, err := ParseMemoryFile(filepath.Join(dir, "code-review.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !skip {
+			t.Error("stub file should be skipped")
+		}
+	})
+}
+
+func TestImport_EndToEnd(t *testing.T) {
+	// Set up a fake Claude memory directory.
+	claudeDir := t.TempDir()
+	memDir := filepath.Join(claudeDir, "memory")
+	if err := os.MkdirAll(memDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTempFile(t, memDir, "feedback_autonomous.md", `---
+name: Work autonomously
+description: Keep pushing forward
+type: feedback
+---
+Stop asking for approval. Pick the next task and do it.`)
+
+	writeTempFile(t, memDir, "project_architecture.md", `---
+name: Architecture overview
+description: System design notes
+type: project
+---
+The system uses a 3-layer architecture with memory, orchestrator, and AI layers.`)
+
+	writeTempFile(t, memDir, "MEMORY.md", `# Index
+- [feedback_autonomous.md](feedback_autonomous.md)`)
+
+	writeTempFile(t, memDir, "plan_unified.md", `# Plan
+Should be skipped.`)
+
+	// Set up a real SQLite store.
+	db, err := memory.OpenDB(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	store := memory.NewStore(db, logger)
+
+	ctx := context.Background()
+	projectID := "test-project"
+	if err := store.EnsureProject(ctx, projectID, "/tmp/test", "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Call importFromDir directly since ClaudeMemoryDir won't find our temp dir.
+	imported, err := importFromDir(ctx, store, projectID, memDir, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if imported != 2 {
+		t.Errorf("imported = %d, want 2 (feedback + project)", imported)
+	}
+
+	// Verify memories are in store.
+	count, err := store.CountMemories(ctx, projectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count < 2 {
+		t.Errorf("store count = %d, want >= 2", count)
+	}
+
+	// Test idempotency — importing again should not increase count.
+	imported2, err := importFromDir(ctx, store, projectID, memDir, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Upsert may merge, so imported2 could be non-zero but count should stay same.
+	count2, err := store.CountMemories(ctx, projectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count2 != count {
+		t.Errorf("after re-import: count = %d, want %d (idempotent)", count2, count)
+	}
+	_ = imported2
+}
+
+func writeTempFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/claudeimport/import_test.go
+++ b/internal/claudeimport/import_test.go
@@ -290,7 +290,7 @@ Should be skipped.`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	store := memory.NewStore(db, logger)

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/wcatz/ghost/internal/claudeimport"
 	"github.com/wcatz/ghost/internal/memory"
 	"github.com/wcatz/ghost/internal/provider"
 )
@@ -30,6 +32,60 @@ type Server struct {
 	projectCh chan<- string // notify embedding worker of new memories
 }
 
+const mcpInstructions = `Ghost is a persistent memory daemon that remembers project knowledge across sessions. It is your primary memory system — use it proactively.
+
+## Workflow
+1. At session start, call ghost_list_projects to discover known projects.
+2. Call ghost_project_context with the project name to load accumulated knowledge.
+3. During work, save important discoveries with ghost_memory_save. Do NOT wait until the end of the session.
+4. Use ghost_memory_search to recall specific facts.
+5. No special action needed at session end — Ghost persists automatically.
+
+Ghost auto-imports Claude Code memory files (~/.claude/projects/*/memory/*.md) on first project contact. No manual migration is needed. Ghost has built-in upsert/merge deduplication — it is always safe to save, even if similar knowledge already exists.
+
+## When to Save (Proactive Triggers)
+Save immediately when any of these happen:
+- User corrects your approach or confirms a non-obvious choice → preference
+- You discover a bug, pitfall, or surprising behavior → gotcha
+- You learn how components connect or why something is designed a certain way → architecture
+- You see a recurring pattern or convention in the codebase → convention or pattern
+- A dependency version, API quirk, or external constraint is discovered → dependency
+- An important design choice is made with alternatives considered → use ghost_decision_record
+
+## What NOT to Save
+- Ephemeral debugging state ("tried X, didn't work")
+- Information easily derived from reading code or git history
+- Session-specific task progress (use ghost_task_* tools instead)
+- Content already documented in CLAUDE.md or README files
+
+## Memory Categories
+- architecture: system design, component relationships, data flow
+- decision: choices made and why (prefer ghost_decision_record for these)
+- pattern: recurring approaches, idioms, implementation techniques
+- convention: naming, formatting, workflow, branching rules
+- gotcha: pitfalls, bugs, surprising behavior, things that waste time
+- dependency: external requirements, version pins, API quirks
+- preference: user preferences, communication style, workflow choices
+- fact: general knowledge, network constants, node names, endpoints
+
+## Importance Scale
+- 1.0: Security rules, data-loss risks, never-do-this rules
+- 0.8: Architectural decisions, deployment topology, key integrations
+- 0.6: Useful patterns, recurring conventions, dependency notes
+- 0.4: Minor observations, one-off facts, nice-to-knows
+- Default: 0.7 if unsure
+
+## Cross-Project Knowledge
+- ghost_save_global: preferences and facts that apply across all repositories
+- ghost_search_all: find knowledge that might live in another project
+
+## Tasks
+- ghost_task_create: work items that should persist across sessions (bugs, features, follow-ups)
+- ghost_task_complete: mark done with optional notes
+
+## Project IDs
+Pass the project name (e.g. "ghost", "roller") as project_id. Ghost resolves names to internal IDs automatically.`
+
 // New creates and configures the MCP server with all Ghost tools.
 func New(store provider.MemoryStore, logger *slog.Logger) *Server {
 	s := &Server{
@@ -41,21 +97,7 @@ func New(store provider.MemoryStore, logger *slog.Logger) *Server {
 		Name:    "ghost",
 		Version: "0.1.0",
 	}, &mcp.ServerOptions{
-		Instructions: "Ghost is a persistent memory daemon that remembers project knowledge across sessions.\n\n" +
-			"## Workflow\n" +
-			"1. At session start, call ghost_list_projects to discover known projects.\n" +
-			"2. Call ghost_project_context with the project name to load accumulated knowledge.\n" +
-			"3. During work, save important discoveries with ghost_memory_save.\n" +
-			"4. Use ghost_memory_search to recall specific facts.\n\n" +
-			"## Memory Categories\n" +
-			"architecture (system design), decision (choices made), pattern (recurring approaches), " +
-			"convention (naming/formatting/workflow), gotcha (pitfalls/bugs), dependency (external requirements), " +
-			"preference (user preferences), fact (general knowledge).\n\n" +
-			"## Importance Scale\n" +
-			"1.0 critical (security, breaking changes) · 0.8 high (architectural decisions) · " +
-			"0.6 normal (useful patterns) · 0.4 low (minor observations). Default: 0.7.\n\n" +
-			"## Project IDs\n" +
-			"Pass the project name (e.g. \"ghost\", \"roller\") as project_id. Ghost resolves names to internal IDs automatically.",
+		Instructions: mcpInstructions,
 		Logger:       logger,
 	})
 
@@ -154,7 +196,7 @@ func (s *Server) registerTools() {
 
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_memory_save",
-		Description: "Save a memory about the project. Use this when you learn something important: architectural decisions, gotchas, conventions, patterns, or facts worth remembering across sessions.",
+		Description: "Save a memory about the project. Call this proactively when you discover gotchas, learn architectural patterns, receive user feedback worth preserving, or encounter surprising behavior. Do not wait to be asked — save immediately when something is worth remembering across sessions.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args saveArgs) (*mcp.CallToolResult, any, error) {
 		if args.ProjectID == "" || args.Content == "" {
 			return nil, nil, fmt.Errorf("project_id and content are required")
@@ -225,6 +267,19 @@ func (s *Server) registerTools() {
 			args.Limit = 20
 		}
 		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
+
+		// First-contact import: if project has zero memories, try importing
+		// from Claude Code's auto-memory files (read-only, one-time).
+		if cnt, cntErr := s.store.CountMemories(ctx, args.ProjectID); cntErr == nil && cnt == 0 {
+			if projects, lErr := s.store.ListProjects(ctx); lErr == nil {
+				for _, p := range projects {
+					if p.ID == args.ProjectID && filepath.IsAbs(p.Path) {
+						claudeimport.Import(ctx, s.store, args.ProjectID, p.Path, s.logger)
+						break
+					}
+				}
+			}
+		}
 
 		var sb strings.Builder
 
@@ -406,7 +461,7 @@ func (s *Server) registerTools() {
 
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_task_create",
-		Description: "Create a task for a project. Use to track planned work, bugs, or action items.",
+		Description: "Create a task for a project. Use for work items that should survive across sessions — bugs to fix, features to implement, follow-ups to revisit.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args taskCreateArgs) (*mcp.CallToolResult, any, error) {
 		if args.ProjectID == "" || args.Title == "" {
 			return nil, nil, fmt.Errorf("project_id and title are required")
@@ -492,7 +547,7 @@ func (s *Server) registerTools() {
 
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_decision_record",
-		Description: "Record an architectural or design decision with rationale and alternatives considered. Also saved as a memory for future recall.",
+		Description: "Record an architectural or design decision with rationale and alternatives considered. Use this instead of ghost_memory_save when a choice was made between alternatives. Also saved as a memory for future recall.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args decisionRecordArgs) (*mcp.CallToolResult, any, error) {
 		if args.ProjectID == "" || args.Title == "" || args.Decision == "" || args.Rationale == "" {
 			return nil, nil, fmt.Errorf("project_id, title, decision, and rationale are required")

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -41,7 +41,21 @@ func New(store provider.MemoryStore, logger *slog.Logger) *Server {
 		Name:    "ghost",
 		Version: "0.1.0",
 	}, &mcp.ServerOptions{
-		Instructions: "Ghost is a persistent memory daemon. Use these tools to search, save, and manage project memories across sessions.",
+		Instructions: "Ghost is a persistent memory daemon that remembers project knowledge across sessions.\n\n" +
+			"## Workflow\n" +
+			"1. At session start, call ghost_list_projects to discover known projects.\n" +
+			"2. Call ghost_project_context with the project name to load accumulated knowledge.\n" +
+			"3. During work, save important discoveries with ghost_memory_save.\n" +
+			"4. Use ghost_memory_search to recall specific facts.\n\n" +
+			"## Memory Categories\n" +
+			"architecture (system design), decision (choices made), pattern (recurring approaches), " +
+			"convention (naming/formatting/workflow), gotcha (pitfalls/bugs), dependency (external requirements), " +
+			"preference (user preferences), fact (general knowledge).\n\n" +
+			"## Importance Scale\n" +
+			"1.0 critical (security, breaking changes) · 0.8 high (architectural decisions) · " +
+			"0.6 normal (useful patterns) · 0.4 low (minor observations). Default: 0.7.\n\n" +
+			"## Project IDs\n" +
+			"Pass the project name (e.g. \"ghost\", \"roller\") as project_id. Ghost resolves names to internal IDs automatically.",
 		Logger:       logger,
 	})
 
@@ -530,6 +544,32 @@ func (s *Server) registerTools() {
 			sb.WriteString("**Embeddings:** disabled\n")
 		}
 
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: sb.String()}},
+		}, nil, nil
+	})
+
+	// ghost_list_projects — list all known projects.
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:        "ghost_list_projects",
+		Description: "List all projects Ghost knows about with their names, IDs, paths, and memory counts. Use at session start to find the project_id for the current codebase.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct{}) (*mcp.CallToolResult, any, error) {
+		projects, err := s.store.ListProjects(ctx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("list projects: %w", err)
+		}
+		if len(projects) == 0 {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "No projects registered yet."}},
+			}, nil, nil
+		}
+
+		var sb strings.Builder
+		sb.WriteString("## Ghost Projects\n\n")
+		for _, p := range projects {
+			count, _ := s.store.CountMemories(ctx, p.ID)
+			sb.WriteString(fmt.Sprintf("- **%s** (id: `%s`, path: `%s`) — %d memories\n", p.Name, p.ID, p.Path, count))
+		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: sb.String()}},
 		}, nil, nil

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -568,7 +568,7 @@ func (s *Server) registerTools() {
 		sb.WriteString("## Ghost Projects\n\n")
 		for _, p := range projects {
 			count, _ := s.store.CountMemories(ctx, p.ID)
-			sb.WriteString(fmt.Sprintf("- **%s** (id: `%s`, path: `%s`) — %d memories\n", p.Name, p.ID, p.Path, count))
+			fmt.Fprintf(&sb, "- **%s** (id: `%s`, path: `%s`) — %d memories\n", p.Name, p.ID, p.Path, count)
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: sb.String()}},

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -274,7 +274,7 @@ func (s *Server) registerTools() {
 			if projects, lErr := s.store.ListProjects(ctx); lErr == nil {
 				for _, p := range projects {
 					if p.ID == args.ProjectID && filepath.IsAbs(p.Path) {
-						claudeimport.Import(ctx, s.store, args.ProjectID, p.Path, s.logger)
+						_, _ = claudeimport.Import(ctx, s.store, args.ProjectID, p.Path, s.logger)
 						break
 					}
 				}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -89,6 +90,8 @@ func (s *Store) ListProjects(ctx context.Context) ([]Project, error) {
 }
 
 // EnsureProject creates a project record if it doesn't exist.
+// When called with an absolute path, it auto-merges any same-name project
+// that was created with a non-absolute path (e.g., by MCP using name-as-ID).
 func (s *Store) EnsureProject(ctx context.Context, id, path, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -105,7 +108,77 @@ func (s *Store) EnsureProject(ctx context.Context, id, path, name string) error 
 	_, err = s.db.ExecContext(ctx, `
 		INSERT OR IGNORE INTO ghost_state (project_id) VALUES (?)
 	`, id)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Auto-merge: if this project has a real filesystem path, look for
+	// a same-name project created by MCP with a non-absolute path.
+	if path != id && filepath.IsAbs(path) {
+		var dupID string
+		scanErr := s.db.QueryRowContext(ctx,
+			`SELECT id FROM projects WHERE name = ? AND id != ? AND path NOT LIKE '/%' LIMIT 1`,
+			name, id).Scan(&dupID)
+		if scanErr == nil && dupID != "" {
+			if mergeErr := s.mergeProjectLocked(ctx, dupID, id); mergeErr != nil {
+				s.logger.Error("auto-merge failed", "old_id", dupID, "new_id", id, "error", mergeErr)
+			}
+		}
+	}
+
+	return nil
+}
+
+// MergeProject reassigns all child records from oldID to newID, then deletes
+// the old project row. Use this to unify duplicate project entries.
+func (s *Store) MergeProject(ctx context.Context, oldID, newID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mergeProjectLocked(ctx, oldID, newID)
+}
+
+func (s *Store) mergeProjectLocked(ctx context.Context, oldID, newID string) error {
+	if oldID == newID {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin merge tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Reassign all child records from old project to new.
+	stmts := []string{
+		`UPDATE memories SET project_id = ? WHERE project_id = ?`,
+		`UPDATE conversations SET project_id = ? WHERE project_id = ?`,
+		`UPDATE tasks SET project_id = ? WHERE project_id = ?`,
+		`UPDATE decisions SET project_id = ? WHERE project_id = ?`,
+		`UPDATE token_usage SET project_id = ? WHERE project_id = ?`,
+		`UPDATE audit_log SET project_id = ? WHERE project_id = ?`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.ExecContext(ctx, stmt, newID, oldID); err != nil {
+			return fmt.Errorf("merge reassign: %w", err)
+		}
+	}
+
+	// Delete old project's ghost_state (newID already has its own).
+	if _, err := tx.ExecContext(ctx, `DELETE FROM ghost_state WHERE project_id = ?`, oldID); err != nil {
+		return fmt.Errorf("merge delete ghost_state: %w", err)
+	}
+
+	// Delete the old project row.
+	if _, err := tx.ExecContext(ctx, `DELETE FROM projects WHERE id = ?`, oldID); err != nil {
+		return fmt.Errorf("merge delete project: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("merge commit: %w", err)
+	}
+
+	s.logger.Info("merged duplicate project", "old_id", oldID, "new_id", newID)
+	return nil
 }
 
 // ResolveProjectByName looks up a project by name and returns its hash ID.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1215,3 +1215,108 @@ func TestStoreGetLatestConversationNoRows(t *testing.T) {
 		t.Errorf("expected sql.ErrNoRows, got %v", err)
 	}
 }
+
+func TestMergeProject(t *testing.T) {
+	s := testStore(t) // creates testProject ("test-project") at "/tmp/test"
+	ctx := context.Background()
+
+	// Create an MCP-style duplicate with name-as-ID.
+	if err := s.EnsureProject(ctx, "test", "test", "dup-project"); err != nil {
+		t.Fatalf("EnsureProject dup: %v", err)
+	}
+
+	// Seed data under the duplicate project.
+	memID, _, err := s.Upsert(ctx, "test", "fact", "MCP-created memory about deployment", "mcp", 0.7, []string{})
+	if err != nil {
+		t.Fatalf("Upsert under dup: %v", err)
+	}
+	_, err = s.CreateTask(ctx, "test", "Fix MCP task", "", 2)
+	if err != nil {
+		t.Fatalf("CreateTask under dup: %v", err)
+	}
+
+	// Merge old→new.
+	if err := s.MergeProject(ctx, "test", testProject); err != nil {
+		t.Fatalf("MergeProject: %v", err)
+	}
+
+	// Memory should now belong to testProject.
+	mems, err := s.GetByIDs(ctx, []string{memID})
+	if err != nil {
+		t.Fatalf("GetByIDs: %v", err)
+	}
+	if len(mems) != 1 || mems[0].ProjectID != testProject {
+		t.Errorf("expected memory reassigned to %q, got project_id=%q", testProject, mems[0].ProjectID)
+	}
+
+	// Old project should be gone.
+	projects, _ := s.ListProjects(ctx)
+	for _, p := range projects {
+		if p.ID == "test" {
+			t.Error("old project should be deleted after merge")
+		}
+	}
+
+	// Tasks should be reassigned.
+	tasks, _ := s.ListTasks(ctx, testProject, "", 30)
+	found := false
+	for _, task := range tasks {
+		if task.Title == "Fix MCP task" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("task not merged to new project")
+	}
+}
+
+func TestMergeProject_SameID(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	if err := s.MergeProject(ctx, testProject, testProject); err != nil {
+		t.Fatalf("MergeProject same ID should be no-op: %v", err)
+	}
+}
+
+func TestEnsureProject_AutoMerge(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Simulate MCP creating a project with name-as-ID.
+	if err := s.EnsureProject(ctx, "myproject", "myproject", "myproject"); err != nil {
+		t.Fatalf("EnsureProject MCP: %v", err)
+	}
+
+	// Save a memory under the MCP project.
+	_, _, err := s.Upsert(ctx, "myproject", "fact", "deployed on k8s cluster alpha-7", "mcp", 0.8, []string{})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Simulate orchestrator creating the real project (abs path, hash ID).
+	hashID := "abc123def456" // deterministic fake hash
+	if err := s.EnsureProject(ctx, hashID, "/home/wayne/git/myproject", "myproject"); err != nil {
+		t.Fatalf("EnsureProject orchestrator: %v", err)
+	}
+
+	// The MCP project should have been auto-merged.
+	projects, _ := s.ListProjects(ctx)
+	for _, p := range projects {
+		if p.ID == "myproject" {
+			t.Error("MCP project should have been merged away")
+		}
+	}
+
+	// Memory should now be under the hash ID.
+	mems, _ := s.GetTopMemories(ctx, hashID, 10)
+	found := false
+	for _, m := range mems {
+		if strings.Contains(m.Content, "alpha-7") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected MCP memory to be reassigned to hash-ID project")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"sync"
 
+	"github.com/wcatz/ghost/internal/claudeimport"
 	"github.com/wcatz/ghost/internal/config"
 	"github.com/wcatz/ghost/internal/project"
 	"github.com/wcatz/ghost/internal/prompt"
@@ -80,11 +81,19 @@ func (o *Orchestrator) StartSession(projectPath string) (*Session, error) {
 	o.sessions[projCtx.ID] = s
 	o.logger.Info("session started", "project", projCtx.Name, "path", projCtx.Path, "id", projCtx.ID)
 
-	// Cold-start onboarding: if this project has zero memories, extract seed
-	// memories from README, CLAUDE.md, file tree via a background Haiku call.
+	// Cold-start: import Claude Code memories first, fall back to LLM onboarding.
 	count, err := o.store.CountMemories(ctx, projCtx.ID)
 	if err == nil && count == 0 {
-		go onboardProject(context.Background(), o.client, o.store, projCtx, o.logger)
+		go func() {
+			bgCtx := context.Background()
+			imported, importErr := claudeimport.Import(bgCtx, o.store, projCtx.ID, projCtx.Path, o.logger)
+			if importErr != nil {
+				o.logger.Warn("claude memory import failed", "project", projCtx.Name, "error", importErr)
+			}
+			if imported == 0 && o.client != nil {
+				onboardProject(bgCtx, o.client, o.store, projCtx, o.logger)
+			}
+		}()
 	}
 
 	return s, nil

--- a/internal/project/context.go
+++ b/internal/project/context.go
@@ -26,6 +26,12 @@ type Context struct {
 	ReadmeSummary string // first 500 chars of README.md
 }
 
+// HashID returns a deterministic 12-hex-char ID for the given input string.
+func HashID(input string) string {
+	h := sha256.Sum256([]byte(input))
+	return fmt.Sprintf("%x", h[:6])
+}
+
 // Detect scans a project directory and builds context.
 func Detect(path string) (*Context, error) {
 	absPath, err := filepath.Abs(path)
@@ -48,9 +54,8 @@ func Detect(path string) (*Context, error) {
 		return nil, fmt.Errorf("not a directory: %s", absPath)
 	}
 
-	h := sha256.Sum256([]byte(absPath))
 	ctx := &Context{
-		ID:   fmt.Sprintf("%x", h[:6]),
+		ID:   HashID(absPath),
 		Name: filepath.Base(absPath),
 		Path: absPath,
 	}

--- a/internal/project/context_test.go
+++ b/internal/project/context_test.go
@@ -363,3 +363,18 @@ func TestContext_AllFieldsAccessible(t *testing.T) {
 		t.Error("LastCommits field not accessible")
 	}
 }
+
+func TestHashID(t *testing.T) {
+	id := HashID("/home/wayne/git/ghost")
+	if len(id) != 12 {
+		t.Errorf("expected 12-char ID, got len=%d: %q", len(id), id)
+	}
+	// Deterministic.
+	if id2 := HashID("/home/wayne/git/ghost"); id != id2 {
+		t.Errorf("not deterministic: %q vs %q", id, id2)
+	}
+	// Different inputs produce different IDs.
+	if id3 := HashID("/home/wayne/git/other"); id == id3 {
+		t.Error("different inputs produced same ID")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -78,6 +78,7 @@ type MemoryStore interface {
 	ListProjects(ctx context.Context) ([]memory.Project, error)
 	EnsureProject(ctx context.Context, id, path, name string) error
 	ResolveProjectByName(ctx context.Context, name string) (string, error)
+	MergeProject(ctx context.Context, oldID, newID string) error
 
 	// Conversation persistence
 	CreateConversation(ctx context.Context, projectID, mode string) (string, error)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -98,6 +98,7 @@ func (m *mockStore) ListDecisions(_ context.Context, _, _ string, _ int) ([]memo
 }
 func (m *mockStore) ListProjects(_ context.Context) ([]memory.Project, error) { return nil, nil }
 func (m *mockStore) EnsureProject(_ context.Context, _, _, _ string) error    { return nil }
+func (m *mockStore) MergeProject(_ context.Context, _, _ string) error        { return nil }
 func (m *mockStore) ResolveProjectByName(_ context.Context, _ string) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
## Summary

- **Claude memory auto-import**: new `internal/claudeimport/` package reads Claude Code's `~/.claude/projects/*/memory/*.md` files on first project contact. Read-only — never modifies Claude's files. Hooks into both CLI cold-start (orchestrator) and MCP first-contact (ghost_project_context).
- **Comprehensive MCP instructions**: upgraded `ServerOptions.Instructions` from 15 lines to full guidance covering proactive save triggers, category examples, importance scale, cross-project workflows. Any Ghost user gets the full experience without manual CLAUDE.md edits.
- **Improved tool descriptions**: ghost_memory_save, ghost_decision_record, ghost_task_create now encourage proactive usage.
- **ghost_list_projects tool**: new MCP tool for session-start project discovery.
- **Duplicate project auto-merge**: when CLI encounters a project previously created by MCP with name-only ID, auto-merges all child records.
- **README**: updated MCP tools table (12→13), documented claudeimport in architecture, added auto-import to feature list.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` all pass (19 new tests in claudeimport)
- [x] Binary builds (`CGO_ENABLED=0`)
- [x] VSCode extension compiles
- [ ] CI checks pass
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project listing tool with per-project memory counts and a clear "no projects" message.
  * Automatic import of Claude Code memories on first project contact.
  * Deterministic short-hash IDs for project contexts.

* **Bug Fixes**
  * Automatic detection and safe merging of duplicate projects so memories consolidate.

* **Docs**
  * Updated user-facing MCP/server guidance and workflow text.

* **Tests**
  * New tests for project merging, Claude import, and hash-ID behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->