### PR TITLE
feat(telegram): remote control with streaming, active sessions, voice routing

### DIFF
--- a/internal/telegram/approval.go
+++ b/internal/telegram/approval.go
@@ -25,11 +25,15 @@ type approvalState struct {
 
 // SetServerAddr configures the Ghost server address for API calls.
 func (tb *Bot) SetServerAddr(addr string) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
 	tb.serverAddr = addr
 }
 
 // SetServerToken configures the bearer token for Ghost server API auth.
 func (tb *Bot) SetServerToken(token string) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
 	tb.serverToken = token
 }
 

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -375,7 +375,7 @@ func (tb *Bot) handleMemoryAdd(ctx context.Context, b *bot.Bot, update *models.U
 	if merged {
 		action = "Merged into existing"
 	}
-	tb.reply(ctx, b, update, fmt.Sprintf("✅ %s memory `%s`", action, mdv2.Esc(id[:8])))
+	tb.reply(ctx, b, update, fmt.Sprintf("✅ %s memory `%s`", action, mdv2.Esc(shortID(id))))
 }
 
 func (tb *Bot) handleMemoryDelete(ctx context.Context, b *bot.Bot, update *models.Update, args []string) {
@@ -762,28 +762,6 @@ func (tb *Bot) reply(ctx context.Context, b *bot.Bot, update *models.Update, tex
 	}
 }
 
-// replyText sends plain text with no parse mode — safe for unescaped content such
-// as raw Claude responses that contain standard Markdown but are not MarkdownV2-escaped.
-func (tb *Bot) replyText(ctx context.Context, b *bot.Bot, update *models.Update, text string) {
-	if update.Message == nil {
-		return
-	}
-	chatID := update.Message.Chat.ID
-	for _, chunk := range mdv2.Split(text, telegramMsgMax) {
-		_, err := b.SendMessage(ctx, &bot.SendMessageParams{
-			ChatID: chatID,
-			Text:   chunk,
-			LinkPreviewOptions: &models.LinkPreviewOptions{
-				IsDisabled: bot.True(),
-			},
-		})
-		if err != nil {
-			tb.logger.Error("telegram send (plain)", "error", err, "chat_id", chatID)
-			return
-		}
-	}
-}
-
 // SendAlertToAll sends a formatted P0/P1 GitHub notification alert to all allowed users.
 // Includes the priority emoji, repo/title, reason, and an inline button linking to the PR/issue.
 func (tb *Bot) SendAlertToAll(ctx context.Context, n gh.Notification) {
@@ -883,6 +861,14 @@ func ghAPIToHTML(apiURL, subjectType string) string {
 		return "" // couldn't convert
 	}
 	return s
+}
+
+// shortID returns the first 8 chars of an ID, safe for any length.
+func shortID(id string) string {
+	if len(id) <= 8 {
+		return id
+	}
+	return id[:8]
 }
 
 func truncate(s string, max int) string {

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -46,8 +46,12 @@ type Bot struct {
 	stt             STTProvider   // optional voice transcription
 	approval        approvalState // pending approval tracking
 	mu              sync.Mutex
-	pendingChat     map[int64]string // chatID → sessionID for reply routing
-	sessionCosts    map[string]string // sessionID → last known cost string
+	pendingChat     map[int64]string            // chatID → sessionID for reply routing
+	sessionCosts    map[string]string            // sessionID → last known cost string
+	activeSession   map[int64]string             // chatID → sessionID for free-text routing
+	activeName      map[int64]string             // chatID → project display name
+	lastThinking    map[int64]string             // chatID → last thinking text
+	lastDiffs       map[int64][]map[string]string // chatID → last file diffs
 }
 
 // GoogleProvider is the interface for Google Calendar/Gmail access.
@@ -73,8 +77,12 @@ func New(cfg Config, store provider.MemoryStore, ghMonitor *gh.Monitor, sched *s
 		logger:     logger,
 		token:      cfg.Token,
 		allowedIDs:  make(map[int64]bool, len(cfg.AllowedIDs)),
-		pendingChat:  make(map[int64]string),
-		sessionCosts: make(map[string]string),
+		pendingChat:   make(map[int64]string),
+		sessionCosts:  make(map[string]string),
+		activeSession: make(map[int64]string),
+		activeName:    make(map[int64]string),
+		lastThinking:  make(map[int64]string),
+		lastDiffs:     make(map[int64][]map[string]string),
 	}
 
 	for _, id := range cfg.AllowedIDs {
@@ -103,11 +111,16 @@ func New(cfg Config, store provider.MemoryStore, ghMonitor *gh.Monitor, sched *s
 	b.RegisterHandler(bot.HandlerTypeMessageText, "chat", bot.MatchTypeCommand, tb.handleChat)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "mode", bot.MatchTypeCommand, tb.handleMode)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "cost", bot.MatchTypeCommand, tb.handleCost)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "use", bot.MatchTypeCommand, tb.handleUse)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "detach", bot.MatchTypeCommand, tb.handleDetach)
 
 	// Callback query handlers.
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "approve:", bot.MatchTypePrefix, tb.handleApprovalCallback)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "deny:", bot.MatchTypePrefix, tb.handleApprovalCallback)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "chat:", bot.MatchTypePrefix, tb.handleChatCallback)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "use:", bot.MatchTypePrefix, tb.handleUseCallback)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "thinking:", bot.MatchTypePrefix, tb.handleThinkingCallback)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "diff:", bot.MatchTypePrefix, tb.handleDiffCallback)
 
 	return tb, nil
 }
@@ -137,6 +150,8 @@ func (tb *Bot) registerCommands(ctx context.Context) {
 		{Command: "emails", Description: "Recent unread emails"},
 		{Command: "sessions", Description: "List active Ghost sessions"},
 		{Command: "chat", Description: "Chat with a session: /chat <id> <msg>"},
+		{Command: "use", Description: "Set active session: /use <id>"},
+		{Command: "detach", Description: "Detach active session"},
 		{Command: "mode", Description: "List or switch mode: /mode [name]"},
 		{Command: "cost", Description: "Show session cost: /cost <id>"},
 		{Command: "memory", Description: "Manage memories: search, add, delete"},
@@ -555,18 +570,27 @@ func (tb *Bot) handleEmails(ctx context.Context, b *bot.Bot, update *models.Upda
 func (tb *Bot) handleHelp(ctx context.Context, b *bot.Bot, update *models.Update) {
 	tb.reply(ctx, b, update, `*Ghost Commands*
 
+*Session Control*
+/sessions — List active Ghost sessions
+/chat — Chat with a session: /chat \<id\> \<msg\>
+/use — Set active session: /use \<id\>
+/detach — Detach active session
+/mode — List modes or switch: /mode \<id\> \<name\>
+/cost — Show session cost: /cost \<id\>
+
+*Notifications*
 /status — System status \+ notification summary
 /notifications — List unread GitHub notifications
 /meetings — Today's calendar with Meet links
 /emails — Recent unread emails
-/sessions — List active Ghost sessions
-/chat — Chat with a session
-/mode — List modes or switch: /mode \<id\> \<name\>
-/cost — Show session cost: /cost \<id\>
+
+*Other*
 /memory — Search, add, or delete memories
 /remind — Set a reminder
 /briefing — Get your morning briefing
-/help — This message`)
+/help — This message
+
+_When an active session is set, free\\-text and voice messages are sent directly to it\\._`)
 }
 
 func (tb *Bot) handleDefault(ctx context.Context, b *bot.Bot, update *models.Update) {
@@ -586,7 +610,123 @@ func (tb *Bot) handleDefault(ctx context.Context, b *bot.Bot, update *models.Upd
 	if tb.handlePendingChatReply(ctx, b, update) {
 		return
 	}
+	// Route free-text to active session if set.
+	if update.Message.Text != "" {
+		chatID := update.Message.Chat.ID
+		tb.mu.Lock()
+		sessionID := tb.activeSession[chatID]
+		projectName := tb.activeName[chatID]
+		tb.mu.Unlock()
+		if sessionID != "" {
+			tb.streamToSession(ctx, b, chatID, sessionID, projectName, update.Message.Text)
+			return
+		}
+	}
 	tb.reply(ctx, b, update, "Use /help to see available commands\\.")
+}
+
+// handleUse sets the active session for this chat.
+func (tb *Bot) handleUse(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if tb.serverAddr == "" {
+		tb.reply(ctx, b, update, "Ghost server not configured\\.")
+		return
+	}
+
+	parts := strings.Fields(update.Message.Text)
+	if len(parts) < 2 {
+		tb.reply(ctx, b, update, "Usage: `/use <session_id>`")
+		return
+	}
+
+	prefix := parts[1]
+	sessions, err := tb.fetchSessions()
+	if err != nil {
+		tb.reply(ctx, b, update, "Error: "+mdv2.Esc(err.Error()))
+		return
+	}
+
+	var fullID, projectName string
+	for _, s := range sessions {
+		if strings.HasPrefix(s.ID, prefix) {
+			fullID = s.ID
+			projectName = s.ProjectName
+			break
+		}
+	}
+	if fullID == "" {
+		tb.reply(ctx, b, update, "Session not found\\. Use /sessions to list\\.")
+		return
+	}
+
+	chatID := update.Message.Chat.ID
+	tb.mu.Lock()
+	tb.activeSession[chatID] = fullID
+	tb.activeName[chatID] = projectName
+	tb.mu.Unlock()
+
+	tb.sendWithKeyboard(ctx, b, chatID,
+		fmt.Sprintf("✅ Active session: *%s*\nFree\\-text messages will be sent to this session\\.", mdv2.Esc(projectName)))
+}
+
+// handleDetach clears the active session for this chat.
+func (tb *Bot) handleDetach(ctx context.Context, b *bot.Bot, update *models.Update) {
+	chatID := update.Message.Chat.ID
+	tb.mu.Lock()
+	_, had := tb.activeSession[chatID]
+	delete(tb.activeSession, chatID)
+	delete(tb.activeName, chatID)
+	tb.mu.Unlock()
+
+	if had {
+		tb.sendWithKeyboard(ctx, b, chatID, "✅ Session detached\\. Free\\-text messages disabled\\.")
+	} else {
+		tb.reply(ctx, b, update, "No active session to detach\\.")
+	}
+}
+
+// mainKeyboard returns the persistent reply keyboard based on active session state.
+func (tb *Bot) mainKeyboard(chatID int64) *models.ReplyKeyboardMarkup {
+	tb.mu.Lock()
+	name := tb.activeName[chatID]
+	tb.mu.Unlock()
+
+	row1 := []models.KeyboardButton{
+		{Text: "/sessions"},
+		{Text: "/status"},
+		{Text: "/briefing"},
+	}
+
+	kb := &models.ReplyKeyboardMarkup{
+		Keyboard:       [][]models.KeyboardButton{row1},
+		ResizeKeyboard: true,
+	}
+
+	if name != "" {
+		activeRow := []models.KeyboardButton{
+			{Text: "/detach"},
+			{Text: "/mode"},
+			{Text: "/cost"},
+		}
+		kb.Keyboard = [][]models.KeyboardButton{activeRow, row1}
+	}
+
+	return kb
+}
+
+// sendWithKeyboard sends a MarkdownV2 message with the persistent reply keyboard attached.
+func (tb *Bot) sendWithKeyboard(ctx context.Context, b *bot.Bot, chatID int64, text string) {
+	_, err := b.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:      chatID,
+		Text:        text,
+		ParseMode:   models.ParseModeMarkdown,
+		ReplyMarkup: tb.mainKeyboard(chatID),
+		LinkPreviewOptions: &models.LinkPreviewOptions{
+			IsDisabled: bot.True(),
+		},
+	})
+	if err != nil {
+		tb.logger.Error("telegram send with keyboard", "error", err, "chat_id", chatID)
+	}
 }
 
 // --- Helpers ---

--- a/internal/telegram/sessions.go
+++ b/internal/telegram/sessions.go
@@ -18,8 +18,11 @@ import (
 	"github.com/wcatz/ghost/internal/mode"
 )
 
-// httpClient is used for all outbound API calls to the Ghost server.
+// httpClient is used for short API calls to the Ghost server.
 var httpClient = &http.Client{Timeout: 30 * time.Second}
+
+// sseClient is used for SSE streams which can run for minutes during tool loops.
+var sseClient = &http.Client{Timeout: 10 * time.Minute}
 
 type apiSession struct {
 	ID          string `json:"id"`
@@ -64,6 +67,7 @@ func (tb *Bot) handleSessions(ctx context.Context, b *bot.Bot, update *models.Up
 			status, mdv2.Esc(shortID), mdv2.Esc(s.ProjectName), mdv2.Esc(s.Mode), s.Messages)
 		rows = append(rows, []models.InlineKeyboardButton{
 			{Text: fmt.Sprintf("💬 %s (%s)", s.ProjectName, shortID), CallbackData: "chat:" + s.ID},
+			{Text: "📌 Set active", CallbackData: "use:" + s.ID},
 		})
 	}
 
@@ -106,7 +110,7 @@ func (tb *Bot) handleChatCallback(ctx context.Context, b *bot.Bot, update *model
 	tb.mu.Unlock()
 }
 
-// handleChat sends a message to a specific Ghost session.
+// handleChat sends a message to a specific Ghost session with rich streaming.
 func (tb *Bot) handleChat(ctx context.Context, b *bot.Bot, update *models.Update) {
 	if tb.serverAddr == "" {
 		tb.reply(ctx, b, update, "Ghost server not configured\\.")
@@ -130,10 +134,11 @@ func (tb *Bot) handleChat(ctx context.Context, b *bot.Bot, update *models.Update
 		return
 	}
 
-	fullID := ""
+	var fullID, projectName string
 	for _, s := range sessions {
 		if strings.HasPrefix(s.ID, sessionID) {
 			fullID = s.ID
+			projectName = s.ProjectName
 			break
 		}
 	}
@@ -142,19 +147,8 @@ func (tb *Bot) handleChat(ctx context.Context, b *bot.Bot, update *models.Update
 		return
 	}
 
-	tb.sendTyping(ctx, update)
-
-	response, err := tb.sendChatMessage(fullID, message)
-	if err != nil {
-		tb.reply(ctx, b, update, "Error: "+mdv2.Esc(err.Error()))
-		return
-	}
-
-	if response == "" {
-		response = "(no response)"
-	}
-	// Claude's response is standard Markdown, not MarkdownV2-escaped — use plain text.
-	tb.replyText(ctx, b, update, response)
+	chatID := update.Message.Chat.ID
+	tb.streamToSession(ctx, b, chatID, fullID, projectName, message)
 }
 
 // handlePendingChatReply routes text replies to the pending chat session.
@@ -175,19 +169,18 @@ func (tb *Bot) handlePendingChatReply(ctx context.Context, b *bot.Bot, update *m
 		return false
 	}
 
-	tb.sendTyping(ctx, update)
-
-	response, err := tb.sendChatMessage(sessionID, message)
-	if err != nil {
-		tb.reply(ctx, b, update, "Error: "+mdv2.Esc(err.Error()))
-		return true
+	// Look up project name for the session.
+	projectName := sessionID[:8]
+	if sessions, err := tb.fetchSessions(); err == nil {
+		for _, s := range sessions {
+			if s.ID == sessionID {
+				projectName = s.ProjectName
+				break
+			}
+		}
 	}
 
-	if response == "" {
-		response = "(no response)"
-	}
-	// Claude's response is standard Markdown, not MarkdownV2-escaped — use plain text.
-	tb.replyText(ctx, b, update, response)
+	tb.streamToSession(ctx, b, chatID, sessionID, projectName, message)
 	return true
 }
 
@@ -217,67 +210,66 @@ func (tb *Bot) fetchSessions() ([]apiSession, error) {
 	return sessions, nil
 }
 
-// sendChatMessage sends a message to a Ghost session and collects the streamed response.
-func (tb *Bot) sendChatMessage(sessionID, message string) (string, error) {
+// streamChatMessage opens an SSE connection to a Ghost session and returns a channel
+// of parsed stream events. The channel is closed when the stream ends.
+func (tb *Bot) streamChatMessage(ctx context.Context, sessionID, message string) (<-chan streamEvent, error) {
 	payload, _ := json.Marshal(map[string]string{"message": message})
 	url := fmt.Sprintf("http://%s/api/v1/sessions/%s/send", tb.serverAddr, sessionID)
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
 	if err != nil {
-		return "", fmt.Errorf("create chat request: %w", err)
+		return nil, fmt.Errorf("create chat request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if tb.serverToken != "" {
 		req.Header.Set("Authorization", "Bearer "+tb.serverToken)
 	}
-	resp, err := httpClient.Do(req)
+	resp, err := sseClient.Do(req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("server returned %d: %s", resp.StatusCode, body)
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode, body)
 	}
 
-	// Parse SSE stream and collect assistant text.
-	var response strings.Builder
-	scanner := bufio.NewScanner(resp.Body)
-	var eventType string
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "event: ") {
-			eventType = strings.TrimPrefix(line, "event: ")
-			continue
+	ch := make(chan streamEvent, 64)
+	go func() {
+		defer close(ch)
+		defer func() { _ = resp.Body.Close() }()
+
+		scanner := bufio.NewScanner(resp.Body)
+		// Allow up to 1MB per SSE line (tool outputs can be large).
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		var eventType string
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "event: ") {
+				eventType = strings.TrimPrefix(line, "event: ")
+				continue
+			}
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			data := strings.TrimPrefix(line, "data: ")
+
+			// Skip events we don't display (tool_input_delta, tool_use_end).
+			switch eventType {
+			case "text", "thinking", "tool_use_start", "tool_result", "tool_diff", "done", "error":
+				evt := parseStreamData(eventType, data)
+				select {
+				case ch <- evt:
+				case <-ctx.Done():
+					return
+				}
+			}
 		}
-		if !strings.HasPrefix(line, "data: ") {
-			continue
-		}
-		data := strings.TrimPrefix(line, "data: ")
-		switch eventType {
-		case "text":
-			var payload struct {
-				Text string `json:"text"`
-			}
-			if json.Unmarshal([]byte(data), &payload) == nil {
-				response.WriteString(payload.Text)
-			}
-		case "done":
-			var payload struct {
-				SessionCost string `json:"session_cost"`
-			}
-			if json.Unmarshal([]byte(data), &payload) == nil && payload.SessionCost != "" {
-				tb.mu.Lock()
-				tb.sessionCosts[sessionID] = payload.SessionCost
-				tb.mu.Unlock()
-			}
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return response.String(), fmt.Errorf("stream read: %w", err)
-	}
-	return response.String(), nil
+	}()
+
+	return ch, nil
 }
 
 // createMemory POSTs a new memory to the Ghost server API.

--- a/internal/telegram/sessions.go
+++ b/internal/telegram/sessions.go
@@ -62,11 +62,11 @@ func (tb *Bot) handleSessions(ctx context.Context, b *bot.Bot, update *models.Up
 		if !s.Active {
 			status = "🔴"
 		}
-		shortID := s.ID[:8]
+		sid := shortID(s.ID)
 		fmt.Fprintf(&sb, "%s `%s`\n  %s \\| %s \\| %d msgs\n\n",
-			status, mdv2.Esc(shortID), mdv2.Esc(s.ProjectName), mdv2.Esc(s.Mode), s.Messages)
+			status, mdv2.Esc(sid), mdv2.Esc(s.ProjectName), mdv2.Esc(s.Mode), s.Messages)
 		rows = append(rows, []models.InlineKeyboardButton{
-			{Text: fmt.Sprintf("💬 %s (%s)", s.ProjectName, shortID), CallbackData: "chat:" + s.ID},
+			{Text: fmt.Sprintf("💬 %s (%s)", s.ProjectName, sid), CallbackData: "chat:" + s.ID},
 			{Text: "📌 Set active", CallbackData: "use:" + s.ID},
 		})
 	}
@@ -92,7 +92,7 @@ func (tb *Bot) handleChatCallback(ctx context.Context, b *bot.Bot, update *model
 		return
 	}
 	chatID := update.CallbackQuery.Message.Message.Chat.ID
-	shortID := sessionID[:8]
+	shortID := shortID(sessionID)
 	_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID:    chatID,
 		Text:      fmt.Sprintf("💬 Session `%s` selected.\nReply to this message with your prompt:", shortID),
@@ -170,7 +170,7 @@ func (tb *Bot) handlePendingChatReply(ctx context.Context, b *bot.Bot, update *m
 	}
 
 	// Look up project name for the session.
-	projectName := sessionID[:8]
+	projectName := shortID(sessionID)
 	if sessions, err := tb.fetchSessions(); err == nil {
 		for _, s := range sessions {
 			if s.ID == sessionID {
@@ -230,7 +230,7 @@ func (tb *Bot) streamChatMessage(ctx context.Context, sessionID, message string)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		_ = resp.Body.Close()
 		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode, body)
 	}
@@ -298,7 +298,7 @@ func (tb *Bot) createMemory(projectID, content string) (id string, merged bool, 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return "", false, fmt.Errorf("server returned %d: %s", resp.StatusCode, body)
 	}
 
@@ -346,7 +346,7 @@ func (tb *Bot) setSessionMode(sessionID, modeName string) (string, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return "", fmt.Errorf("server returned %d: %s", resp.StatusCode, body)
 	}
 
@@ -393,9 +393,9 @@ func (tb *Bot) handleMode(ctx context.Context, b *bot.Bot, update *models.Update
 		if len(sessions) > 0 {
 			sb.WriteString("\n*Session Modes*\n\n")
 			for _, s := range sessions {
-				shortID := s.ID[:8]
+				sid := shortID(s.ID)
 				fmt.Fprintf(&sb, "• `%s` %s → `%s`\n",
-					mdv2.Esc(shortID), mdv2.Esc(s.ProjectName), mdv2.Esc(s.Mode))
+					mdv2.Esc(sid), mdv2.Esc(s.ProjectName), mdv2.Esc(s.Mode))
 			}
 		}
 		sb.WriteString("\nSwitch: `/mode <session_id> <mode_name>`")
@@ -457,13 +457,13 @@ func (tb *Bot) handleCost(ctx context.Context, b *bot.Bot, update *models.Update
 		sb.WriteString("*Session Costs*\n\n")
 		tb.mu.Lock()
 		for _, s := range sessions {
-			shortID := s.ID[:8]
+			sid := shortID(s.ID)
 			cost, ok := tb.sessionCosts[s.ID]
 			if !ok {
 				cost = "no data yet"
 			}
 			fmt.Fprintf(&sb, "• `%s` %s — %s\n",
-				mdv2.Esc(shortID), mdv2.Esc(s.ProjectName), mdv2.Esc(cost))
+				mdv2.Esc(sid), mdv2.Esc(s.ProjectName), mdv2.Esc(cost))
 		}
 		tb.mu.Unlock()
 		sb.WriteString("\n_Costs update after each chat message\\._")
@@ -491,8 +491,8 @@ func (tb *Bot) handleCost(ctx context.Context, b *bot.Bot, update *models.Update
 		return
 	}
 
-	shortID := fullID[:8]
-	tb.reply(ctx, b, update, fmt.Sprintf("💰 Session `%s`: %s", mdv2.Esc(shortID), mdv2.Esc(cost)))
+	sid := shortID(fullID)
+	tb.reply(ctx, b, update, fmt.Sprintf("💰 Session `%s`: %s", mdv2.Esc(sid), mdv2.Esc(cost)))
 }
 
 // deleteMemory sends a DELETE request to remove a memory by ID.
@@ -513,7 +513,7 @@ func (tb *Bot) deleteMemory(memoryID string) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return fmt.Errorf("server returned %d: %s", resp.StatusCode, body)
 	}
 	return nil

--- a/internal/telegram/sessions_test.go
+++ b/internal/telegram/sessions_test.go
@@ -15,10 +15,14 @@ func testBot(t *testing.T, serverURL string) *Bot {
 	t.Helper()
 	addr := strings.TrimPrefix(serverURL, "http://")
 	return &Bot{
-		serverAddr:   addr,
-		serverToken:  "test-token",
-		pendingChat:  make(map[int64]string),
-		sessionCosts: make(map[string]string),
+		serverAddr:    addr,
+		serverToken:   "test-token",
+		pendingChat:   make(map[int64]string),
+		sessionCosts:  make(map[string]string),
+		activeSession: make(map[int64]string),
+		activeName:    make(map[int64]string),
+		lastThinking:  make(map[int64]string),
+		lastDiffs:     make(map[int64][]map[string]string),
 	}
 }
 
@@ -108,9 +112,9 @@ func TestFetchSessions_NoAuthToken(t *testing.T) {
 	}
 }
 
-// --- sendChatMessage ---
+// --- streamChatMessage ---
 
-func TestSendChatMessage_SSE(t *testing.T) {
+func TestStreamChatMessage_SSE(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
 			t.Errorf("expected POST, got %s", r.Method)
@@ -132,46 +136,67 @@ func TestSendChatMessage_SSE(t *testing.T) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprint(w, "event: text\ndata: {\"text\":\"Hello \"}\n\n")
+		_, _ = fmt.Fprint(w, "event: thinking\ndata: {\"text\":\"let me think...\"}\n\n")
+		_, _ = fmt.Fprint(w, "event: tool_use_start\ndata: {\"id\":\"t1\",\"name\":\"file_read\"}\n\n")
+		_, _ = fmt.Fprint(w, "event: tool_result\ndata: {\"id\":\"t1\",\"name\":\"file_read\",\"output\":\"ok\",\"duration\":\"320ms\"}\n\n")
 		_, _ = fmt.Fprint(w, "event: text\ndata: {\"text\":\"world!\"}\n\n")
 		_, _ = fmt.Fprint(w, "event: done\ndata: {\"session_cost\":\"$0.12\"}\n\n")
 	}))
 	defer server.Close()
 
-	origClient := httpClient
-	httpClient = server.Client()
-	t.Cleanup(func() { httpClient = origClient })
+	origClient := sseClient
+	sseClient = server.Client()
+	t.Cleanup(func() { sseClient = origClient })
 
 	tb := testBot(t, server.URL)
-	response, err := tb.sendChatMessage("session-abc", "hello ghost")
+	ctx := t.Context()
+	ch, err := tb.streamChatMessage(ctx, "session-abc", "hello ghost")
 	if err != nil {
-		t.Fatalf("sendChatMessage: %v", err)
-	}
-	if response != "Hello world!" {
-		t.Errorf("response = %q, want %q", response, "Hello world!")
+		t.Fatalf("streamChatMessage: %v", err)
 	}
 
-	// Verify cost was tracked.
-	tb.mu.Lock()
-	cost := tb.sessionCosts["session-abc"]
-	tb.mu.Unlock()
-	if cost != "$0.12" {
-		t.Errorf("session cost = %q, want %q", cost, "$0.12")
+	var events []streamEvent
+	for evt := range ch {
+		events = append(events, evt)
+	}
+
+	// Expected: text, thinking, tool_start, tool_result, text, done = 6 events.
+	if len(events) != 6 {
+		t.Fatalf("got %d events, want 6", len(events))
+	}
+	if events[0].Type != "text" || events[0].Text != "Hello " {
+		t.Errorf("event[0] = %+v", events[0])
+	}
+	if events[1].Type != "thinking" || events[1].Text != "let me think..." {
+		t.Errorf("event[1] = %+v", events[1])
+	}
+	if events[2].Type != "tool_start" || events[2].ToolName != "file_read" {
+		t.Errorf("event[2] = %+v", events[2])
+	}
+	if events[3].Type != "tool_result" || events[3].Duration != "320ms" {
+		t.Errorf("event[3] = %+v", events[3])
+	}
+	if events[4].Type != "text" || events[4].Text != "world!" {
+		t.Errorf("event[4] = %+v", events[4])
+	}
+	if events[5].Type != "done" || events[5].Cost != "$0.12" {
+		t.Errorf("event[5] = %+v", events[5])
 	}
 }
 
-func TestSendChatMessage_ServerError(t *testing.T) {
+func TestStreamChatMessage_ServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte("bad request"))
 	}))
 	defer server.Close()
 
-	origClient := httpClient
-	httpClient = server.Client()
-	t.Cleanup(func() { httpClient = origClient })
+	origClient := sseClient
+	sseClient = server.Client()
+	t.Cleanup(func() { sseClient = origClient })
 
 	tb := testBot(t, server.URL)
-	_, err := tb.sendChatMessage("session-abc", "test")
+	_, err := tb.streamChatMessage(t.Context(), "session-abc", "test")
 	if err == nil {
 		t.Fatal("expected error for 400 response")
 	}
@@ -180,7 +205,7 @@ func TestSendChatMessage_ServerError(t *testing.T) {
 	}
 }
 
-func TestSendChatMessage_EmptyResponse(t *testing.T) {
+func TestStreamChatMessage_EmptyResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
@@ -188,17 +213,23 @@ func TestSendChatMessage_EmptyResponse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	origClient := httpClient
-	httpClient = server.Client()
-	t.Cleanup(func() { httpClient = origClient })
+	origClient := sseClient
+	sseClient = server.Client()
+	t.Cleanup(func() { sseClient = origClient })
 
 	tb := testBot(t, server.URL)
-	response, err := tb.sendChatMessage("session-abc", "test")
+	ch, err := tb.streamChatMessage(t.Context(), "session-abc", "test")
 	if err != nil {
-		t.Fatalf("sendChatMessage: %v", err)
+		t.Fatalf("streamChatMessage: %v", err)
 	}
-	if response != "" {
-		t.Errorf("expected empty response, got %q", response)
+
+	var events []streamEvent
+	for evt := range ch {
+		events = append(events, evt)
+	}
+
+	if len(events) != 1 || events[0].Type != "done" {
+		t.Errorf("expected single done event, got %v", events)
 	}
 }
 

--- a/internal/telegram/stream.go
+++ b/internal/telegram/stream.go
@@ -26,6 +26,7 @@ type streamEvent struct {
 
 // toolLogEntry tracks a tool's progress in the status message.
 type toolLogEntry struct {
+	ID       string // tool call ID for correlation
 	Name     string
 	Status   string // "running", "done", "error", "approval"
 	Duration string // e.g. "0.3s"
@@ -210,6 +211,7 @@ func (tb *Bot) handleStreamEvt(st *streamState, evt streamEvent) bool {
 		return true
 	case "tool_start":
 		st.tools = append(st.tools, toolLogEntry{
+			ID:     evt.ToolID,
 			Name:   evt.ToolName,
 			Status: "running",
 		})
@@ -219,9 +221,13 @@ func (tb *Bot) handleStreamEvt(st *streamState, evt streamEvent) bool {
 		}
 		return true
 	case "tool_result":
-		// Update the matching tool entry.
+		// Update the matching tool entry by ID (falls back to name if ID empty).
 		for i := len(st.tools) - 1; i >= 0; i-- {
-			if st.tools[i].Name == evt.ToolName && st.tools[i].Status == "running" {
+			match := evt.ToolID != "" && st.tools[i].ID == evt.ToolID
+			if !match {
+				match = st.tools[i].Name == evt.ToolName && st.tools[i].Status == "running"
+			}
+			if match {
 				if evt.IsError {
 					st.tools[i].Status = "error"
 				} else {
@@ -431,7 +437,7 @@ func (tb *Bot) handleUseCallback(ctx context.Context, b *bot.Bot, update *models
 		}
 	}
 	if projectName == "" {
-		projectName = sessionID[:8]
+		projectName = shortID(sessionID)
 	}
 
 	tb.mu.Lock()

--- a/internal/telegram/stream.go
+++ b/internal/telegram/stream.go
@@ -1,0 +1,518 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+	"github.com/wcatz/ghost/internal/mdv2"
+)
+
+// streamEvent represents a parsed SSE event from the Ghost server.
+type streamEvent struct {
+	Type     string            // text, thinking, tool_start, tool_result, tool_diff, done, error
+	Text     string            // text content / error message
+	ToolName string            // tool name (for tool events)
+	ToolID   string            // tool ID (for correlation)
+	Duration string            // tool execution duration (e.g. "320ms")
+	IsError  bool              // tool result was an error
+	Cost     string            // session cost (on done)
+	Diff     map[string]string // file diff metadata (on tool_diff)
+}
+
+// toolLogEntry tracks a tool's progress in the status message.
+type toolLogEntry struct {
+	Name     string
+	Status   string // "running", "done", "error", "approval"
+	Duration string // e.g. "0.3s"
+}
+
+// streamState accumulates streaming data for a single chat interaction.
+type streamState struct {
+	project       string
+	tools         []toolLogEntry
+	thinkingLen   int
+	thinkingText  strings.Builder
+	responseText  strings.Builder
+	diffs         []map[string]string
+	cost          string
+	started       time.Time
+	lastStatus    string // last rendered status message (skip no-op edits)
+	statusMsgID   int
+	errText       string
+	tickInterval  time.Duration
+}
+
+const (
+	maxToolLogEntries = 10
+	maxStatusLen      = 3500 // leave room for MarkdownV2 overhead
+	defaultTick       = 2 * time.Second
+	backoffTick       = 5 * time.Second
+)
+
+// streamToSession sends a message to a Ghost session and displays real-time progress.
+func (tb *Bot) streamToSession(ctx context.Context, b *bot.Bot, chatID int64, sessionID, projectName, message string) {
+	// Send initial status message.
+	st := &streamState{
+		project:      projectName,
+		started:      time.Now(),
+		tickInterval: defaultTick,
+	}
+
+	statusMsg, err := b.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:    chatID,
+		Text:      fmt.Sprintf("⚡ Sending to %s\\.\\.\\.", mdv2.Esc(projectName)),
+		ParseMode: models.ParseModeMarkdown,
+		LinkPreviewOptions: &models.LinkPreviewOptions{
+			IsDisabled: bot.True(),
+		},
+	})
+	if err != nil {
+		tb.logger.Error("telegram stream status", "error", err)
+		return
+	}
+	st.statusMsgID = statusMsg.ID
+
+	// Open SSE stream.
+	events, err := tb.streamChatMessage(ctx, sessionID, message)
+	if err != nil {
+		tb.editStatus(ctx, b, chatID, st, fmt.Sprintf("❌ Error: %s", mdv2.Esc(err.Error())))
+		return
+	}
+
+	// Event loop with periodic status edits.
+	ticker := time.NewTicker(st.tickInterval)
+	defer ticker.Stop()
+	dirty := false
+
+	for {
+		select {
+		case evt, ok := <-events:
+			if !ok {
+				// Channel closed — stream complete.
+				goto done
+			}
+			dirty = tb.handleStreamEvt(st, evt) || dirty
+
+			// On significant events, trigger an immediate status update.
+			switch evt.Type {
+			case "tool_start", "tool_result", "error", "done":
+				if dirty {
+					tb.editStatus(ctx, b, chatID, st, formatStatusMessage(st))
+					dirty = false
+					ticker.Reset(st.tickInterval)
+				}
+			}
+
+			if evt.Type == "done" || evt.Type == "error" {
+				goto done
+			}
+
+		case <-ticker.C:
+			if dirty {
+				tb.editStatus(ctx, b, chatID, st, formatStatusMessage(st))
+				dirty = false
+			}
+
+		case <-ctx.Done():
+			goto done
+		}
+	}
+
+done:
+	// Delete the status message.
+	_, _ = b.DeleteMessage(ctx, &bot.DeleteMessageParams{
+		ChatID:    chatID,
+		MessageID: st.statusMsgID,
+	})
+
+	// Send error if stream failed.
+	if st.errText != "" {
+		_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: chatID,
+			Text:   "❌ " + st.errText,
+		})
+		return
+	}
+
+	// Send the final response.
+	response := st.responseText.String()
+	if response == "" {
+		response = "(no response)"
+	}
+
+	// Build inline buttons for post-response actions.
+	var buttons [][]models.InlineKeyboardButton
+	if st.thinkingLen > 0 {
+		buttons = append(buttons, []models.InlineKeyboardButton{
+			{Text: fmt.Sprintf("💭 Show thinking (%d chars)", st.thinkingLen), CallbackData: "thinking:" + sessionID},
+		})
+	}
+	if len(st.diffs) > 0 {
+		buttons = append(buttons, []models.InlineKeyboardButton{
+			{Text: fmt.Sprintf("📝 Show diffs (%d)", len(st.diffs)), CallbackData: "diff:" + sessionID},
+		})
+	}
+
+	// Store thinking/diff for callback retrieval.
+	if st.thinkingLen > 0 || len(st.diffs) > 0 {
+		tb.mu.Lock()
+		if st.thinkingLen > 0 {
+			tb.lastThinking[chatID] = st.thinkingText.String()
+		}
+		if len(st.diffs) > 0 {
+			tb.lastDiffs[chatID] = st.diffs
+		}
+		tb.mu.Unlock()
+	}
+
+	// Store cost.
+	if st.cost != "" {
+		tb.mu.Lock()
+		tb.sessionCosts[sessionID] = st.cost
+		tb.mu.Unlock()
+	}
+
+	// Send response — plain text (Claude's markdown is not MarkdownV2).
+	chunks := mdv2.Split(response, telegramMsgMax)
+	for i, chunk := range chunks {
+		params := &bot.SendMessageParams{
+			ChatID: chatID,
+			Text:   chunk,
+			LinkPreviewOptions: &models.LinkPreviewOptions{
+				IsDisabled: bot.True(),
+			},
+		}
+		// Attach buttons to last chunk.
+		if i == len(chunks)-1 && len(buttons) > 0 {
+			params.ReplyMarkup = &models.InlineKeyboardMarkup{InlineKeyboard: buttons}
+		}
+		if _, err := b.SendMessage(ctx, params); err != nil {
+			tb.logger.Error("telegram stream response", "error", err, "chat_id", chatID)
+			return
+		}
+	}
+}
+
+// handleStreamEvt processes a single SSE event and updates stream state. Returns true if state changed.
+func (tb *Bot) handleStreamEvt(st *streamState, evt streamEvent) bool {
+	switch evt.Type {
+	case "text":
+		st.responseText.WriteString(evt.Text)
+		return true
+	case "thinking":
+		st.thinkingText.WriteString(evt.Text)
+		st.thinkingLen = st.thinkingText.Len()
+		return true
+	case "tool_start":
+		st.tools = append(st.tools, toolLogEntry{
+			Name:   evt.ToolName,
+			Status: "running",
+		})
+		// Trim oldest entries.
+		if len(st.tools) > maxToolLogEntries {
+			st.tools = st.tools[len(st.tools)-maxToolLogEntries:]
+		}
+		return true
+	case "tool_result":
+		// Update the matching tool entry.
+		for i := len(st.tools) - 1; i >= 0; i-- {
+			if st.tools[i].Name == evt.ToolName && st.tools[i].Status == "running" {
+				if evt.IsError {
+					st.tools[i].Status = "error"
+				} else {
+					st.tools[i].Status = "done"
+				}
+				st.tools[i].Duration = evt.Duration
+				break
+			}
+		}
+		return true
+	case "tool_diff":
+		st.diffs = append(st.diffs, evt.Diff)
+		return true
+	case "done":
+		st.cost = evt.Cost
+		return true
+	case "error":
+		st.errText = evt.Text
+		return true
+	}
+	return false
+}
+
+// editStatus edits the status message, handling rate limit backoff.
+func (tb *Bot) editStatus(ctx context.Context, b *bot.Bot, chatID int64, st *streamState, text string) {
+	if text == st.lastStatus {
+		return // no-op
+	}
+	st.lastStatus = text
+
+	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+		ChatID:    chatID,
+		MessageID: st.statusMsgID,
+		Text:      text,
+		ParseMode: models.ParseModeMarkdown,
+		LinkPreviewOptions: &models.LinkPreviewOptions{
+			IsDisabled: bot.True(),
+		},
+	})
+	if err != nil {
+		// Check for rate limit (429) in error string.
+		if strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "Too Many Requests") {
+			st.tickInterval = backoffTick
+		}
+	}
+}
+
+// formatStatusMessage builds the MarkdownV2 status display.
+func formatStatusMessage(st *streamState) string {
+	var sb strings.Builder
+	elapsed := time.Since(st.started).Truncate(time.Second)
+
+	fmt.Fprintf(&sb, "⚙ *Working on %s\\.\\.\\.*\n", mdv2.Esc(st.project))
+
+	if len(st.tools) > 0 {
+		sb.WriteString("\n")
+		for _, t := range st.tools {
+			var icon, suffix string
+			switch t.Status {
+			case "running":
+				icon = "🔧"
+				suffix = "⏳"
+			case "done":
+				icon = "🔧"
+				suffix = "✓"
+				if t.Duration != "" {
+					suffix = "✓ " + mdv2.Esc(t.Duration)
+				}
+			case "error":
+				icon = "❌"
+				suffix = "failed"
+			case "approval":
+				icon = "🔐"
+				suffix = "awaiting approval"
+			}
+			fmt.Fprintf(&sb, "%s %s %s\n", icon, mdv2.Esc(t.Name), suffix)
+		}
+	}
+
+	if st.thinkingLen > 0 {
+		fmt.Fprintf(&sb, "\n💭 Thinking\\.\\.\\. \\(%s chars\\)\n", mdv2.Esc(fmt.Sprintf("%d", st.thinkingLen)))
+	}
+
+	fmt.Fprintf(&sb, "\n⏱ %s", mdv2.Esc(elapsed.String()))
+
+	result := sb.String()
+	if len(result) > maxStatusLen {
+		result = result[:maxStatusLen]
+	}
+	return result
+}
+
+// handleThinkingCallback sends the stored thinking text for a chat.
+func (tb *Bot) handleThinkingCallback(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if update.CallbackQuery == nil {
+		return
+	}
+
+	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+		CallbackQueryID: update.CallbackQuery.ID,
+		Text:            "Sending thinking...",
+	})
+
+	if update.CallbackQuery.Message.Message == nil {
+		return
+	}
+	chatID := update.CallbackQuery.Message.Message.Chat.ID
+
+	tb.mu.Lock()
+	thinking := tb.lastThinking[chatID]
+	tb.mu.Unlock()
+
+	if thinking == "" {
+		_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: chatID,
+			Text:   "No thinking data available.",
+		})
+		return
+	}
+
+	// Send thinking as plain text, chunked.
+	for _, chunk := range mdv2.Split(thinking, telegramMsgMax) {
+		_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: chatID,
+			Text:   chunk,
+		})
+	}
+}
+
+// handleDiffCallback sends the stored diffs for a chat.
+func (tb *Bot) handleDiffCallback(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if update.CallbackQuery == nil {
+		return
+	}
+
+	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+		CallbackQueryID: update.CallbackQuery.ID,
+		Text:            "Sending diffs...",
+	})
+
+	if update.CallbackQuery.Message.Message == nil {
+		return
+	}
+	chatID := update.CallbackQuery.Message.Message.Chat.ID
+
+	tb.mu.Lock()
+	diffs := tb.lastDiffs[chatID]
+	tb.mu.Unlock()
+
+	if len(diffs) == 0 {
+		_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: chatID,
+			Text:   "No diff data available.",
+		})
+		return
+	}
+
+	for _, d := range diffs {
+		name := d["name"]
+		path := d["path"]
+		diff := d["diff"]
+
+		header := name
+		if path != "" {
+			header = path
+		}
+
+		text := fmt.Sprintf("📝 %s\n```\n%s\n```", header, diff)
+		for _, chunk := range mdv2.Split(text, telegramMsgMax) {
+			_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+				ChatID:    chatID,
+				Text:      chunk,
+				ParseMode: models.ParseModeMarkdown,
+			})
+		}
+	}
+}
+
+// handleUseCallback handles inline "Set active" button from /sessions.
+func (tb *Bot) handleUseCallback(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if update.CallbackQuery == nil {
+		return
+	}
+	sessionID := strings.TrimPrefix(update.CallbackQuery.Data, "use:")
+
+	if update.CallbackQuery.Message.Message == nil {
+		return
+	}
+	chatID := update.CallbackQuery.Message.Message.Chat.ID
+
+	// Resolve session info.
+	sessions, err := tb.fetchSessions()
+	if err != nil {
+		_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+			CallbackQueryID: update.CallbackQuery.ID,
+			Text:            "Error: " + err.Error(),
+			ShowAlert:       true,
+		})
+		return
+	}
+
+	var projectName string
+	for _, s := range sessions {
+		if s.ID == sessionID {
+			projectName = s.ProjectName
+			break
+		}
+	}
+	if projectName == "" {
+		projectName = sessionID[:8]
+	}
+
+	tb.mu.Lock()
+	tb.activeSession[chatID] = sessionID
+	tb.activeName[chatID] = projectName
+	tb.mu.Unlock()
+
+	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+		CallbackQueryID: update.CallbackQuery.ID,
+		Text:            "✅ Active: " + projectName,
+	})
+
+	// Send confirmation with keyboard.
+	tb.sendWithKeyboard(ctx, b, chatID,
+		fmt.Sprintf("✅ Active session: *%s*\nFree\\-text messages will be sent to this session\\.", mdv2.Esc(projectName)))
+}
+
+// parseStreamEvents parses JSON data from an SSE event into a streamEvent.
+func parseStreamData(eventType, data string) streamEvent {
+	evt := streamEvent{Type: eventType}
+
+	switch eventType {
+	case "text", "thinking":
+		var payload struct {
+			Text string `json:"text"`
+		}
+		if json.Unmarshal([]byte(data), &payload) == nil {
+			evt.Text = payload.Text
+		}
+
+	case "tool_use_start":
+		var payload struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		}
+		if json.Unmarshal([]byte(data), &payload) == nil {
+			evt.ToolID = payload.ID
+			evt.ToolName = payload.Name
+			evt.Type = "tool_start"
+		}
+
+	case "tool_result":
+		var payload struct {
+			ID       string `json:"id"`
+			Name     string `json:"name"`
+			Output   string `json:"output"`
+			IsError  bool   `json:"is_error"`
+			Duration string `json:"duration"`
+		}
+		if json.Unmarshal([]byte(data), &payload) == nil {
+			evt.ToolID = payload.ID
+			evt.ToolName = payload.Name
+			evt.IsError = payload.IsError
+			evt.Duration = payload.Duration
+			evt.Text = payload.Output
+		}
+
+	case "tool_diff":
+		var payload map[string]string
+		if json.Unmarshal([]byte(data), &payload) == nil {
+			evt.ToolName = payload["name"]
+			evt.ToolID = payload["id"]
+			evt.Diff = payload
+		}
+
+	case "done":
+		var payload struct {
+			SessionCost string `json:"session_cost"`
+		}
+		if json.Unmarshal([]byte(data), &payload) == nil {
+			evt.Cost = payload.SessionCost
+		}
+
+	case "error":
+		var payload struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal([]byte(data), &payload) == nil {
+			evt.Text = payload.Error
+		}
+	}
+
+	return evt
+}

--- a/internal/telegram/stream_test.go
+++ b/internal/telegram/stream_test.go
@@ -1,0 +1,193 @@
+package telegram
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatStatusMessage_Basic(t *testing.T) {
+	st := &streamState{
+		project: "ghost",
+		started: time.Now().Add(-5 * time.Second),
+	}
+	msg := formatStatusMessage(st)
+	if !strings.Contains(msg, "ghost") {
+		t.Error("should contain project name")
+	}
+	if !strings.Contains(msg, "⚙") {
+		t.Error("should contain working icon")
+	}
+	if !strings.Contains(msg, "⏱") {
+		t.Error("should contain elapsed time")
+	}
+}
+
+func TestFormatStatusMessage_WithTools(t *testing.T) {
+	st := &streamState{
+		project: "ghost",
+		started: time.Now(),
+		tools: []toolLogEntry{
+			{Name: "file_read", Status: "done", Duration: "0.3s"},
+			{Name: "grep", Status: "running"},
+		},
+	}
+	msg := formatStatusMessage(st)
+	// Note: mdv2.Esc escapes underscores, so "file_read" becomes "file\_read".
+	if !strings.Contains(msg, "file") {
+		t.Error("should contain file_read tool")
+	}
+	if !strings.Contains(msg, "grep") {
+		t.Error("should contain grep tool")
+	}
+	if !strings.Contains(msg, "✓") {
+		t.Error("should contain done checkmark")
+	}
+	if !strings.Contains(msg, "⏳") {
+		t.Error("should contain running indicator")
+	}
+}
+
+func TestFormatStatusMessage_WithThinking(t *testing.T) {
+	st := &streamState{
+		project:     "ghost",
+		started:     time.Now(),
+		thinkingLen: 2048,
+	}
+	msg := formatStatusMessage(st)
+	if !strings.Contains(msg, "💭") {
+		t.Error("should contain thinking icon")
+	}
+	if !strings.Contains(msg, "2048") {
+		t.Error("should contain thinking char count")
+	}
+}
+
+func TestFormatStatusMessage_MaxLength(t *testing.T) {
+	st := &streamState{
+		project: "ghost",
+		started: time.Now(),
+	}
+	// Add many tools to push over the limit.
+	for i := 0; i < 100; i++ {
+		st.tools = append(st.tools, toolLogEntry{
+			Name:   "very_long_tool_name_that_takes_up_space",
+			Status: "done",
+		})
+	}
+	msg := formatStatusMessage(st)
+	if len(msg) > maxStatusLen {
+		t.Errorf("status message length %d exceeds max %d", len(msg), maxStatusLen)
+	}
+}
+
+func TestParseStreamData_Text(t *testing.T) {
+	evt := parseStreamData("text", `{"text":"hello"}`)
+	if evt.Type != "text" || evt.Text != "hello" {
+		t.Errorf("got %+v", evt)
+	}
+}
+
+func TestParseStreamData_Thinking(t *testing.T) {
+	evt := parseStreamData("thinking", `{"text":"reasoning..."}`)
+	if evt.Type != "thinking" || evt.Text != "reasoning..." {
+		t.Errorf("got %+v", evt)
+	}
+}
+
+func TestParseStreamData_ToolStart(t *testing.T) {
+	evt := parseStreamData("tool_use_start", `{"id":"t1","name":"grep"}`)
+	if evt.Type != "tool_start" || evt.ToolName != "grep" || evt.ToolID != "t1" {
+		t.Errorf("got %+v", evt)
+	}
+}
+
+func TestParseStreamData_ToolResult(t *testing.T) {
+	evt := parseStreamData("tool_result", `{"id":"t1","name":"grep","output":"found","duration":"150ms","is_error":false}`)
+	if evt.Type != "tool_result" || evt.ToolName != "grep" || evt.Duration != "150ms" || evt.IsError {
+		t.Errorf("got %+v", evt)
+	}
+}
+
+func TestParseStreamData_ToolResultError(t *testing.T) {
+	evt := parseStreamData("tool_result", `{"id":"t1","name":"bash","output":"exit 1","is_error":true}`)
+	if !evt.IsError {
+		t.Error("expected is_error=true")
+	}
+}
+
+func TestParseStreamData_ToolDiff(t *testing.T) {
+	evt := parseStreamData("tool_diff", `{"id":"t1","name":"file_edit","path":"main.go","diff":"+ line"}`)
+	if evt.Type != "tool_diff" || evt.Diff["path"] != "main.go" {
+		t.Errorf("got %+v", evt)
+	}
+}
+
+func TestParseStreamData_Done(t *testing.T) {
+	evt := parseStreamData("done", `{"session_cost":"$0.45"}`)
+	if evt.Type != "done" || evt.Cost != "$0.45" {
+		t.Errorf("got %+v", evt)
+	}
+}
+
+func TestParseStreamData_Error(t *testing.T) {
+	evt := parseStreamData("error", `{"error":"overloaded"}`)
+	if evt.Type != "error" || evt.Text != "overloaded" {
+		t.Errorf("got %+v", evt)
+	}
+}
+
+func TestHandleStreamEvt_Accumulation(t *testing.T) {
+	tb := &Bot{}
+	st := &streamState{started: time.Now()}
+
+	// Text accumulates.
+	tb.handleStreamEvt(st, streamEvent{Type: "text", Text: "Hello "})
+	tb.handleStreamEvt(st, streamEvent{Type: "text", Text: "world"})
+	if got := st.responseText.String(); got != "Hello world" {
+		t.Errorf("responseText = %q", got)
+	}
+
+	// Thinking accumulates.
+	tb.handleStreamEvt(st, streamEvent{Type: "thinking", Text: "hmm..."})
+	if st.thinkingLen != 6 {
+		t.Errorf("thinkingLen = %d, want 6", st.thinkingLen)
+	}
+
+	// Tool start adds entry.
+	tb.handleStreamEvt(st, streamEvent{Type: "tool_start", ToolName: "grep"})
+	if len(st.tools) != 1 || st.tools[0].Name != "grep" {
+		t.Errorf("tools = %+v", st.tools)
+	}
+
+	// Tool result updates entry.
+	tb.handleStreamEvt(st, streamEvent{Type: "tool_result", ToolName: "grep", Duration: "50ms"})
+	if st.tools[0].Status != "done" || st.tools[0].Duration != "50ms" {
+		t.Errorf("tool after result = %+v", st.tools[0])
+	}
+
+	// Done sets cost.
+	tb.handleStreamEvt(st, streamEvent{Type: "done", Cost: "$1.00"})
+	if st.cost != "$1.00" {
+		t.Errorf("cost = %q", st.cost)
+	}
+
+	// Error sets errText.
+	tb.handleStreamEvt(st, streamEvent{Type: "error", Text: "boom"})
+	if st.errText != "boom" {
+		t.Errorf("errText = %q", st.errText)
+	}
+}
+
+func TestHandleStreamEvt_ToolLogTrimming(t *testing.T) {
+	tb := &Bot{}
+	st := &streamState{started: time.Now()}
+
+	for i := 0; i < 15; i++ {
+		tb.handleStreamEvt(st, streamEvent{Type: "tool_start", ToolName: "tool"})
+	}
+
+	if len(st.tools) != maxToolLogEntries {
+		t.Errorf("tools length = %d, want %d", len(st.tools), maxToolLogEntries)
+	}
+}

--- a/internal/telegram/voice.go
+++ b/internal/telegram/voice.go
@@ -105,12 +105,30 @@ func (tb *Bot) handleVoice(ctx context.Context, b *bot.Bot, update *models.Updat
 		return
 	}
 
-	// Reply with the transcription.
-	b.SendMessage(ctx, &bot.SendMessageParams{
-		ChatID: update.Message.Chat.ID,
-		Text:   fmt.Sprintf("🎤 *Transcription:*\n%s", mdv2.Esc(text)),
+	chatID := update.Message.Chat.ID
+	tb.logger.Info("voice message transcribed", "chars", len(text))
+
+	// If there's an active session, send the transcription to it.
+	tb.mu.Lock()
+	sessionID := tb.activeSession[chatID]
+	projectName := tb.activeName[chatID]
+	tb.mu.Unlock()
+
+	if sessionID != "" {
+		// Show transcript briefly, then stream to session.
+		_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID:    chatID,
+			Text:      fmt.Sprintf("🎤 %s", mdv2.Esc(text)),
+			ParseMode: models.ParseModeMarkdown,
+		})
+		tb.streamToSession(ctx, b, chatID, sessionID, projectName, text)
+		return
+	}
+
+	// No active session — just reply with the transcription.
+	_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:    chatID,
+		Text:      fmt.Sprintf("🎤 *Transcription:*\n%s\n\n_Use /use \\<id\\> to set an active session for voice messages\\._", mdv2.Esc(text)),
 		ParseMode: models.ParseModeMarkdown,
 	})
-
-	tb.logger.Info("voice message transcribed", "chars", len(text))
 }

--- a/internal/telegram/voice.go
+++ b/internal/telegram/voice.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
-	"time"
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
@@ -57,14 +55,21 @@ func (tb *Bot) handleVoice(ctx context.Context, b *bot.Bot, update *models.Updat
 	file, err := b.GetFile(ctx, &bot.GetFileParams{FileID: update.Message.Voice.FileID})
 	if err != nil {
 		tb.logger.Error("get voice file", "error", err)
+		_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: update.Message.Chat.ID,
+			Text:   "Failed to retrieve voice file from Telegram.",
+		})
 		return
 	}
 
 	fileURL := fmt.Sprintf("https://api.telegram.org/file/bot%s/%s", tb.token, file.FilePath)
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Get(fileURL)
+	resp, err := httpClient.Get(fileURL)
 	if err != nil {
 		tb.logger.Error("download voice file", "error", err)
+		_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: update.Message.Chat.ID,
+			Text:   "Failed to download voice message.",
+		})
 		return
 	}
 	defer resp.Body.Close()
@@ -72,6 +77,10 @@ func (tb *Bot) handleVoice(ctx context.Context, b *bot.Bot, update *models.Updat
 	oggData, err := io.ReadAll(io.LimitReader(resp.Body, 25*1024*1024)) // 25MB limit
 	if err != nil {
 		tb.logger.Error("read voice file", "error", err)
+		_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: update.Message.Chat.ID,
+			Text:   "Failed to read voice file data.",
+		})
 		return
 	}
 


### PR DESCRIPTION
## Summary

- **Active sessions**: `/use <id>` sets a session so free-text and voice messages route directly to it. `/detach` clears it.
- **Rich streaming**: Real-time status message shows tool progress, thinking indicator, and elapsed time. Replaces the old batched response.
- **Full SSE parsing**: All event types parsed — text, thinking, tool_start, tool_result, tool_diff, done, error. Previously only text + done were collected.
- **Post-response buttons**: "Show thinking" and "Show diffs" inline buttons after responses.
- **Voice → session**: Voice messages transcribe and send to active session automatically.
- **Persistent keyboard**: Reply keyboard adapts to active session state.
- **Audit fixes**: Panic guard on short IDs, mutex on SetServerAddr/SetServerToken, bounded error body reads, dead code removal, tool correlation by ID.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `go build ./cmd/ghost` compiles
- [ ] Manual: `/sessions` → "Set active" button → send free text → see streaming status → final response
- [ ] Manual: voice message with active session → transcribes → streams to session
- [ ] Manual: `/detach` → free text shows "Use /help"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced active session management: use `/use` to set an active session and `/detach` to clear it
  * Implemented real-time streaming responses with live status updates and progress tracking
  * Added inline buttons to view AI thinking and tool execution details for each response
  * Voice messages now automatically route to the active session when configured

* **Bug Fixes**
  * Improved error reporting for voice transcription failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->