### PR TITLE
feat(mcp): ghost mcp init for Claude Code integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,24 @@ Connects Claude Code, Cursor, or any MCP client to Ghost's memory via stdio.
 | `ghost_decision_record` | Record an architectural decision with rationale |
 | `ghost_health` | System stats (memory count, embeddings, costs) |
 
-The MCP server ships with comprehensive instructions that teach Claude when and how to save memories proactively, which categories to use, and how to leverage cross-project search. No CLAUDE.md configuration required.
+The MCP server ships with comprehensive instructions that teach Claude when and how to save memories proactively, which categories to use, and how to leverage cross-project search.
+
+### `ghost mcp init` — Claude Code Setup
+
+One command to fully integrate Ghost with Claude Code:
+
+```bash
+ghost mcp init
+```
+
+This configures:
+1. **MCP server registration** — registers `ghost mcp` with the `claude` CLI
+2. **Tool permissions** — adds all 13 `mcp__ghost__*` tools to the allow list
+3. **SessionStart hook** — reminds Claude to load Ghost context at every session start
+4. **Memory import** — imports existing Claude Code memory files into Ghost (deduplicated)
+5. **Project redirects** — writes `MEMORY.md` files that point Claude to Ghost
+
+Idempotent — safe to re-run after updates. Requires both `ghost` and `claude` on PATH.
 
 **MCP Resources:**
 

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/wcatz/ghost/internal/embedding"
 	"github.com/wcatz/ghost/internal/github"
 	goog "github.com/wcatz/ghost/internal/google"
+	"github.com/wcatz/ghost/internal/mcpinit"
 	"github.com/wcatz/ghost/internal/mcpserver"
 	"github.com/wcatz/ghost/internal/memory"
 	"github.com/wcatz/ghost/internal/orchestrator"
@@ -50,7 +51,14 @@ func main() {
 			runServe()
 			return
 		case "mcp":
+			if len(os.Args) > 2 && os.Args[2] == "init" {
+				runMCPInit()
+				return
+			}
 			runMCP()
+			return
+		case "hook":
+			runHook()
 			return
 		}
 	}
@@ -435,6 +443,25 @@ func runMCP() {
 	if err := srv.Run(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+// runMCPInit configures Claude Code to use Ghost as its memory system.
+func runMCPInit() {
+	if err := mcpinit.Run(os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runHook dispatches Claude Code hook events.
+func runHook() {
+	if len(os.Args) < 3 {
+		os.Exit(0)
+	}
+	switch os.Args[2] {
+	case "session-start":
+		mcpinit.HandleSessionStartHook(os.Stdin, os.Stdout)
 	}
 }
 

--- a/internal/claudeimport/import.go
+++ b/internal/claudeimport/import.go
@@ -43,9 +43,9 @@ var importanceMap = map[string]float32{
 
 const defaultImportance float32 = 0.7
 
-// encodeProjectPath converts an absolute path to Claude's directory name format.
+// EncodeProjectPath converts an absolute path to Claude's directory name format.
 // E.g., "/home/wayne/git/ghost" → "-home-wayne-git-ghost".
-func encodeProjectPath(projectPath string) string {
+func EncodeProjectPath(projectPath string) string {
 	return strings.ReplaceAll(projectPath, "/", "-")
 }
 
@@ -56,7 +56,7 @@ func ClaudeMemoryDir(projectPath string) string {
 	if err != nil {
 		return ""
 	}
-	encoded := encodeProjectPath(projectPath)
+	encoded := EncodeProjectPath(projectPath)
 	dir := filepath.Join(home, ".claude", "projects", encoded, "memory")
 	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
 		return ""

--- a/internal/claudeimport/import_test.go
+++ b/internal/claudeimport/import_test.go
@@ -13,10 +13,10 @@ import (
 
 func TestClaudeMemoryDir(t *testing.T) {
 	t.Run("encoding", func(t *testing.T) {
-		got := encodeProjectPath("/home/wayne/git/ghost")
+		got := EncodeProjectPath("/home/wayne/git/ghost")
 		want := "-home-wayne-git-ghost"
 		if got != want {
-			t.Errorf("encodeProjectPath = %q, want %q", got, want)
+			t.Errorf("EncodeProjectPath = %q, want %q", got, want)
 		}
 	})
 

--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -1,0 +1,19 @@
+package mcpinit
+
+import (
+	"fmt"
+	"io"
+)
+
+// HandleSessionStartHook is invoked by Claude Code at session start via:
+//
+//	ghost hook session-start
+//
+// Its stdout becomes visible in Claude's context, reinforcing Ghost usage.
+// Zero DB access, zero network — runs in ~1ms.
+func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
+	_, _ = io.Copy(io.Discard, stdin) // drain stdin
+	fmt.Fprintln(stdout, "Ghost memory is active. Before starting work:")
+	fmt.Fprintln(stdout, "1. Call ghost_project_context with the project name")
+	fmt.Fprintln(stdout, "2. Save discoveries with ghost_memory_save during work")
+}

--- a/internal/mcpinit/init.go
+++ b/internal/mcpinit/init.go
@@ -1,0 +1,304 @@
+package mcpinit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/wcatz/ghost/internal/claudeimport"
+	"github.com/wcatz/ghost/internal/config"
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+// Run executes the 6-step Claude Code integration setup.
+func Run(w io.Writer) error {
+	// Step 1: Prerequisites.
+	fmt.Fprintln(w, "\n[1/6] Checking prerequisites...")
+	ghostBin, claudeBin, err := checkPrereqs(w)
+	if err != nil {
+		return err
+	}
+
+	// Step 2: MCP server registration.
+	fmt.Fprintln(w, "\n[2/6] Registering MCP server...")
+	if err := registerMCP(w, ghostBin, claudeBin); err != nil {
+		return err
+	}
+
+	// Step 3: Tool permissions.
+	fmt.Fprintln(w, "\n[3/6] Adding tool permissions...")
+	settingsFile, err := ensurePermissions(w)
+	if err != nil {
+		return err
+	}
+
+	// Step 4: SessionStart hook.
+	fmt.Fprintln(w, "\n[4/6] Configuring SessionStart hook...")
+	if err := ensureHook(w, settingsFile, ghostBin); err != nil {
+		return err
+	}
+
+	// Save settings (steps 3+4 both modify it).
+	if err := settingsFile.save(); err != nil {
+		return fmt.Errorf("save settings: %w", err)
+	}
+
+	// Step 5: Import Claude Code memories.
+	fmt.Fprintln(w, "\n[5/6] Importing Claude Code memories...")
+	projects, err := importMemories(w)
+	if err != nil {
+		fmt.Fprintf(w, "  ! import error: %v (continuing)\n", err)
+	}
+
+	// Step 6: Project memory redirects.
+	fmt.Fprintln(w, "\n[6/6] Writing project memory redirects...")
+	writeRedirects(w, projects)
+
+	fmt.Fprintln(w, "\nDone! Restart Claude Code to activate.")
+	return nil
+}
+
+// checkPrereqs verifies that both ghost and claude binaries are on PATH.
+func checkPrereqs(w io.Writer) (ghostBin, claudeBin string, err error) {
+	ghostBin, err = exec.LookPath("ghost")
+	if err != nil {
+		return "", "", fmt.Errorf("ghost binary not found in PATH — install it first")
+	}
+	fmt.Fprintf(w, "  ✓ ghost binary at %s\n", ghostBin)
+
+	claudeBin, err = exec.LookPath("claude")
+	if err != nil {
+		return "", "", fmt.Errorf("claude CLI not found in PATH — install Claude Code first")
+	}
+	fmt.Fprintf(w, "  ✓ claude CLI at %s\n", claudeBin)
+
+	return ghostBin, claudeBin, nil
+}
+
+// registerMCP ensures the ghost MCP server is registered with claude.
+func registerMCP(w io.Writer, ghostBin, claudeBin string) error {
+	// Check current registration.
+	out, err := exec.Command(claudeBin, "mcp", "get", "ghost").CombinedOutput()
+	currentOutput := string(out)
+
+	alreadyRegistered := err == nil && strings.Contains(currentOutput, "Command:")
+	correctPath := strings.Contains(currentOutput, ghostBin)
+
+	if alreadyRegistered && correctPath {
+		fmt.Fprintln(w, "  ✓ ghost MCP server already registered")
+		return nil
+	}
+
+	// Register or update.
+	mcpConfig := map[string]any{
+		"type":    "stdio",
+		"command": ghostBin,
+		"args":    []string{"mcp"},
+	}
+	configJSON, err := json.Marshal(mcpConfig)
+	if err != nil {
+		return fmt.Errorf("marshal mcp config: %w", err)
+	}
+
+	cmd := exec.Command(claudeBin, "mcp", "add-json", "-s", "user", "ghost", string(configJSON))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("claude mcp add-json: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+
+	if alreadyRegistered {
+		fmt.Fprintf(w, "  ✓ updated ghost MCP server (command: %s)\n", ghostBin)
+	} else {
+		fmt.Fprintf(w, "  + registered ghost MCP server (command: %s)\n", ghostBin)
+	}
+	return nil
+}
+
+// ensurePermissions loads settings.json and adds missing ghost permissions.
+func ensurePermissions(w io.Writer) (*settingsFile, error) {
+	path, err := settingsPath()
+	if err != nil {
+		return nil, err
+	}
+
+	sf, err := loadSettings(path)
+	if err != nil {
+		return nil, err
+	}
+
+	added, err := sf.addPermissions(ghostPermissions)
+	if err != nil {
+		return nil, fmt.Errorf("add permissions: %w", err)
+	}
+
+	existing := len(ghostPermissions) - len(added)
+	if existing > 0 {
+		fmt.Fprintf(w, "  ✓ %d permissions already present\n", existing)
+	}
+	for _, p := range added {
+		fmt.Fprintf(w, "  + %s\n", p)
+	}
+	if len(added) == 0 {
+		fmt.Fprintf(w, "  ✓ all %d ghost permissions configured\n", len(ghostPermissions))
+	}
+
+	return sf, nil
+}
+
+// ensureHook adds a SessionStart hook if not already present.
+func ensureHook(w io.Writer, sf *settingsFile, ghostBin string) error {
+	// Quote the binary path if it contains spaces.
+	bin := ghostBin
+	if strings.Contains(bin, " ") {
+		bin = `"` + bin + `"`
+	}
+	hookCmd := bin + " hook session-start"
+
+	if sf.hasHook("SessionStart", "ghost hook session-start") {
+		fmt.Fprintln(w, "  ✓ SessionStart hook already configured")
+		return nil
+	}
+
+	entry := hookEntry{
+		Matcher: "",
+		Hooks: []hookAction{
+			{Type: "command", Command: hookCmd},
+		},
+	}
+	if err := sf.addHook("SessionStart", entry); err != nil {
+		return fmt.Errorf("add hook: %w", err)
+	}
+
+	fmt.Fprintf(w, "  + added SessionStart hook: %s\n", hookCmd)
+	return nil
+}
+
+type projectInfo struct {
+	ID   string
+	Path string
+	Name string
+}
+
+// importMemories opens the Ghost DB and imports Claude Code memory files
+// for all known projects.
+func importMemories(w io.Writer) ([]projectInfo, error) {
+	dataDir, err := config.DataDir()
+	if err != nil {
+		return nil, fmt.Errorf("data dir: %w", err)
+	}
+	dbPath := filepath.Join(dataDir, "ghost.db")
+
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		fmt.Fprintln(w, "  - no Ghost database found (run ghost serve first)")
+		return nil, nil
+	}
+
+	db, err := memory.OpenDB(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+	defer db.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := memory.NewStore(db, logger)
+
+	ctx := context.Background()
+	projects, err := store.ListProjects(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list projects: %w", err)
+	}
+
+	var infos []projectInfo
+	for _, p := range projects {
+		infos = append(infos, projectInfo{ID: p.ID, Path: p.Path, Name: p.Name})
+
+		if !filepath.IsAbs(p.Path) {
+			continue
+		}
+
+		n, err := claudeimport.Import(ctx, store, p.ID, p.Path, logger)
+		if err != nil {
+			fmt.Fprintf(w, "  ! %s — import error: %v\n", p.Name, err)
+			continue
+		}
+		if n > 0 {
+			fmt.Fprintf(w, "  ✓ %s — %d memories imported\n", p.Name, n)
+		} else {
+			fmt.Fprintf(w, "  - %s — no new memories\n", p.Name)
+		}
+	}
+
+	return infos, nil
+}
+
+// sanitizeName strips characters that could inject markdown directives or
+// newlines into MEMORY.md files loaded by Claude Code.
+func sanitizeName(name string) string {
+	var sb strings.Builder
+	for _, r := range name {
+		if r == '\n' || r == '\r' || r == '`' {
+			continue
+		}
+		sb.WriteRune(r)
+	}
+	s := sb.String()
+	if len(s) > 64 {
+		s = s[:64]
+	}
+	return s
+}
+
+// writeRedirects creates MEMORY.md redirect files in Claude's project memory
+// directories for each known Ghost project.
+func writeRedirects(w io.Writer, projects []projectInfo) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(w, "  ! cannot determine home directory: %v\n", err)
+		return
+	}
+
+	for _, p := range projects {
+		if !filepath.IsAbs(p.Path) {
+			continue
+		}
+
+		encoded := claudeimport.EncodeProjectPath(p.Path)
+		dir := filepath.Join(home, ".claude", "projects", encoded, "memory")
+		target := filepath.Join(dir, "MEMORY.md")
+
+		// Check if redirect already exists.
+		if data, err := os.ReadFile(target); err == nil {
+			if strings.Contains(string(data), "stored in Ghost") {
+				fmt.Fprintf(w, "  ✓ %s — redirect exists\n", p.Name)
+				continue
+			}
+			// File exists with other content — don't clobber.
+			fmt.Fprintf(w, "  - %s — MEMORY.md exists (not overwriting)\n", p.Name)
+			continue
+		}
+
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			fmt.Fprintf(w, "  ! %s — mkdir error: %v\n", p.Name, err)
+			continue
+		}
+
+		safeName := sanitizeName(p.Name)
+		content := fmt.Sprintf(`# %s Project Memory
+
+All project knowledge is stored in Ghost. At session start, run:
+1. `+"`ghost_list_projects`"+` to discover projects
+2. `+"`ghost_project_context`"+` with project_id "%s" to load accumulated knowledge
+`, safeName, safeName)
+
+		if err := os.WriteFile(target, []byte(content), 0644); err != nil {
+			fmt.Fprintf(w, "  ! %s — write error: %v\n", p.Name, err)
+			continue
+		}
+		fmt.Fprintf(w, "  + %s — created redirect\n", p.Name)
+	}
+}

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -1,0 +1,147 @@
+package mcpinit
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHandleSessionStartHook(t *testing.T) {
+	var out bytes.Buffer
+	HandleSessionStartHook(strings.NewReader(`{"event":"SessionStart"}`), &out)
+
+	output := out.String()
+	if !strings.Contains(output, "ghost_project_context") {
+		t.Error("hook output should mention ghost_project_context")
+	}
+	if !strings.Contains(output, "ghost_memory_save") {
+		t.Error("hook output should mention ghost_memory_save")
+	}
+}
+
+func TestWriteRedirects_CreatesFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projects := []projectInfo{
+		{ID: "abc123", Path: "/home/test/git/myproject", Name: "myproject"},
+	}
+
+	var out bytes.Buffer
+	writeRedirects(&out, projects)
+
+	encoded := strings.ReplaceAll("/home/test/git/myproject", "/", "-")
+	target := filepath.Join(home, ".claude", "projects", encoded, "memory", "MEMORY.md")
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("expected redirect file to be created: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "stored in Ghost") {
+		t.Error("redirect should contain 'stored in Ghost'")
+	}
+	if !strings.Contains(content, "myproject") {
+		t.Error("redirect should contain project name")
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "created redirect") {
+		t.Errorf("output should say 'created redirect', got: %s", output)
+	}
+}
+
+func TestWriteRedirects_SkipsExisting(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Pre-create the redirect file.
+	encoded := strings.ReplaceAll("/home/test/git/myproject", "/", "-")
+	dir := filepath.Join(home, ".claude", "projects", encoded, "memory")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "MEMORY.md"), []byte("All project knowledge is stored in Ghost."), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	projects := []projectInfo{
+		{ID: "abc123", Path: "/home/test/git/myproject", Name: "myproject"},
+	}
+
+	var out bytes.Buffer
+	writeRedirects(&out, projects)
+
+	output := out.String()
+	if !strings.Contains(output, "redirect exists") {
+		t.Errorf("should report redirect exists, got: %s", output)
+	}
+}
+
+func TestWriteRedirects_SkipsRelativePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projects := []projectInfo{
+		{ID: "abc123", Path: "relative/path", Name: "rel"},
+	}
+
+	var out bytes.Buffer
+	writeRedirects(&out, projects)
+
+	// Should produce no output for relative paths.
+	if out.String() != "" {
+		t.Errorf("expected no output for relative path, got: %s", out.String())
+	}
+}
+
+func TestWriteRedirects_DoesNotClobber(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Pre-create a file with user content (not a Ghost redirect).
+	encoded := strings.ReplaceAll("/home/test/git/myproject", "/", "-")
+	dir := filepath.Join(home, ".claude", "projects", encoded, "memory")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	original := "User's custom memory content here."
+	if err := os.WriteFile(filepath.Join(dir, "MEMORY.md"), []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	projects := []projectInfo{
+		{ID: "abc123", Path: "/home/test/git/myproject", Name: "myproject"},
+	}
+
+	var out bytes.Buffer
+	writeRedirects(&out, projects)
+
+	// Verify it was NOT overwritten.
+	data, _ := os.ReadFile(filepath.Join(dir, "MEMORY.md"))
+	if string(data) != original {
+		t.Error("writeRedirects clobbered existing non-Ghost MEMORY.md")
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "not overwriting") {
+		t.Errorf("should say 'not overwriting', got: %s", output)
+	}
+}
+
+func TestGhostPermissions_Complete(t *testing.T) {
+	// Verify the canonical list has the expected count.
+	if len(ghostPermissions) != 13 {
+		t.Errorf("expected 13 ghost permissions, got %d", len(ghostPermissions))
+	}
+
+	// All should start with the correct prefix.
+	for _, p := range ghostPermissions {
+		if !strings.HasPrefix(p, "mcp__ghost__ghost_") {
+			t.Errorf("permission %q has unexpected prefix", p)
+		}
+	}
+}

--- a/internal/mcpinit/settings.go
+++ b/internal/mcpinit/settings.go
@@ -1,0 +1,221 @@
+// Package mcpinit configures Claude Code to use Ghost as its memory system.
+package mcpinit
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ghostPermissions is the canonical list of MCP tool permissions to allow.
+var ghostPermissions = []string{
+	"mcp__ghost__ghost_decision_record",
+	"mcp__ghost__ghost_health",
+	"mcp__ghost__ghost_list_projects",
+	"mcp__ghost__ghost_memories_list",
+	"mcp__ghost__ghost_memory_delete",
+	"mcp__ghost__ghost_memory_save",
+	"mcp__ghost__ghost_memory_search",
+	"mcp__ghost__ghost_project_context",
+	"mcp__ghost__ghost_save_global",
+	"mcp__ghost__ghost_search_all",
+	"mcp__ghost__ghost_task_complete",
+	"mcp__ghost__ghost_task_create",
+	"mcp__ghost__ghost_task_list",
+}
+
+// hookEntry represents one matcher+hooks pair in settings.json.
+type hookEntry struct {
+	Matcher string       `json:"matcher"`
+	Hooks   []hookAction `json:"hooks"`
+}
+
+type hookAction struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+// settingsFile provides safe read-modify-write for ~/.claude/settings.json.
+// It preserves all keys it does not understand via json.RawMessage.
+type settingsFile struct {
+	path string
+	raw  map[string]json.RawMessage
+}
+
+// settingsPath returns the path to ~/.claude/settings.json.
+func settingsPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".claude", "settings.json"), nil
+}
+
+// loadSettings reads and parses the settings file.
+// If the file does not exist, returns an empty settings ready to populate.
+func loadSettings(path string) (*settingsFile, error) {
+	s := &settingsFile{
+		path: path,
+		raw:  make(map[string]json.RawMessage),
+	}
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return s, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	if err := json.Unmarshal(data, &s.raw); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return s, nil
+}
+
+// save writes the settings back to disk, creating a .bak backup first.
+func (s *settingsFile) save() error {
+	// Backup existing file.
+	if _, err := os.Stat(s.path); err == nil {
+		data, err := os.ReadFile(s.path)
+		if err == nil {
+			_ = os.WriteFile(s.path+".bak", data, 0600)
+		}
+	}
+
+	out, err := json.MarshalIndent(s.raw, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+	out = append(out, '\n')
+
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create dir %s: %w", dir, err)
+	}
+	return os.WriteFile(s.path, out, 0600)
+}
+
+// getPermissions extracts the permissions.allow string slice.
+func (s *settingsFile) getPermissions() ([]string, error) {
+	permsRaw, ok := s.raw["permissions"]
+	if !ok {
+		return nil, nil
+	}
+	var perms struct {
+		Allow []string `json:"allow"`
+	}
+	if err := json.Unmarshal(permsRaw, &perms); err != nil {
+		return nil, err
+	}
+	return perms.Allow, nil
+}
+
+// addPermissions adds any missing ghost permissions and returns the list of
+// newly added entries.
+func (s *settingsFile) addPermissions(perms []string) ([]string, error) {
+	existing, err := s.getPermissions()
+	if err != nil {
+		return nil, err
+	}
+
+	set := make(map[string]bool, len(existing))
+	for _, p := range existing {
+		set[p] = true
+	}
+
+	var added []string
+	for _, p := range perms {
+		if !set[p] {
+			existing = append(existing, p)
+			added = append(added, p)
+		}
+	}
+
+	if len(added) == 0 {
+		return nil, nil
+	}
+
+	// Rebuild the permissions object, preserving other fields.
+	var permsMap map[string]json.RawMessage
+	if raw, ok := s.raw["permissions"]; ok {
+		if err := json.Unmarshal(raw, &permsMap); err != nil {
+			permsMap = make(map[string]json.RawMessage)
+		}
+	} else {
+		permsMap = make(map[string]json.RawMessage)
+	}
+
+	allowJSON, err := json.Marshal(existing)
+	if err != nil {
+		return nil, err
+	}
+	permsMap["allow"] = allowJSON
+
+	permsJSON, err := json.Marshal(permsMap)
+	if err != nil {
+		return nil, err
+	}
+	s.raw["permissions"] = permsJSON
+
+	return added, nil
+}
+
+// hasHook checks if a SessionStart hook containing cmdSubstr already exists.
+func (s *settingsFile) hasHook(event, cmdSubstr string) bool {
+	hooksRaw, ok := s.raw["hooks"]
+	if !ok {
+		return false
+	}
+
+	var hooks map[string][]hookEntry
+	if err := json.Unmarshal(hooksRaw, &hooks); err != nil {
+		return false
+	}
+
+	for _, entry := range hooks[event] {
+		for _, h := range entry.Hooks {
+			if strings.Contains(h.Command, cmdSubstr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// addHook adds a hook entry for the given event. Does not clobber existing hooks.
+func (s *settingsFile) addHook(event string, entry hookEntry) error {
+	var hooks map[string]json.RawMessage
+	if raw, ok := s.raw["hooks"]; ok {
+		if err := json.Unmarshal(raw, &hooks); err != nil {
+			hooks = make(map[string]json.RawMessage)
+		}
+	} else {
+		hooks = make(map[string]json.RawMessage)
+	}
+
+	// Get existing entries for this event.
+	var entries []hookEntry
+	if raw, ok := hooks[event]; ok {
+		if err := json.Unmarshal(raw, &entries); err != nil {
+			return fmt.Errorf("parse existing %s hooks: %w", event, err)
+		}
+	}
+
+	entries = append(entries, entry)
+
+	entriesJSON, err := json.Marshal(entries)
+	if err != nil {
+		return err
+	}
+	hooks[event] = entriesJSON
+
+	hooksJSON, err := json.Marshal(hooks)
+	if err != nil {
+		return err
+	}
+	s.raw["hooks"] = hooksJSON
+	return nil
+}

--- a/internal/mcpinit/settings_test.go
+++ b/internal/mcpinit/settings_test.go
@@ -1,0 +1,207 @@
+package mcpinit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func tempSettings(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if content != "" {
+		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return path
+}
+
+func TestLoadSettings_Empty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatalf("loadSettings: %v", err)
+	}
+	if len(sf.raw) != 0 {
+		t.Errorf("expected empty raw, got %d keys", len(sf.raw))
+	}
+}
+
+func TestLoadSettings_Existing(t *testing.T) {
+	path := tempSettings(t, `{"permissions":{"allow":["Bash"]},"effortLevel":"high"}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatalf("loadSettings: %v", err)
+	}
+	if _, ok := sf.raw["permissions"]; !ok {
+		t.Error("expected permissions key")
+	}
+	if _, ok := sf.raw["effortLevel"]; !ok {
+		t.Error("expected effortLevel key")
+	}
+}
+
+func TestAddPermissions_AllNew(t *testing.T) {
+	path := tempSettings(t, `{"permissions":{"allow":["Bash"]}}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	added, err := sf.addPermissions([]string{"mcp__ghost__ghost_health", "mcp__ghost__ghost_list_projects"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(added) != 2 {
+		t.Errorf("expected 2 added, got %d", len(added))
+	}
+
+	// Verify the allow list now has 3 entries.
+	perms, err := sf.getPermissions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(perms) != 3 {
+		t.Errorf("expected 3 permissions, got %d", len(perms))
+	}
+}
+
+func TestAddPermissions_Idempotent(t *testing.T) {
+	path := tempSettings(t, `{"permissions":{"allow":["mcp__ghost__ghost_health"]}}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	added, err := sf.addPermissions([]string{"mcp__ghost__ghost_health"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(added) != 0 {
+		t.Errorf("expected 0 added (idempotent), got %d", len(added))
+	}
+}
+
+func TestAddPermissions_NoExistingPerms(t *testing.T) {
+	path := tempSettings(t, `{}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	added, err := sf.addPermissions([]string{"mcp__ghost__ghost_health"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(added) != 1 {
+		t.Errorf("expected 1 added, got %d", len(added))
+	}
+}
+
+func TestHasHook_NotPresent(t *testing.T) {
+	path := tempSettings(t, `{}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sf.hasHook("SessionStart", "ghost hook session-start") {
+		t.Error("expected hasHook to return false")
+	}
+}
+
+func TestAddHook_AndHasHook(t *testing.T) {
+	path := tempSettings(t, `{}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry := hookEntry{
+		Matcher: "",
+		Hooks:   []hookAction{{Type: "command", Command: "ghost hook session-start"}},
+	}
+	if err := sf.addHook("SessionStart", entry); err != nil {
+		t.Fatal(err)
+	}
+
+	if !sf.hasHook("SessionStart", "ghost hook session-start") {
+		t.Error("expected hasHook to return true after addHook")
+	}
+}
+
+func TestAddHook_PreservesExisting(t *testing.T) {
+	existing := `{"hooks":{"PreToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"check.sh"}]}]}}`
+	path := tempSettings(t, existing)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry := hookEntry{
+		Matcher: "",
+		Hooks:   []hookAction{{Type: "command", Command: "ghost hook session-start"}},
+	}
+	if err := sf.addHook("SessionStart", entry); err != nil {
+		t.Fatal(err)
+	}
+
+	// PreToolUse should still be there.
+	var hooks map[string]json.RawMessage
+	if err := json.Unmarshal(sf.raw["hooks"], &hooks); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := hooks["PreToolUse"]; !ok {
+		t.Error("existing PreToolUse hook was clobbered")
+	}
+	if _, ok := hooks["SessionStart"]; !ok {
+		t.Error("SessionStart hook was not added")
+	}
+}
+
+func TestSave_RoundTrip(t *testing.T) {
+	path := tempSettings(t, `{"permissions":{"allow":["Bash"]},"effortLevel":"high"}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sf.addPermissions([]string{"mcp__ghost__ghost_health"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sf.save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-read and verify.
+	sf2, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// effortLevel should be preserved.
+	if _, ok := sf2.raw["effortLevel"]; !ok {
+		t.Error("effortLevel was lost during save")
+	}
+
+	perms, err := sf2.getPermissions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, p := range perms {
+		if p == "mcp__ghost__ghost_health" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("mcp__ghost__ghost_health not found after round-trip")
+	}
+
+	// Backup should exist.
+	if _, err := os.Stat(path + ".bak"); err != nil {
+		t.Error("backup file not created")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ghost mcp init` — a single command that fully configures Claude Code to use Ghost as its memory system
- Adds `ghost hook session-start` — a lightweight SessionStart hook that reminds Claude to load Ghost context
- Exports `EncodeProjectPath` from `claudeimport` package for reuse

### What `ghost mcp init` does (6 steps):
1. Verifies `ghost` and `claude` binaries are on PATH
2. Registers Ghost MCP server via `claude mcp add-json`
3. Adds all 13 `mcp__ghost__*` tool permissions to `~/.claude/settings.json`
4. Configures a `SessionStart` hook that reminds Claude to call `ghost_project_context`
5. Imports existing Claude Code memory files into Ghost (deduplicated via upsert)
6. Writes `MEMORY.md` redirect files for all known projects

Idempotent — safe to re-run after updates.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` — all pass (15 new tests in mcpinit + existing tests unchanged)
- [x] `go build ./cmd/ghost/` compiles
- [ ] Manual: `ghost mcp init` — verify output, check settings.json, check MEMORY.md files
- [ ] Manual: new Claude Code session — verify SessionStart hook fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ghost mcp init` command for streamlined Claude Code integration setup in a single operation
  * Automatic MCP server registration and tool permission configuration
  * Support for importing existing Claude Code memory files into Ghost with deduplication
  * Session start hook integration for seamless Claude Code workflow

* **Documentation**
  * Updated README with comprehensive MCP setup guide and requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->