### PR TITLE
fix(mcpinit): atomic settings write, allowlist sanitizer, hook consistency

### DIFF
--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -14,6 +14,7 @@ import (
 func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 	_, _ = io.Copy(io.Discard, stdin) // drain stdin
 	fmt.Fprintln(stdout, "Ghost memory is active. Before starting work:")
-	fmt.Fprintln(stdout, "1. Call ghost_project_context with the project name")
-	fmt.Fprintln(stdout, "2. Save discoveries with ghost_memory_save during work")
+	fmt.Fprintln(stdout, "1. Call ghost_list_projects to discover known projects")
+	fmt.Fprintln(stdout, "2. Call ghost_project_context with the project name")
+	fmt.Fprintln(stdout, "3. Save discoveries with ghost_memory_save during work")
 }

--- a/internal/mcpinit/init.go
+++ b/internal/mcpinit/init.go
@@ -236,19 +236,22 @@ func importMemories(w io.Writer) ([]projectInfo, error) {
 	return infos, nil
 }
 
-// sanitizeName strips characters that could inject markdown directives or
-// newlines into MEMORY.md files loaded by Claude Code.
+// sanitizeName allowlists safe characters for project names interpolated into
+// MEMORY.md files that Claude Code auto-loads (prevents prompt injection).
 func sanitizeName(name string) string {
 	var sb strings.Builder
 	for _, r := range name {
-		if r == '\n' || r == '\r' || r == '`' {
-			continue
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '-' || r == '_' || r == ' ' || r == '.' {
+			sb.WriteRune(r)
 		}
-		sb.WriteRune(r)
 	}
 	s := sb.String()
 	if len(s) > 64 {
 		s = s[:64]
+	}
+	if s == "" {
+		s = "unknown"
 	}
 	return s
 }

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -13,6 +13,9 @@ func TestHandleSessionStartHook(t *testing.T) {
 	HandleSessionStartHook(strings.NewReader(`{"event":"SessionStart"}`), &out)
 
 	output := out.String()
+	if !strings.Contains(output, "ghost_list_projects") {
+		t.Error("hook output should mention ghost_list_projects")
+	}
 	if !strings.Contains(output, "ghost_project_context") {
 		t.Error("hook output should mention ghost_project_context")
 	}

--- a/internal/mcpinit/settings.go
+++ b/internal/mcpinit/settings.go
@@ -75,13 +75,17 @@ func loadSettings(path string) (*settingsFile, error) {
 	return s, nil
 }
 
-// save writes the settings back to disk, creating a .bak backup first.
+// save writes the settings back to disk atomically, creating a .bak backup first.
 func (s *settingsFile) save() error {
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create dir %s: %w", dir, err)
+	}
+
 	// Backup existing file.
-	if _, err := os.Stat(s.path); err == nil {
-		data, err := os.ReadFile(s.path)
-		if err == nil {
-			_ = os.WriteFile(s.path+".bak", data, 0600)
+	if data, err := os.ReadFile(s.path); err == nil {
+		if err := os.WriteFile(s.path+".bak", data, 0600); err != nil {
+			return fmt.Errorf("backup %s: %w", s.path+".bak", err)
 		}
 	}
 
@@ -91,11 +95,31 @@ func (s *settingsFile) save() error {
 	}
 	out = append(out, '\n')
 
-	dir := filepath.Dir(s.path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("create dir %s: %w", dir, err)
+	// Atomic write: temp file + rename.
+	tmp, err := os.CreateTemp(dir, ".settings-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
 	}
-	return os.WriteFile(s.path, out, 0600)
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(out); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0600); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+	return nil
 }
 
 // getPermissions extracts the permissions.allow string slice.


### PR DESCRIPTION
## Summary
- **Atomic settings write**: Replace `os.WriteFile` with temp file + `os.Rename` for POSIX atomicity on `~/.claude/settings.json`. Backup failure is now a hard error.
- **Allowlist sanitizer**: Switch `sanitizeName` from denylist (strip backticks/newlines) to allowlist `[a-zA-Z0-9 -_.]` — prevents prompt injection via project names interpolated into MEMORY.md files that Claude Code auto-loads.
- **Hook consistency**: Add `ghost_list_projects` as step 1 in SessionStart hook output to match MEMORY.md redirect instructions.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./internal/mcpinit/...` passes
- [x] Updated test for new hook output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project name validation to handle special characters and edge cases more reliably
  * Enhanced settings file handling with automatic backups and safer persistence

* **Documentation**
  * Updated session start instructions to prioritize project discovery as the first recommended step

<!-- end of auto-generated comment: release notes by coderabbit.ai -->