### PR TITLE
feat(mcpinit): dry-run, status command, error recovery

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -51,9 +51,15 @@ func main() {
 			runServe()
 			return
 		case "mcp":
-			if len(os.Args) > 2 && os.Args[2] == "init" {
-				runMCPInit()
-				return
+			if len(os.Args) > 2 {
+				switch os.Args[2] {
+				case "init":
+					runMCPInit()
+					return
+				case "status":
+					runMCPStatus()
+					return
+				}
 			}
 			runMCP()
 			return
@@ -448,7 +454,16 @@ func runMCP() {
 
 // runMCPInit configures Claude Code to use Ghost as its memory system.
 func runMCPInit() {
-	if err := mcpinit.Run(os.Stdout); err != nil {
+	dryRun := len(os.Args) > 3 && os.Args[3] == "--dry-run"
+	if err := mcpinit.Run(os.Stdout, dryRun); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runMCPStatus checks the health of the Ghost ↔ Claude Code integration.
+func runMCPStatus() {
+	if err := mcpinit.Status(os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/internal/mcpinit/init.go
+++ b/internal/mcpinit/init.go
@@ -17,51 +17,69 @@ import (
 )
 
 // Run executes the 6-step Claude Code integration setup.
-func Run(w io.Writer) error {
+// When dryRun is true, it reports what would change without modifying anything.
+func Run(w io.Writer, dryRun bool) error {
+	if dryRun {
+		fmt.Fprintf(w, "\nDry run — showing what would change:\n\n")
+	}
+
 	// Step 1: Prerequisites.
-	fmt.Fprintln(w, "\n[1/6] Checking prerequisites...")
+	fmt.Fprintln(w, "[1/6] Checking prerequisites...")
 	ghostBin, claudeBin, err := checkPrereqs(w)
 	if err != nil {
-		return err
+		return retryHint(err)
 	}
 
 	// Step 2: MCP server registration.
 	fmt.Fprintln(w, "\n[2/6] Registering MCP server...")
-	if err := registerMCP(w, ghostBin, claudeBin); err != nil {
-		return err
+	if err := registerMCP(w, ghostBin, claudeBin, dryRun); err != nil {
+		return retryHint(err)
 	}
 
 	// Step 3: Tool permissions.
 	fmt.Fprintln(w, "\n[3/6] Adding tool permissions...")
 	settingsFile, err := ensurePermissions(w)
 	if err != nil {
-		return err
+		return retryHint(err)
 	}
 
 	// Step 4: SessionStart hook.
 	fmt.Fprintln(w, "\n[4/6] Configuring SessionStart hook...")
 	if err := ensureHook(w, settingsFile, ghostBin); err != nil {
-		return err
+		return retryHint(err)
 	}
 
 	// Save settings (steps 3+4 both modify it).
-	if err := settingsFile.save(); err != nil {
-		return fmt.Errorf("save settings: %w", err)
+	if dryRun {
+		fmt.Fprintln(w, "\n  (skipping settings write — dry run)")
+	} else {
+		if err := settingsFile.save(); err != nil {
+			return retryHint(fmt.Errorf("save settings: %w", err))
+		}
 	}
 
 	// Step 5: Import Claude Code memories.
 	fmt.Fprintln(w, "\n[5/6] Importing Claude Code memories...")
-	projects, err := importMemories(w)
+	projects, err := importMemories(w, dryRun)
 	if err != nil {
 		fmt.Fprintf(w, "  ! import error: %v (continuing)\n", err)
 	}
 
 	// Step 6: Project memory redirects.
 	fmt.Fprintln(w, "\n[6/6] Writing project memory redirects...")
-	writeRedirects(w, projects)
+	writeRedirects(w, projects, dryRun)
 
-	fmt.Fprintln(w, "\nDone! Restart Claude Code to activate.")
+	if dryRun {
+		fmt.Fprintln(w, "\nNo changes made (dry run).")
+	} else {
+		fmt.Fprintln(w, "\nDone! Restart Claude Code to activate.")
+	}
 	return nil
+}
+
+// retryHint wraps an error with a re-run suggestion.
+func retryHint(err error) error {
+	return fmt.Errorf("%w\n  Re-run `ghost mcp init` to retry", err)
 }
 
 // checkPrereqs verifies that both ghost and claude binaries are on PATH.
@@ -82,7 +100,7 @@ func checkPrereqs(w io.Writer) (ghostBin, claudeBin string, err error) {
 }
 
 // registerMCP ensures the ghost MCP server is registered with claude.
-func registerMCP(w io.Writer, ghostBin, claudeBin string) error {
+func registerMCP(w io.Writer, ghostBin, claudeBin string, dryRun bool) error {
 	// Check current registration.
 	out, err := exec.Command(claudeBin, "mcp", "get", "ghost").CombinedOutput()
 	currentOutput := string(out)
@@ -92,6 +110,15 @@ func registerMCP(w io.Writer, ghostBin, claudeBin string) error {
 
 	if alreadyRegistered && correctPath {
 		fmt.Fprintln(w, "  ✓ ghost MCP server already registered")
+		return nil
+	}
+
+	if dryRun {
+		if alreadyRegistered {
+			fmt.Fprintf(w, "  ~ would update ghost MCP server (command: %s)\n", ghostBin)
+		} else {
+			fmt.Fprintf(w, "  ~ would register ghost MCP server (command: %s)\n", ghostBin)
+		}
 		return nil
 	}
 
@@ -186,7 +213,7 @@ type projectInfo struct {
 
 // importMemories opens the Ghost DB and imports Claude Code memory files
 // for all known projects.
-func importMemories(w io.Writer) ([]projectInfo, error) {
+func importMemories(w io.Writer, dryRun bool) ([]projectInfo, error) {
 	dataDir, err := config.DataDir()
 	if err != nil {
 		return nil, fmt.Errorf("data dir: %w", err)
@@ -218,6 +245,11 @@ func importMemories(w io.Writer) ([]projectInfo, error) {
 		infos = append(infos, projectInfo{ID: p.ID, Path: p.Path, Name: p.Name})
 
 		if !filepath.IsAbs(p.Path) {
+			continue
+		}
+
+		if dryRun {
+			fmt.Fprintf(w, "  ~ %s — would scan for importable memories\n", p.Name)
 			continue
 		}
 
@@ -258,7 +290,7 @@ func sanitizeName(name string) string {
 
 // writeRedirects creates MEMORY.md redirect files in Claude's project memory
 // directories for each known Ghost project.
-func writeRedirects(w io.Writer, projects []projectInfo) {
+func writeRedirects(w io.Writer, projects []projectInfo, dryRun bool) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		fmt.Fprintf(w, "  ! cannot determine home directory: %v\n", err)
@@ -282,6 +314,11 @@ func writeRedirects(w io.Writer, projects []projectInfo) {
 			}
 			// File exists with other content — don't clobber.
 			fmt.Fprintf(w, "  - %s — MEMORY.md exists (not overwriting)\n", p.Name)
+			continue
+		}
+
+		if dryRun {
+			fmt.Fprintf(w, "  ~ %s — would create redirect\n", p.Name)
 			continue
 		}
 

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -2,6 +2,7 @@ package mcpinit
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,7 +34,7 @@ func TestWriteRedirects_CreatesFile(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	writeRedirects(&out, projects)
+	writeRedirects(&out, projects, false)
 
 	encoded := strings.ReplaceAll("/home/test/git/myproject", "/", "-")
 	target := filepath.Join(home, ".claude", "projects", encoded, "memory", "MEMORY.md")
@@ -76,7 +77,7 @@ func TestWriteRedirects_SkipsExisting(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	writeRedirects(&out, projects)
+	writeRedirects(&out, projects, false)
 
 	output := out.String()
 	if !strings.Contains(output, "redirect exists") {
@@ -93,7 +94,7 @@ func TestWriteRedirects_SkipsRelativePath(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	writeRedirects(&out, projects)
+	writeRedirects(&out, projects, false)
 
 	// Should produce no output for relative paths.
 	if out.String() != "" {
@@ -121,7 +122,7 @@ func TestWriteRedirects_DoesNotClobber(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	writeRedirects(&out, projects)
+	writeRedirects(&out, projects, false)
 
 	// Verify it was NOT overwritten.
 	data, _ := os.ReadFile(filepath.Join(dir, "MEMORY.md"))
@@ -132,6 +133,41 @@ func TestWriteRedirects_DoesNotClobber(t *testing.T) {
 	output := out.String()
 	if !strings.Contains(output, "not overwriting") {
 		t.Errorf("should say 'not overwriting', got: %s", output)
+	}
+}
+
+func TestWriteRedirects_DryRun(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projects := []projectInfo{
+		{ID: "abc123", Path: "/home/test/git/myproject", Name: "myproject"},
+	}
+
+	var out bytes.Buffer
+	writeRedirects(&out, projects, true)
+
+	output := out.String()
+	if !strings.Contains(output, "would create redirect") {
+		t.Errorf("dry run should say 'would create redirect', got: %s", output)
+	}
+
+	// Verify no file was created.
+	encoded := strings.ReplaceAll("/home/test/git/myproject", "/", "-")
+	target := filepath.Join(home, ".claude", "projects", encoded, "memory", "MEMORY.md")
+	if _, err := os.Stat(target); err == nil {
+		t.Error("dry run should not create files")
+	}
+}
+
+func TestRetryHint(t *testing.T) {
+	err := retryHint(fmt.Errorf("something broke"))
+	msg := err.Error()
+	if !strings.Contains(msg, "something broke") {
+		t.Error("should preserve original error")
+	}
+	if !strings.Contains(msg, "ghost mcp init") {
+		t.Error("should include retry hint")
 	}
 }
 

--- a/internal/mcpinit/status.go
+++ b/internal/mcpinit/status.go
@@ -1,0 +1,123 @@
+package mcpinit
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/wcatz/ghost/internal/claudeimport"
+	"github.com/wcatz/ghost/internal/config"
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+// Status checks the health of the Ghost ↔ Claude Code integration.
+func Status(w io.Writer) error {
+	fmt.Fprintf(w, "\nGhost ↔ Claude Code integration status:\n\n")
+
+	healthy := true
+	check := func(ok bool, pass, fail string) {
+		if ok {
+			fmt.Fprintf(w, "  ✓ %s\n", pass)
+		} else {
+			fmt.Fprintf(w, "  ✗ %s\n", fail)
+			healthy = false
+		}
+	}
+
+	// 1. Ghost binary.
+	ghostBin, err := exec.LookPath("ghost")
+	check(err == nil,
+		fmt.Sprintf("ghost binary: %s", ghostBin),
+		"ghost binary not found in PATH")
+
+	// 2. Claude CLI.
+	claudeBin, err := exec.LookPath("claude")
+	check(err == nil,
+		fmt.Sprintf("claude CLI: %s", claudeBin),
+		"claude CLI not found in PATH")
+
+	// 3. MCP server registration.
+	if claudeBin != "" {
+		out, err := exec.Command(claudeBin, "mcp", "get", "ghost").CombinedOutput()
+		registered := err == nil && strings.Contains(string(out), "Command:")
+		check(registered, "MCP server registered", "MCP server not registered")
+	}
+
+	// 4-5. Settings: permissions + hook.
+	path, err := settingsPath()
+	if err == nil {
+		sf, err := loadSettings(path)
+		if err == nil {
+			// Permissions.
+			existing, _ := sf.getPermissions()
+			set := make(map[string]bool, len(existing))
+			for _, p := range existing {
+				set[p] = true
+			}
+			var present int
+			for _, p := range ghostPermissions {
+				if set[p] {
+					present++
+				}
+			}
+			check(present == len(ghostPermissions),
+				fmt.Sprintf("permissions: %d/%d", present, len(ghostPermissions)),
+				fmt.Sprintf("permissions: %d/%d (run ghost mcp init)", present, len(ghostPermissions)))
+
+			// Hook.
+			hasHk := sf.hasHook("SessionStart", "ghost hook session-start")
+			check(hasHk, "SessionStart hook configured", "SessionStart hook missing")
+		} else {
+			fmt.Fprintf(w, "  ✗ cannot read settings: %v\n", err)
+			healthy = false
+		}
+	}
+
+	// 6. Project redirects.
+	dataDir, err := config.DataDir()
+	if err == nil {
+		dbPath := filepath.Join(dataDir, "ghost.db")
+		if _, err := os.Stat(dbPath); err == nil {
+			db, err := memory.OpenDB(dbPath)
+			if err == nil {
+				defer db.Close()
+				logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+				store := memory.NewStore(db, logger)
+				projects, err := store.ListProjects(context.Background())
+				if err == nil {
+					home, _ := os.UserHomeDir()
+					var total, redirected int
+					for _, p := range projects {
+						if !filepath.IsAbs(p.Path) {
+							continue
+						}
+						total++
+						encoded := claudeimport.EncodeProjectPath(p.Path)
+						target := filepath.Join(home, ".claude", "projects", encoded, "memory", "MEMORY.md")
+						if data, err := os.ReadFile(target); err == nil && strings.Contains(string(data), "stored in Ghost") {
+							redirected++
+						}
+					}
+					check(redirected == total,
+						fmt.Sprintf("project redirects: %d/%d", redirected, total),
+						fmt.Sprintf("project redirects: %d/%d", redirected, total))
+				}
+			}
+		} else {
+			fmt.Fprintln(w, "  - no Ghost database (run ghost first)")
+		}
+	}
+
+	fmt.Println()
+	if healthy {
+		fmt.Fprintln(w, "All checks passed.")
+	} else {
+		fmt.Fprintln(w, "Run `ghost mcp init` to fix issues.")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- **`ghost mcp init --dry-run`**: Preview what would change without modifying any files. Uses `~` prefix for "would do" actions vs `✓`/`+` for actual changes.
- **`ghost mcp status`**: Health check for the Ghost ↔ Claude Code integration — verifies MCP registration, permissions (N/M), SessionStart hook, and project redirects.
- **Error recovery**: Failed init steps now include "Re-run `ghost mcp init` to retry" hint since the command is idempotent.

## Test plan
- [x] `go vet ./...` clean
- [x] All 17 mcpinit tests pass
- [x] New tests: `TestWriteRedirects_DryRun`, `TestRetryHint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ghost mcp status` command to verify MCP integration health and check component configuration
  * Added `--dry-run` flag to `ghost mcp init` to preview changes before applying them

* **Improvements**
  * Enhanced error messages with retry guidance for failed operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->