### PR TITLE
fix(mcpinit): idempotent MCP registration

### DIFF
--- a/internal/mcpinit/init.go
+++ b/internal/mcpinit/init.go
@@ -122,6 +122,11 @@ func registerMCP(w io.Writer, ghostBin, claudeBin string, dryRun bool) error {
 		return nil
 	}
 
+	// Remove stale registration before re-adding.
+	if alreadyRegistered {
+		_ = exec.Command(claudeBin, "mcp", "remove", "-s", "user", "ghost").Run()
+	}
+
 	// Register or update.
 	mcpConfig := map[string]any{
 		"type":    "stdio",


### PR DESCRIPTION
## Summary
- `claude mcp add-json` rejects duplicates with "already exists" error
- When server is registered but path is stale, remove it first then re-add
- Fixes `ghost mcp init` failing on second run

## Test plan
- [x] `ghost mcp init` succeeds on fresh setup
- [x] `ghost mcp init` succeeds on re-run (idempotent)
- [x] `ghost mcp status` shows all green after init

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude MCP registration handling by removing stale registrations before re-registering, ensuring proper configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->