### PR TITLE
feat(cli): help output, -v flag, ghost upgrade, mcp guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ make build
 
 Download from [GitHub Releases](https://github.com/wcatz/ghost/releases) — available for linux, macOS, and Windows (amd64 + arm64).
 
+### Update
+
+```bash
+ghost upgrade
+```
+
+Downloads the latest release from GitHub, replaces the running binary in-place (wherever it lives), and prints the version diff. No package manager required.
+
 ### Docker
 
 ```bash
@@ -84,6 +92,15 @@ ghost serve
 
 # MCP server for Claude Code / Cursor
 ghost mcp
+
+# Set up Claude Code integration
+ghost mcp init
+
+# Check integration health
+ghost mcp status
+
+# Self-update to latest release
+ghost upgrade
 ```
 
 ## Runtime Modes
@@ -99,7 +116,7 @@ ghost mcp
 | `-continue` | Resume last conversation |
 | `-no-memory` | Disable automatic memory extraction |
 | `-no-tui` | Force legacy REPL (no bubbletea) |
-| `-version` | Print version and exit |
+| `-v`, `version` | Print version and exit |
 
 **Slash commands:**
 
@@ -191,7 +208,9 @@ The MCP server ships with comprehensive instructions that teach Claude when and 
 One command to fully integrate Ghost with Claude Code:
 
 ```bash
-ghost mcp init
+ghost mcp init              # configure everything
+ghost mcp init --dry-run    # preview changes without modifying files
+ghost mcp status            # verify integration health
 ```
 
 This configures:
@@ -358,6 +377,8 @@ internal/
   tui/                     Terminal REPL (bubbletea)
   server/                  HTTP REST API (chi)
   mcpserver/               MCP server (stdio, 13 tools + resources)
+  mcpinit/                 Claude Code integration setup (init, status, hook)
+  selfupdate/              Self-update from GitHub releases
   telegram/                Bot, approvals, session management
   google/                  Calendar + Gmail OAuth2
   calendar/                CalDAV client

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/wcatz/ghost/internal/memory"
 	"github.com/wcatz/ghost/internal/orchestrator"
 	"github.com/wcatz/ghost/internal/scheduler"
+	"github.com/wcatz/ghost/internal/selfupdate"
 	"github.com/wcatz/ghost/internal/server"
 	"github.com/wcatz/ghost/internal/telegram"
 	"github.com/wcatz/ghost/internal/tool"
@@ -44,9 +45,15 @@ func (s *stringSlice) Set(v string) error {
 }
 
 func main() {
-	// Check for subcommands before flag parsing.
+	// Check for subcommands and flags before flag parsing.
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
+		case "-v", "--version", "version":
+			fmt.Printf("ghost %s\n", version)
+			return
+		case "help", "--help", "-h":
+			printUsage()
+			return
 		case "serve":
 			runServe()
 			return
@@ -66,26 +73,24 @@ func main() {
 		case "hook":
 			runHook()
 			return
+		case "upgrade":
+			runUpgrade()
+			return
 		}
 	}
 
 	var (
-		projects    stringSlice
-		modeFlag    = flag.String("mode", "", "Operating mode: chat, code, debug, review, plan, refactor")
+		projects stringSlice
+		modeFlag = flag.String("mode", "", "Operating mode: chat, code, debug, review, plan, refactor")
 		modelFlag   = flag.String("model", "", "Model override (e.g. claude-opus-4-6-20250514)")
 		yolo        = flag.Bool("yolo", false, "Skip all tool approval prompts")
 		noMemory    = flag.Bool("no-memory", false, "Disable memory extraction for this session")
 		noTUI       = flag.Bool("no-tui", false, "Force legacy REPL (no bubbletea)")
 		cont        = flag.Bool("continue", false, "Resume last conversation")
-		versionFlag = flag.Bool("version", false, "Print version and exit")
 	)
+	flag.Usage = printUsage
 	flag.Var(&projects, "project", "Project path (can be specified multiple times)")
 	flag.Parse()
-
-	if *versionFlag {
-		fmt.Printf("ghost %s\n", version)
-		os.Exit(0)
-	}
 
 	cfg, logger, store, _ := bootstrap()
 	defer store.Close()
@@ -428,6 +433,11 @@ func runServe() {
 
 // runMCP starts ghost as an MCP server on stdio.
 func runMCP() {
+	if tui.IsTerminal() {
+		fmt.Fprintln(os.Stderr, "Starting MCP server on stdio (this is meant to be called by Claude Code).")
+		fmt.Fprintln(os.Stderr, "If you meant to set up the integration, run: ghost mcp init")
+		fmt.Fprintln(os.Stderr, "")
+	}
 	cfg, logger, store, _ := bootstrap()
 	defer store.Close()
 
@@ -467,6 +477,90 @@ func runMCPStatus() {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// printUsage displays the top-level help.
+func printUsage() {
+	fmt.Fprintf(os.Stderr, `ghost %s — memory-first AI assistant
+
+Usage:
+  ghost [flags] [message]     Start interactive session or send one-shot message
+  ghost <command>             Run a subcommand
+
+Commands:
+  serve                       Start HTTP daemon with all subsystems
+  mcp                         Start MCP server on stdio (used by Claude Code)
+  mcp init [--dry-run]        Configure Claude Code integration
+  mcp status                  Check Claude Code integration health
+  upgrade                     Update ghost to the latest release
+  version                     Print version
+
+Flags:
+  -mode string                Operating mode: chat, code, debug, review, plan, refactor
+  -model string               Model override (e.g. claude-opus-4-6-20250514)
+  -project path               Project path (repeatable)
+  -continue                   Resume last conversation
+  -yolo                       Skip all tool approval prompts
+  -no-memory                  Disable memory extraction for this session
+  -no-tui                     Force legacy REPL (no bubbletea)
+
+Environment:
+  ANTHROPIC_API_KEY           Required for AI features
+  GHOST_DEBUG                 Enable debug logging
+  GHOST_PLAIN                 Force plain REPL (no bubbletea)
+`, version)
+}
+
+// runUpgrade downloads and installs the latest ghost release.
+func runUpgrade() {
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: cannot determine binary path: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Current: ghost %s (%s)\n", version, exe)
+	fmt.Println("Checking for updates...")
+
+	rel, err := selfupdate.LatestRelease()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	latest := strings.TrimPrefix(rel.TagName, "v")
+	if latest == version {
+		fmt.Printf("Already up to date (%s).\n", version)
+		return
+	}
+
+	asset, err := selfupdate.FindAsset(rel)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Downloading %s...\n", asset.Name)
+	body, err := selfupdate.Download(asset.BrowserDownloadURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	defer body.Close()
+
+	bin, err := selfupdate.ExtractBinary(body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Replacing %s...\n", exe)
+	if err := selfupdate.Replace(exe, bin); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Updated: ghost %s → %s\n", version, latest)
 }
 
 // runHook dispatches Claude Code hook events.

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -747,7 +747,7 @@ func formatMemories(memories []memory.Memory) string {
 			tagsJSON, _ := json.Marshal(m.Tags)
 			tags = " tags:" + string(tagsJSON)
 		}
-		sb.WriteString(fmt.Sprintf("- [%s] (%.1f%s%s) %s\n", m.Category, m.Importance, pin, tags, m.Content))
+		sb.WriteString(fmt.Sprintf("- [%s] `%s` (%.1f%s%s) %s\n", m.Category, m.ID, m.Importance, pin, tags, m.Content))
 	}
 	return sb.String()
 }

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -100,23 +100,23 @@ func TestFormatMemories(t *testing.T) {
 		{
 			name: "single memory",
 			memories: []memory.Memory{
-				{Category: "fact", Importance: 0.7, Content: "test content"},
+				{ID: "ABC123", Category: "fact", Importance: 0.7, Content: "test content"},
 			},
-			wantIn: []string{"[fact]", "0.7", "test content"},
+			wantIn: []string{"[fact]", "`ABC123`", "0.7", "test content"},
 		},
 		{
 			name: "pinned memory",
 			memories: []memory.Memory{
-				{Category: "decision", Importance: 0.9, Content: "important decision", Pinned: true},
+				{ID: "DEF456", Category: "decision", Importance: 0.9, Content: "important decision", Pinned: true},
 			},
-			wantIn: []string{"[pinned]", "decision", "important decision"},
+			wantIn: []string{"`DEF456`", "[pinned]", "decision", "important decision"},
 		},
 		{
 			name: "memory with tags",
 			memories: []memory.Memory{
-				{Category: "pattern", Importance: 0.5, Content: "tagged memory", Tags: []string{"go", "test"}},
+				{ID: "GHI789", Category: "pattern", Importance: 0.5, Content: "tagged memory", Tags: []string{"go", "test"}},
 			},
-			wantIn: []string{"tags:", "go", "test", "tagged memory"},
+			wantIn: []string{"`GHI789`", "tags:", "go", "test", "tagged memory"},
 		},
 	}
 

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,0 +1,175 @@
+// Package selfupdate provides self-update capability for ghost binaries
+// by downloading releases from GitHub.
+package selfupdate
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+)
+
+const repoAPI = "https://api.github.com/repos/wcatz/ghost/releases/latest"
+
+// Release represents the subset of GitHub release API we need.
+type Release struct {
+	TagName string  `json:"tag_name"`
+	Assets  []Asset `json:"assets"`
+}
+
+// Asset represents a release asset.
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// LatestRelease fetches the latest release metadata from GitHub.
+func LatestRelease() (*Release, error) {
+	req, err := http.NewRequest("GET", repoAPI, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("github API returned %d", resp.StatusCode)
+	}
+
+	var rel Release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("decode release: %w", err)
+	}
+	return &rel, nil
+}
+
+// AssetName returns the expected archive name for the current platform.
+func AssetName(version string) string {
+	os := runtime.GOOS
+	arch := runtime.GOARCH
+	ext := "tar.gz"
+	if os == "windows" {
+		ext = "zip"
+	}
+	return fmt.Sprintf("ghost_%s_%s_%s.%s", version, os, arch, ext)
+}
+
+// FindAsset finds the matching asset for the current platform.
+func FindAsset(rel *Release) (*Asset, error) {
+	ver := strings.TrimPrefix(rel.TagName, "v")
+	want := AssetName(ver)
+	for i := range rel.Assets {
+		if rel.Assets[i].Name == want {
+			return &rel.Assets[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no release asset for %s/%s (expected %s)", runtime.GOOS, runtime.GOARCH, want)
+}
+
+// Download fetches the asset and returns the reader. Caller must close.
+func Download(url string) (io.ReadCloser, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("download: %w", err)
+	}
+	if resp.StatusCode != 200 {
+		resp.Body.Close()
+		return nil, fmt.Errorf("download returned %d", resp.StatusCode)
+	}
+	return resp.Body, nil
+}
+
+// ExtractBinary extracts the "ghost" binary from a .tar.gz archive.
+func ExtractBinary(r io.Reader) ([]byte, error) {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("tar: %w", err)
+		}
+		// The binary is at the root of the archive, named "ghost" or "ghost.exe".
+		name := hdr.Name
+		if name == "ghost" || name == "ghost.exe" {
+			return io.ReadAll(tr)
+		}
+	}
+	return nil, fmt.Errorf("ghost binary not found in archive")
+}
+
+// Replace atomically replaces the binary at targetPath.
+func Replace(targetPath string, newBinary []byte) error {
+	// Resolve symlinks so we replace the actual file.
+	resolved, err := resolveSymlinks(targetPath)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", resolved, err)
+	}
+
+	// Write to temp file next to target, then rename.
+	dir := dirOf(resolved)
+	tmp, err := os.CreateTemp(dir, ".ghost-update-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(newBinary); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Chmod(tmpPath, info.Mode()); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, resolved); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+func resolveSymlinks(path string) (string, error) {
+	resolved, err := os.Readlink(path)
+	if err != nil {
+		// Not a symlink.
+		return path, nil
+	}
+	return resolved, nil
+}
+
+func dirOf(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' || path[i] == '\\' {
+			return path[:i]
+		}
+	}
+	return "."
+}


### PR DESCRIPTION
## Summary
- **Custom help**: `ghost help` / `--help` / `-h` shows subcommands, flags, and env vars instead of raw `flag.Usage`
- **Version shorthand**: `ghost -v` / `ghost version` alongside existing `--version`
- **`ghost upgrade`**: Self-update from GitHub releases. Uses `os.Executable()` to find and replace the running binary — works regardless of install location
- **MCP terminal guard**: `ghost mcp` from a terminal prints a warning + hint instead of silently hanging on stdio
- **README**: documents `ghost upgrade`, `mcp init --dry-run`, `mcp status`

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `ghost -v`, `ghost version`, `ghost help`, `ghost --help` all produce correct output
- [x] `ghost upgrade` tested manually (self-update flow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ghost upgrade` command for automatic binary updates from GitHub releases
  * Improved version and help handling with `-v`, `--version`, `version`, `help`, `--help`, `-h` support

* **Documentation**
  * Expanded Quick Start with MCP initialization examples (`ghost mcp init`, `--dry-run`, `status`)
  * Added self-update and architecture documentation

* **Improvements**
  * Memory listings now display unique IDs for easier reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->