### PR TITLE
feat(mcp,reflection): tool annotations, tiered consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Pure Go. No CGO. Single binary.
 - **3-block prompt caching** — 90%+ cache hit rates, ~76% savings on input tokens
 - **Hybrid search** — FTS5 keyword + vector cosine similarity via Reciprocal Rank Fusion
 - **Free embeddings** — `nomic-embed-text:v1.5` runs locally through Ollama, no API costs
+- **Tiered consolidation** — memory dedup via Haiku API, Ollama local LLM, or pure SQLite (works without API credits)
 - **Time-decay scoring** — stale memories fade automatically by category half-life
 - **Cost tracking** — per-session and monthly cost aggregation with cache savings, API vs subscription comparison
 - **Google Calendar + Gmail** — meeting notifications, email summaries via OAuth2
@@ -311,6 +312,26 @@ CalDAV is also supported as an alternative calendar source (iCloud, Fastmail, et
 | gotcha | 30-day | Bugs and edge cases |
 | dependency | 30-day | Libraries and versions |
 
+### Tiered Consolidation
+
+Memory consolidation runs periodically to merge duplicates, prune stale entries, and maintain quality. Three tiers are available — Ghost tries the highest quality tier and falls back automatically:
+
+| Tier | Backend | Cost | Quality | Requirements |
+|------|---------|------|---------|-------------|
+| 2 | Haiku API | ~$0.001/run | Best | Anthropic API key |
+| 1 | Ollama (`qwen2.5:3b`) | Free | Good | Ollama running locally |
+| 0 | SQLite (Jaccard dedup) | Free | Mechanical | None (always available) |
+
+Default is `auto` — uses the best available tier. Configure explicitly:
+
+```yaml
+reflection:
+  backend: "auto"              # auto, haiku, ollama, sqlite, disabled
+  ollama_model: "qwen2.5:3b"  # model for Ollama tier
+```
+
+Users with a Claude subscription but no API credits: install [Ollama](https://ollama.com) and `ollama pull qwen2.5:3b` for free local consolidation.
+
 ## Configuration
 
 Config loads in layers (later overrides earlier):
@@ -336,6 +357,10 @@ embedding:
   enabled: true
   ollama_url: "http://localhost:11434"
   model: "nomic-embed-text:v1.5"
+
+reflection:
+  backend: "auto"                      # auto, haiku, ollama, sqlite, disabled
+  ollama_model: "qwen2.5:3b"
 
 github:
   token: "ghp_..."
@@ -369,7 +394,7 @@ internal/
   tool/                    Tool registry + built-in executors (file, grep, glob, git, bash, memory)
   orchestrator/            Multi-project sessions, context compression, multi-turn caching
   claudeimport/            Auto-import Claude Code memory files on first project contact
-  reflection/              Haiku memory consolidation + auto-extraction
+  reflection/              Tiered memory consolidation (Haiku → Ollama → SQLite) + auto-extraction
   prompt/                  3-block cached system prompt
   mode/                    Operating modes (chat, code, debug, review, plan, refactor)
   project/                 Auto-detection (language, tests, git)

--- a/internal/config/config.example.yaml
+++ b/internal/config/config.example.yaml
@@ -46,6 +46,12 @@
 #   model: "nomic-embed-text:v1.5"   # 274MB, runs fine on CPU
 #   dimensions: 768
 
+# --- Memory Consolidation ---
+# reflection:
+#   backend: "auto"                  # "auto", "haiku", "ollama", "sqlite", "disabled"
+#                                    # auto: tries haiku → ollama → sqlite
+#   ollama_model: "qwen2.5:3b"      # model for Ollama tier (runs locally, no API cost)
+
 # --- GitHub Notifications ---
 # github:
 #   token: ""                        # PAT with notifications scope

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,15 +28,16 @@ var exampleConfig []byte
 
 // Config holds the global ghost configuration.
 type Config struct {
-	API       APIConfig       `koanf:"api"`
-	Defaults  DefaultsConfig  `koanf:"defaults"`
-	Display   DisplayConfig   `koanf:"display"`
-	Server    ServerConfig    `koanf:"server"`
-	Embedding EmbeddingConfig `koanf:"embedding"`
-	GitHub    GitHubConfig    `koanf:"github"`
-	Telegram  TelegramConfig  `koanf:"telegram"`
-	Calendar  CalendarConfig  `koanf:"calendar"`
-	Google    GoogleConfig    `koanf:"google"`
+	API        APIConfig        `koanf:"api"`
+	Defaults   DefaultsConfig   `koanf:"defaults"`
+	Display    DisplayConfig    `koanf:"display"`
+	Server     ServerConfig     `koanf:"server"`
+	Embedding  EmbeddingConfig  `koanf:"embedding"`
+	Reflection ReflectionConfig `koanf:"reflection"`
+	GitHub     GitHubConfig     `koanf:"github"`
+	Telegram   TelegramConfig   `koanf:"telegram"`
+	Calendar   CalendarConfig   `koanf:"calendar"`
+	Google     GoogleConfig     `koanf:"google"`
 	Briefing   BriefingConfig   `koanf:"briefing"`
 	CostReport CostReportConfig `koanf:"cost_report"`
 	Voice      VoiceConfig      `koanf:"voice"`
@@ -91,6 +92,12 @@ type VoiceConfig struct {
 type ServerConfig struct {
 	ListenAddr string `koanf:"listen_addr"`
 	AuthToken  string `koanf:"auth_token"`
+}
+
+// ReflectionConfig holds memory consolidation settings.
+type ReflectionConfig struct {
+	Backend     string `koanf:"backend"`      // "auto", "haiku", "ollama", "sqlite", "disabled"
+	OllamaModel string `koanf:"ollama_model"` // model for Ollama tier (default "qwen2.5:3b")
 }
 
 // EmbeddingConfig holds local embedding settings.
@@ -167,6 +174,8 @@ var defaults = map[string]interface{}{
 	"embedding.ollama_url":       "http://localhost:11434",
 	"embedding.model":            "nomic-embed-text:v1.5",
 	"embedding.dimensions":       768,
+	"reflection.backend":         "auto",
+	"reflection.ollama_model":    "qwen2.5:3b",
 	"github.interval":            60,
 	"briefing.enabled":           false,
 	"briefing.schedule":          "0 8 * * 1-5",

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -23,6 +23,36 @@ type Embedder interface {
 	Embed(ctx context.Context, text string) ([]float32, error)
 }
 
+func boolPtr(b bool) *bool { return &b }
+
+// validateTags enforces tag limits: max 10 tags, max 64 chars each.
+func validateTags(tags []string) []string {
+	if len(tags) > 10 {
+		tags = tags[:10]
+	}
+	for i, t := range tags {
+		if len(t) > 64 {
+			tags[i] = t[:64]
+		}
+	}
+	return tags
+}
+
+// defaultImportance returns the importance value, defaulting to fallback when nil.
+func defaultImportance(p *float32, fallback float32) float32 {
+	if p == nil {
+		return fallback
+	}
+	v := *p
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
 // Server wraps the MCP server with Ghost's memory store.
 type Server struct {
 	store     provider.MemoryStore
@@ -153,6 +183,10 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_memory_search",
 		Description: "Search Ghost's memory for project facts, patterns, decisions, and gotchas. Use this to recall things learned in previous sessions.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:  true,
+			OpenWorldHint: boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args searchArgs) (*mcp.CallToolResult, any, error) {
 		if args.ProjectID == "" || args.Query == "" {
 			return nil, nil, fmt.Errorf("project_id and query are required")
@@ -190,13 +224,18 @@ func (s *Server) registerTools() {
 		ProjectID  string   `json:"project_id" jsonschema:"Project ID to save the memory under"`
 		Content    string   `json:"content" jsonschema:"The memory content to save"`
 		Category   string   `json:"category,omitempty" jsonschema:"Category: architecture, decision, pattern, convention, gotcha, dependency, preference, fact"`
-		Importance float32  `json:"importance,omitempty" jsonschema:"Importance score 0.0-1.0 (default 0.7)"`
+		Importance *float32 `json:"importance,omitempty" jsonschema:"Importance score 0.0-1.0 (default 0.7)"`
 		Tags       []string `json:"tags,omitempty" jsonschema:"Optional tags for categorization"`
 	}
 
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_memory_save",
 		Description: "Save a memory about the project. Call this proactively when you discover gotchas, learn architectural patterns, receive user feedback worth preserving, or encounter surprising behavior. Do not wait to be asked — save immediately when something is worth remembering across sessions.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args saveArgs) (*mcp.CallToolResult, any, error) {
 		if args.ProjectID == "" || args.Content == "" {
 			return nil, nil, fmt.Errorf("project_id and content are required")
@@ -211,22 +250,18 @@ func (s *Server) registerTools() {
 		if !validCategories[args.Category] {
 			return nil, nil, fmt.Errorf("invalid category %q — must be one of: architecture, decision, pattern, convention, gotcha, dependency, preference, fact", args.Category)
 		}
-		if args.Importance <= 0 {
-			args.Importance = 0.7
-		}
-		if args.Importance > 1 {
-			args.Importance = 1
-		}
+		importance := defaultImportance(args.Importance, 0.7)
 		if args.Tags == nil {
 			args.Tags = []string{}
 		}
+		args.Tags = validateTags(args.Tags)
 		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
 
 		if err := s.store.EnsureProject(ctx, args.ProjectID, args.ProjectID, args.ProjectID); err != nil {
 			return nil, nil, fmt.Errorf("ensure project: %w", err)
 		}
 
-		id, merged, err := s.store.Upsert(ctx, args.ProjectID, args.Category, args.Content, "mcp", args.Importance, args.Tags)
+		id, merged, err := s.store.Upsert(ctx, args.ProjectID, args.Category, args.Content, "mcp", importance, args.Tags)
 		if err != nil {
 			return nil, nil, fmt.Errorf("save failed: %w", err)
 		}
@@ -259,6 +294,10 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_project_context",
 		Description: "Get Ghost's accumulated knowledge about a project: top memories ranked by importance and recency, plus any learned context summaries. Use this at the start of a session to recall what Ghost knows.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:  true,
+			OpenWorldHint: boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args contextArgs) (*mcp.CallToolResult, any, error) {
 		if args.ProjectID == "" {
 			return nil, nil, fmt.Errorf("project_id is required")
@@ -321,6 +360,10 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_memories_list",
 		Description: "List Ghost memories for a project, optionally filtered by category.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:  true,
+			OpenWorldHint: boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args listArgs) (*mcp.CallToolResult, any, error) {
 		if args.ProjectID == "" {
 			return nil, nil, fmt.Errorf("project_id is required")
@@ -361,6 +404,10 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_memory_delete",
 		Description: "Delete a specific memory by its ID.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(true),
+			OpenWorldHint:   boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args deleteArgs) (*mcp.CallToolResult, any, error) {
 		if args.MemoryID == "" {
 			return nil, nil, fmt.Errorf("memory_id is required")
@@ -384,6 +431,10 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_search_all",
 		Description: "Search Ghost memories across ALL projects. Use when looking for cross-project patterns or when unsure which project a memory belongs to.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:  true,
+			OpenWorldHint: boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args searchAllArgs) (*mcp.CallToolResult, any, error) {
 		if args.Query == "" {
 			return nil, nil, fmt.Errorf("query is required")
@@ -409,13 +460,18 @@ func (s *Server) registerTools() {
 	type saveGlobalArgs struct {
 		Content    string   `json:"content" jsonschema:"The memory content to save"`
 		Category   string   `json:"category,omitempty" jsonschema:"Category (default: fact)"`
-		Importance float32  `json:"importance,omitempty" jsonschema:"Importance 0.0-1.0 (default 0.8)"`
+		Importance *float32 `json:"importance,omitempty" jsonschema:"Importance 0.0-1.0 (default 0.8)"`
 		Tags       []string `json:"tags,omitempty" jsonschema:"Optional tags"`
 	}
 
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_save_global",
 		Description: "Save a memory that applies across all projects: personal preferences, coding conventions, toolchain facts, cross-repo relationships.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args saveGlobalArgs) (*mcp.CallToolResult, any, error) {
 		if args.Content == "" {
 			return nil, nil, fmt.Errorf("content is required")
@@ -423,20 +479,16 @@ func (s *Server) registerTools() {
 		if args.Category == "" {
 			args.Category = "fact"
 		}
-		if args.Importance <= 0 {
-			args.Importance = 0.8
-		}
-		if args.Importance > 1 {
-			args.Importance = 1
-		}
+		importance := defaultImportance(args.Importance, 0.8)
 		if args.Tags == nil {
 			args.Tags = []string{}
 		}
+		args.Tags = validateTags(args.Tags)
 
 		if err := s.store.EnsureProject(ctx, "_global", "_global", "global"); err != nil {
 			return nil, nil, fmt.Errorf("ensure global project: %w", err)
 		}
-		id, merged, err := s.store.Upsert(ctx, "_global", args.Category, args.Content, "mcp", args.Importance, args.Tags)
+		id, merged, err := s.store.Upsert(ctx, "_global", args.Category, args.Content, "mcp", importance, args.Tags)
 		if err != nil {
 			return nil, nil, fmt.Errorf("save failed: %w", err)
 		}
@@ -462,6 +514,10 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_task_create",
 		Description: "Create a task for a project. Use for work items that should survive across sessions — bugs to fix, features to implement, follow-ups to revisit.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(false),
+			OpenWorldHint:   boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args taskCreateArgs) (*mcp.CallToolResult, any, error) {
 		if args.ProjectID == "" || args.Title == "" {
 			return nil, nil, fmt.Errorf("project_id and title are required")
@@ -488,6 +544,10 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_task_list",
 		Description: "List tasks for a project, optionally filtered by status.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:  true,
+			OpenWorldHint: boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args taskListArgs) (*mcp.CallToolResult, any, error) {
 		if args.ProjectID == "" {
 			return nil, nil, fmt.Errorf("project_id is required")
@@ -523,6 +583,11 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_task_complete",
 		Description: "Mark a task as done with optional completion notes.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args taskCompleteArgs) (*mcp.CallToolResult, any, error) {
 		if args.TaskID == "" {
 			return nil, nil, fmt.Errorf("task_id is required")
@@ -548,6 +613,10 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_decision_record",
 		Description: "Record an architectural or design decision with rationale and alternatives considered. Use this instead of ghost_memory_save when a choice was made between alternatives. Also saved as a memory for future recall.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(false),
+			OpenWorldHint:   boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args decisionRecordArgs) (*mcp.CallToolResult, any, error) {
 		if args.ProjectID == "" || args.Title == "" || args.Decision == "" || args.Rationale == "" {
 			return nil, nil, fmt.Errorf("project_id, title, decision, and rationale are required")
@@ -559,6 +628,7 @@ func (s *Server) registerTools() {
 		if args.Tags == nil {
 			args.Tags = []string{}
 		}
+		args.Tags = validateTags(args.Tags)
 		id, err := s.store.RecordDecision(ctx, args.ProjectID, args.Title, args.Decision, args.Rationale, args.Alternatives, args.Tags)
 		if err != nil {
 			return nil, nil, fmt.Errorf("record decision: %w", err)
@@ -572,6 +642,10 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_health",
 		Description: "Get Ghost system health: project count, memory counts, embedding status.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:  true,
+			OpenWorldHint: boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct{}) (*mcp.CallToolResult, any, error) {
 		projects, err := s.store.ListProjects(ctx)
 		if err != nil {
@@ -608,6 +682,10 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_list_projects",
 		Description: "List all projects Ghost knows about with their names, IDs, paths, and memory counts. Use at session start to find the project_id for the current codebase.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:  true,
+			OpenWorldHint: boolPtr(false),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct{}) (*mcp.CallToolResult, any, error) {
 		projects, err := s.store.ListProjects(ctx)
 		if err != nil {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -589,3 +589,56 @@ func TestFormatMemories_EdgeCases(t *testing.T) {
 		t.Errorf("expected 3 lines, got %d", len(lines))
 	}
 }
+
+func TestValidateTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     []string
+		wantLen  int
+		wantLast string
+	}{
+		{"nil", nil, 0, ""},
+		{"empty", []string{}, 0, ""},
+		{"under limit", []string{"a", "b", "c"}, 3, "c"},
+		{"at limit", make([]string, 10), 10, ""},
+		{"over limit", make([]string, 15), 10, ""},
+		{"long tag", []string{strings.Repeat("x", 100)}, 1, strings.Repeat("x", 64)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateTags(tt.tags)
+			if len(got) != tt.wantLen {
+				t.Errorf("len = %d, want %d", len(got), tt.wantLen)
+			}
+			if tt.wantLast != "" && len(got) > 0 && got[len(got)-1] != tt.wantLast {
+				t.Errorf("last = %q, want %q", got[len(got)-1], tt.wantLast)
+			}
+		})
+	}
+}
+
+func TestDefaultImportance(t *testing.T) {
+	f := func(v float32) *float32 { return &v }
+
+	tests := []struct {
+		name     string
+		p        *float32
+		fallback float32
+		want     float32
+	}{
+		{"nil defaults", nil, 0.7, 0.7},
+		{"explicit zero", f(0), 0.7, 0},
+		{"normal value", f(0.5), 0.7, 0.5},
+		{"clamp high", f(2.0), 0.7, 1.0},
+		{"clamp negative", f(-1), 0.7, 0},
+		{"max value", f(1.0), 0.7, 1.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := defaultImportance(tt.p, tt.fallback)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -59,7 +59,8 @@ func (o *Orchestrator) StartSession(projectPath string) (*Session, error) {
 	}
 
 	builder := prompt.NewBuilder(o.store)
-	reflector := reflection.NewEngine(o.client, o.store, o.logger, o.cfg.Defaults.ReflectionInterval)
+	consolidator := o.buildConsolidator()
+	reflector := reflection.NewEngine(consolidator, o.store, o.logger, o.cfg.Defaults.ReflectionInterval)
 
 	s := NewSession(
 		projCtx,
@@ -183,4 +184,33 @@ func (o *Orchestrator) Shutdown(_ context.Context) error {
 		s.mu.Unlock()
 	}
 	return nil
+}
+
+// buildConsolidator creates the appropriate memory consolidator based on config.
+func (o *Orchestrator) buildConsolidator() reflection.Consolidator {
+	backend := o.cfg.Reflection.Backend
+	if backend == "" {
+		backend = "auto"
+	}
+
+	switch backend {
+	case "haiku":
+		return reflection.NewHaikuConsolidator(o.client)
+	case "ollama":
+		return reflection.NewOllamaConsolidator(o.cfg.Embedding.OllamaURL, o.cfg.Reflection.OllamaModel)
+	case "sqlite":
+		return reflection.NewSQLiteConsolidator()
+	case "disabled":
+		return nil
+	default: // "auto"
+		var tiers []reflection.Consolidator
+		if o.client != nil {
+			tiers = append(tiers, reflection.NewHaikuConsolidator(o.client))
+		}
+		if o.cfg.Embedding.OllamaURL != "" {
+			tiers = append(tiers, reflection.NewOllamaConsolidator(o.cfg.Embedding.OllamaURL, o.cfg.Reflection.OllamaModel))
+		}
+		tiers = append(tiers, reflection.NewSQLiteConsolidator())
+		return reflection.NewTieredConsolidator(tiers, o.logger)
+	}
 }

--- a/internal/reflection/consolidator.go
+++ b/internal/reflection/consolidator.go
@@ -1,0 +1,81 @@
+package reflection
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+)
+
+// Consolidator performs memory consolidation. Each tier implements this
+// differently: Haiku uses the Anthropic API, Ollama uses a local LLM,
+// and SQLite uses Jaccard similarity for mechanical deduplication.
+type Consolidator interface {
+	Name() string
+	Available(ctx context.Context) bool
+	Consolidate(ctx context.Context, input ReflectionInput) (ReflectionResult, error)
+}
+
+// TieredConsolidator tries consolidators in priority order (highest tier first),
+// falling back to the next tier on failure or unavailability.
+type TieredConsolidator struct {
+	tiers  []Consolidator
+	active atomic.Int32
+	logger *slog.Logger
+}
+
+// NewTieredConsolidator creates a consolidator that tries each tier in order.
+// Tiers should be ordered from highest quality to lowest (e.g. haiku, ollama, sqlite).
+func NewTieredConsolidator(tiers []Consolidator, logger *slog.Logger) *TieredConsolidator {
+	return &TieredConsolidator{
+		tiers:  tiers,
+		logger: logger,
+	}
+}
+
+func (t *TieredConsolidator) Name() string {
+	idx := int(t.active.Load())
+	if idx >= 0 && idx < len(t.tiers) {
+		return "tiered:" + t.tiers[idx].Name()
+	}
+	return "tiered:none"
+}
+
+func (t *TieredConsolidator) Available(ctx context.Context) bool {
+	for _, tier := range t.tiers {
+		if tier.Available(ctx) {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *TieredConsolidator) Consolidate(ctx context.Context, input ReflectionInput) (ReflectionResult, error) {
+	var lastErr error
+	for i, tier := range t.tiers {
+		if !tier.Available(ctx) {
+			t.logger.Debug("consolidator unavailable, skipping", "tier", tier.Name())
+			continue
+		}
+
+		result, err := tier.Consolidate(ctx, input)
+		if err != nil {
+			t.logger.Warn("consolidator failed, trying next tier", "tier", tier.Name(), "error", err)
+			lastErr = err
+			continue
+		}
+
+		t.active.Store(int32(i))
+		return result, nil
+	}
+
+	if lastErr != nil {
+		return ReflectionResult{}, fmt.Errorf("all consolidation tiers failed (last: %w)", lastErr)
+	}
+	return ReflectionResult{}, fmt.Errorf("no consolidation tiers available")
+}
+
+// ActiveTier returns the name of the currently active consolidation tier.
+func (t *TieredConsolidator) ActiveTier() string {
+	return t.Name()
+}

--- a/internal/reflection/consolidator_test.go
+++ b/internal/reflection/consolidator_test.go
@@ -1,0 +1,195 @@
+package reflection
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+func TestTieredConsolidator_UsesFirstAvailable(t *testing.T) {
+	unavailable := &stubConsolidator{name: "unavail", available: false}
+	available := &stubConsolidator{
+		name:      "avail",
+		available: true,
+		result:    ReflectionResult{LearnedContext: "from-avail"},
+	}
+
+	tc := NewTieredConsolidator([]Consolidator{unavailable, available}, slog.Default())
+	result, err := tc.Consolidate(context.Background(), ReflectionInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.LearnedContext != "from-avail" {
+		t.Errorf("expected result from avail tier, got %q", result.LearnedContext)
+	}
+	if tc.ActiveTier() != "tiered:avail" {
+		t.Errorf("expected active tier 'tiered:avail', got %q", tc.ActiveTier())
+	}
+}
+
+func TestTieredConsolidator_FallsBackOnError(t *testing.T) {
+	failing := &stubConsolidator{name: "fail", available: true, err: fmt.Errorf("boom")}
+	fallback := &stubConsolidator{
+		name:      "fallback",
+		available: true,
+		result:    ReflectionResult{LearnedContext: "from-fallback"},
+	}
+
+	tc := NewTieredConsolidator([]Consolidator{failing, fallback}, slog.Default())
+	result, err := tc.Consolidate(context.Background(), ReflectionInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.LearnedContext != "from-fallback" {
+		t.Errorf("expected fallback result, got %q", result.LearnedContext)
+	}
+}
+
+func TestTieredConsolidator_AllFail(t *testing.T) {
+	failing := &stubConsolidator{name: "fail", available: true, err: fmt.Errorf("boom")}
+
+	tc := NewTieredConsolidator([]Consolidator{failing}, slog.Default())
+	_, err := tc.Consolidate(context.Background(), ReflectionInput{})
+	if err == nil {
+		t.Fatal("expected error when all tiers fail")
+	}
+}
+
+func TestTieredConsolidator_NoneAvailable(t *testing.T) {
+	tc := NewTieredConsolidator([]Consolidator{
+		&stubConsolidator{name: "off", available: false},
+	}, slog.Default())
+
+	if tc.Available(context.Background()) {
+		t.Error("should not be available when no tiers are")
+	}
+	_, err := tc.Consolidate(context.Background(), ReflectionInput{})
+	if err == nil {
+		t.Fatal("expected error when no tiers available")
+	}
+}
+
+func TestSQLiteConsolidator_MergesDuplicates(t *testing.T) {
+	sc := NewSQLiteConsolidator()
+
+	input := ReflectionInput{
+		CurrentContext: "existing context",
+		ExistingMemories: []memory.Memory{
+			{Category: "fact", Content: "Ghost uses SQLite for storage with FTS5", Importance: 0.7, Tags: []string{"db"}},
+			{Category: "fact", Content: "Ghost uses SQLite for persistent storage with FTS5 search", Importance: 0.8, Tags: []string{"storage"}},
+			{Category: "pattern", Content: "completely different memory about patterns", Importance: 0.6, Tags: []string{}},
+		},
+	}
+
+	result, err := sc.Consolidate(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The two similar "fact" memories should be merged into one.
+	if len(result.Memories) != 2 {
+		t.Fatalf("expected 2 memories after dedup, got %d", len(result.Memories))
+	}
+	if result.LearnedContext != "existing context" {
+		t.Error("should preserve existing learned context")
+	}
+
+	// The merged memory should have the higher importance.
+	for _, m := range result.Memories {
+		if m.Category == "fact" && m.Importance != 0.8 {
+			t.Errorf("merged fact should have importance 0.8, got %v", m.Importance)
+		}
+	}
+}
+
+func TestSQLiteConsolidator_DifferentCategoriesNotMerged(t *testing.T) {
+	sc := NewSQLiteConsolidator()
+
+	input := ReflectionInput{
+		ExistingMemories: []memory.Memory{
+			{Category: "fact", Content: "Ghost uses SQLite for storage", Importance: 0.7},
+			{Category: "architecture", Content: "Ghost uses SQLite for storage", Importance: 0.8},
+		},
+	}
+
+	result, err := sc.Consolidate(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Same content but different categories — should NOT be merged.
+	if len(result.Memories) != 2 {
+		t.Fatalf("expected 2 memories (different categories), got %d", len(result.Memories))
+	}
+}
+
+func TestSQLiteConsolidator_EmptyInput(t *testing.T) {
+	sc := NewSQLiteConsolidator()
+	result, err := sc.Consolidate(context.Background(), ReflectionInput{CurrentContext: "ctx"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Memories) != 0 {
+		t.Errorf("expected 0 memories for empty input, got %d", len(result.Memories))
+	}
+	if result.LearnedContext != "ctx" {
+		t.Error("should preserve context on empty input")
+	}
+}
+
+func TestJaccard(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b map[string]bool
+		want float64
+	}{
+		{"identical", map[string]bool{"go": true, "sqlite": true}, map[string]bool{"go": true, "sqlite": true}, 1.0},
+		{"disjoint", map[string]bool{"go": true}, map[string]bool{"rust": true}, 0.0},
+		{"partial", map[string]bool{"go": true, "sqlite": true, "fts5": true}, map[string]bool{"go": true, "sqlite": true, "vector": true}, 0.5},
+		{"both empty", map[string]bool{}, map[string]bool{}, 1.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := jaccard(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("jaccard = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTokenize(t *testing.T) {
+	tokens := tokenize("Ghost uses SQLite for FTS5 search!")
+	if !tokens["ghost"] || !tokens["sqlite"] || !tokens["fts5"] {
+		t.Errorf("expected key tokens, got %v", tokens)
+	}
+	// Single-char words should be excluded.
+	if tokens["a"] {
+		t.Error("single-char tokens should be excluded")
+	}
+}
+
+func TestHaikuConsolidator_NilClient(t *testing.T) {
+	h := NewHaikuConsolidator(nil)
+	if h.Available(context.Background()) {
+		t.Error("should not be available with nil client")
+	}
+}
+
+// --- stubs ---
+
+type stubConsolidator struct {
+	name      string
+	available bool
+	result    ReflectionResult
+	err       error
+}
+
+func (s *stubConsolidator) Name() string                     { return s.name }
+func (s *stubConsolidator) Available(_ context.Context) bool { return s.available }
+func (s *stubConsolidator) Consolidate(_ context.Context, _ ReflectionInput) (ReflectionResult, error) {
+	return s.result, s.err
+}

--- a/internal/reflection/engine.go
+++ b/internal/reflection/engine.go
@@ -31,29 +31,30 @@ type memoryStore interface {
 
 // Engine manages periodic reflection for memory consolidation.
 type Engine struct {
-	client   reflector
-	store    memoryStore
-	logger   *slog.Logger
-	interval int
+	consolidator Consolidator
+	store        memoryStore
+	logger       *slog.Logger
+	interval     int
 }
 
-// NewEngine creates a reflection engine.
-func NewEngine(client reflector, store memoryStore, logger *slog.Logger, interval int) *Engine {
+// NewEngine creates a reflection engine with a consolidator.
+// If consolidator is nil, consolidation is disabled (MaybeReflect becomes a no-op).
+func NewEngine(consolidator Consolidator, store memoryStore, logger *slog.Logger, interval int) *Engine {
 	if interval <= 0 {
 		interval = 10
 	}
 	return &Engine{
-		client:   client,
-		store:    store,
-		logger:   logger,
-		interval: interval,
+		consolidator: consolidator,
+		store:        store,
+		logger:       logger,
+		interval:     interval,
 	}
 }
 
 // MaybeReflect increments the interaction count and triggers reflection
 // when the count hits the interval. Safe to call from a goroutine.
 func (e *Engine) MaybeReflect(ctx context.Context, projectID string, projCtx *project.Context) {
-	if e.client == nil || e.store == nil {
+	if e.consolidator == nil || e.store == nil {
 		return
 	}
 
@@ -95,14 +96,11 @@ func (e *Engine) MaybeReflect(ctx context.Context, projectID string, projCtx *pr
 		ProjectName:      projCtx.Name,
 	}
 
-	prompt := BuildReflectionPrompt(input)
-	responseText, _, err := e.client.Reflect(reflectCtx, prompt)
+	result, err := e.consolidator.Consolidate(reflectCtx, input)
 	if err != nil {
-		e.logger.Error("reflection failed", "error", err, "project_id", projectID)
+		e.logger.Error("consolidation failed", "error", err, "project_id", projectID, "tier", e.consolidator.Name())
 		return
 	}
-
-	result := parseReflectionResponse(responseText)
 
 	// Filter out empty-content memories before processing.
 	var validMemories []ReflectMemory

--- a/internal/reflection/engine_test.go
+++ b/internal/reflection/engine_test.go
@@ -6,18 +6,19 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/wcatz/ghost/internal/ai"
 	"github.com/wcatz/ghost/internal/memory"
 	"github.com/wcatz/ghost/internal/project"
 )
 
-// mockReflector implements the reflector interface for testing.
-type mockReflector struct {
+// mockConsolidator implements the Consolidator interface for testing.
+type mockConsolidator struct {
 	response string
 }
 
-func (m *mockReflector) Reflect(_ context.Context, _ string) (string, ai.TokenUsage, error) {
-	return m.response, ai.TokenUsage{}, nil
+func (m *mockConsolidator) Name() string                          { return "mock" }
+func (m *mockConsolidator) Available(_ context.Context) bool      { return true }
+func (m *mockConsolidator) Consolidate(_ context.Context, _ ReflectionInput) (ReflectionResult, error) {
+	return parseReflectionResponse(m.response), nil
 }
 
 // mockMemStore implements the memoryStore interface for testing.
@@ -86,7 +87,7 @@ func TestEngineFiltersEmptyContent(t *testing.T) {
 		},
 	}
 
-	client := &mockReflector{
+	client := &mockConsolidator{
 		response: `{"learned_context":"ctx","memories":[
 			{"category":"fact","content":"valid","importance":0.8,"tags":["go"]},
 			{"category":"fact","content":"","importance":0.5,"tags":[]},
@@ -122,7 +123,7 @@ func TestEnginePreventsDataLoss(t *testing.T) {
 		existingMemories: existing,
 	}
 
-	client := &mockReflector{
+	client := &mockConsolidator{
 		response: `{"learned_context":"ctx","memories":[
 			{"category":"fact","content":"only one","importance":0.8,"tags":[]},
 			{"category":"fact","content":"only two","importance":0.7,"tags":[]}
@@ -155,7 +156,7 @@ func TestEngineAllowsReasonableConsolidation(t *testing.T) {
 	}
 	response := mustJSON(t, ReflectionResult{LearnedContext: "ctx", Memories: memories})
 
-	client := &mockReflector{response: response}
+	client := &mockConsolidator{response: response}
 
 	e := NewEngine(client, store, testLogger(), 10)
 	e.MaybeReflect(context.Background(), "proj1", testProjectCtx())
@@ -180,7 +181,7 @@ func TestEngineSkipsGuardForSmallSets(t *testing.T) {
 		existingMemories: existing,
 	}
 
-	client := &mockReflector{
+	client := &mockConsolidator{
 		response: `{"learned_context":"ctx","memories":[
 			{"category":"fact","content":"the only one","importance":0.9,"tags":[]}
 		]}`,
@@ -209,7 +210,7 @@ func TestEngineCountsOnlyNonManual(t *testing.T) {
 		existingMemories: existing,
 	}
 
-	client := &mockReflector{
+	client := &mockConsolidator{
 		response: `{"learned_context":"ctx","memories":[
 			{"category":"fact","content":"consolidated","importance":0.9,"tags":[]}
 		]}`,

--- a/internal/reflection/tier_haiku.go
+++ b/internal/reflection/tier_haiku.go
@@ -1,0 +1,29 @@
+package reflection
+
+import "context"
+
+// HaikuConsolidator uses the Anthropic API (Haiku model) for consolidation.
+// Highest quality tier but requires API credits.
+type HaikuConsolidator struct {
+	client reflector
+}
+
+// NewHaikuConsolidator wraps an existing LLM client that has a Reflect method.
+func NewHaikuConsolidator(client reflector) *HaikuConsolidator {
+	return &HaikuConsolidator{client: client}
+}
+
+func (h *HaikuConsolidator) Name() string { return "haiku" }
+
+func (h *HaikuConsolidator) Available(_ context.Context) bool {
+	return h.client != nil
+}
+
+func (h *HaikuConsolidator) Consolidate(ctx context.Context, input ReflectionInput) (ReflectionResult, error) {
+	prompt := BuildReflectionPrompt(input)
+	responseText, _, err := h.client.Reflect(ctx, prompt)
+	if err != nil {
+		return ReflectionResult{}, err
+	}
+	return parseReflectionResponse(responseText), nil
+}

--- a/internal/reflection/tier_ollama.go
+++ b/internal/reflection/tier_ollama.go
@@ -1,0 +1,127 @@
+package reflection
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// OllamaConsolidator uses a local Ollama model for consolidation.
+// Mid-tier: free, runs locally, quality depends on model.
+type OllamaConsolidator struct {
+	baseURL string
+	model   string
+	client  *http.Client
+}
+
+// NewOllamaConsolidator creates a consolidator that calls Ollama's /api/chat.
+func NewOllamaConsolidator(baseURL, model string) *OllamaConsolidator {
+	return &OllamaConsolidator{
+		baseURL: baseURL,
+		model:   model,
+		client:  &http.Client{Timeout: 90 * time.Second},
+	}
+}
+
+func (o *OllamaConsolidator) Name() string { return "ollama:" + o.model }
+
+func (o *OllamaConsolidator) Available(ctx context.Context) bool {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, o.baseURL+"/", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == 200
+}
+
+type ollamaChatRequest struct {
+	Model    string          `json:"model"`
+	Messages []ollamaMessage `json:"messages"`
+	Stream   bool            `json:"stream"`
+	Format   json.RawMessage `json:"format"`
+	Options  map[string]any  `json:"options,omitempty"`
+}
+
+type ollamaMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ollamaChatResponse struct {
+	Message ollamaMessage `json:"message"`
+}
+
+// reflectionSchema enforces structured JSON output via Ollama's GBNF grammar.
+var reflectionSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"learned_context": {"type": "string"},
+		"memories": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"category": {"type": "string", "enum": ["architecture","decision","pattern","convention","gotcha","dependency","preference","fact"]},
+					"content": {"type": "string"},
+					"importance": {"type": "number"},
+					"tags": {"type": "array", "items": {"type": "string"}}
+				},
+				"required": ["category", "content", "importance", "tags"]
+			}
+		}
+	},
+	"required": ["learned_context", "memories"]
+}`)
+
+func (o *OllamaConsolidator) Consolidate(ctx context.Context, input ReflectionInput) (ReflectionResult, error) {
+	prompt := BuildReflectionPrompt(input)
+
+	reqBody := ollamaChatRequest{
+		Model: o.model,
+		Messages: []ollamaMessage{
+			{Role: "system", Content: "You analyze a software developer's coding patterns and produce structured memory output. Return ONLY valid JSON matching the required schema. Be specific and actionable."},
+			{Role: "user", Content: prompt},
+		},
+		Stream:  false,
+		Format:  reflectionSchema,
+		Options: map[string]any{"temperature": 0},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return ReflectionResult{}, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/api/chat", bytes.NewReader(body))
+	if err != nil {
+		return ReflectionResult{}, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return ReflectionResult{}, fmt.Errorf("ollama chat: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return ReflectionResult{}, fmt.Errorf("ollama returned %d", resp.StatusCode)
+	}
+
+	var chatResp ollamaChatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&chatResp); err != nil {
+		return ReflectionResult{}, fmt.Errorf("decode response: %w", err)
+	}
+
+	return parseReflectionResponse(chatResp.Message.Content), nil
+}

--- a/internal/reflection/tier_sqlite.go
+++ b/internal/reflection/tier_sqlite.go
@@ -1,0 +1,126 @@
+package reflection
+
+import (
+	"context"
+	"strings"
+	"unicode"
+)
+
+// SQLiteConsolidator performs mechanical deduplication using Jaccard similarity.
+// Lowest tier: always available, zero external dependencies, but only merges
+// near-duplicates without summarizing or restructuring.
+type SQLiteConsolidator struct{}
+
+// NewSQLiteConsolidator creates a consolidator that deduplicates via token overlap.
+func NewSQLiteConsolidator() *SQLiteConsolidator {
+	return &SQLiteConsolidator{}
+}
+
+func (s *SQLiteConsolidator) Name() string { return "sqlite" }
+
+func (s *SQLiteConsolidator) Available(_ context.Context) bool { return true }
+
+func (s *SQLiteConsolidator) Consolidate(_ context.Context, input ReflectionInput) (ReflectionResult, error) {
+	mems := input.ExistingMemories
+	if len(mems) == 0 {
+		return ReflectionResult{LearnedContext: input.CurrentContext}, nil
+	}
+
+	// Build token sets for each memory.
+	type tokenized struct {
+		tokens map[string]bool
+	}
+
+	items := make([]tokenized, len(mems))
+	for i, m := range mems {
+		items[i] = tokenized{tokens: tokenize(m.Content)}
+	}
+
+	// Find and merge duplicates (Jaccard >= 0.5, same category only).
+	absorbed := make([]bool, len(items))
+	var result []ReflectMemory
+
+	for i := range items {
+		if absorbed[i] {
+			continue
+		}
+
+		best := mems[i]
+		for j := i + 1; j < len(items); j++ {
+			if absorbed[j] {
+				continue
+			}
+			if mems[i].Category != mems[j].Category {
+				continue
+			}
+
+			sim := jaccard(items[i].tokens, items[j].tokens)
+			if sim >= 0.5 {
+				absorbed[j] = true
+				if mems[j].Importance > best.Importance {
+					best.Importance = mems[j].Importance
+				}
+				if len(mems[j].Content) > len(best.Content) {
+					best.Content = mems[j].Content
+				}
+				// Union tags.
+				tagSet := make(map[string]bool)
+				for _, t := range best.Tags {
+					tagSet[t] = true
+				}
+				for _, t := range mems[j].Tags {
+					tagSet[t] = true
+				}
+				best.Tags = make([]string, 0, len(tagSet))
+				for t := range tagSet {
+					best.Tags = append(best.Tags, t)
+				}
+			}
+		}
+
+		result = append(result, ReflectMemory{
+			Category:   best.Category,
+			Content:    best.Content,
+			Importance: best.Importance,
+			Tags:       best.Tags,
+		})
+	}
+
+	return ReflectionResult{
+		LearnedContext: input.CurrentContext,
+		Memories:       result,
+	}, nil
+}
+
+// tokenize splits text into a set of lowercase word tokens (length > 1).
+func tokenize(s string) map[string]bool {
+	tokens := make(map[string]bool)
+	for _, word := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		if len(word) > 1 {
+			tokens[word] = true
+		}
+	}
+	return tokens
+}
+
+// jaccard computes the Jaccard similarity coefficient between two token sets.
+func jaccard(a, b map[string]bool) float64 {
+	if len(a) == 0 && len(b) == 0 {
+		return 1.0
+	}
+
+	intersection := 0
+	for token := range a {
+		if b[token] {
+			intersection++
+		}
+	}
+
+	union := len(a) + len(b) - intersection
+	if union == 0 {
+		return 0
+	}
+	return float64(intersection) / float64(union)
+}


### PR DESCRIPTION
## Summary

- **MCP tool annotations**: All 14 tools now have proper `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` annotations per MCP spec
- **Tag validation**: Max 10 tags, max 64 chars each — prevents unbounded input
- **Importance=0 fix**: `*float32` distinguishes explicit zero from omitted (was silently defaulting `0` to `0.7`)
- **Tiered memory consolidation**: Haiku API → Ollama local LLM → SQLite Jaccard dedup, auto-fallback. Works without API credits via `ollama pull qwen2.5:3b`
- **Config**: `reflection.backend` (`auto`/`haiku`/`ollama`/`sqlite`/`disabled`), `reflection.ollama_model`

## New files

| File | Purpose |
|------|---------|
| `internal/reflection/consolidator.go` | `Consolidator` interface + `TieredConsolidator` dispatcher |
| `internal/reflection/tier_haiku.go` | Tier 2: Anthropic API (wraps existing `Reflect`) |
| `internal/reflection/tier_ollama.go` | Tier 1: Ollama `/api/chat` with JSON schema structured output |
| `internal/reflection/tier_sqlite.go` | Tier 0: Jaccard similarity dedup (always available) |
| `internal/reflection/consolidator_test.go` | Tests for tiered dispatch, SQLite dedup, Jaccard math |

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` all passing (including new consolidator + mcpserver tests)
- [x] `go build ./cmd/ghost` compiles
- [ ] Manual: verify `ghost mcp` serves tools with annotations (check via MCP inspector)
- [ ] Manual: verify tiered fallback with Ollama running / stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory consolidation now supports tiered backend selection (Haiku API → local Ollama → SQLite deduplication) with automatic fallback via new `reflection.backend` and `reflection.ollama_model` configuration options. The `auto` mode selects the highest available tier.

* **Documentation**
  * Added tiered consolidation documentation and configuration guide to README, including usage without API credits via local Ollama.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->