### PR TITLE
feat(cli,memory): ghost reflect with safe consolidation

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -517,7 +517,7 @@ Flags:
 	}
 
 	cfg, logger, store, _ := bootstrap()
-	defer store.Close()
+	defer store.Close() //nolint:errcheck
 
 	ctx := context.Background()
 
@@ -637,15 +637,12 @@ Flags:
 	fmt.Println()
 
 	// Show each memory.
-	for i, m := range result.Memories {
+	for _, m := range result.Memories {
 		truncated := m.Content
 		if len(truncated) > 120 {
 			truncated = truncated[:120] + "..."
 		}
 		fmt.Printf("  [%s] (%.1f) %s\n", m.Category, m.Importance, truncated)
-		if i < len(result.Memories)-1 {
-			// space between entries for readability
-		}
 	}
 	fmt.Println()
 

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/wcatz/ghost/internal/mcpserver"
 	"github.com/wcatz/ghost/internal/memory"
 	"github.com/wcatz/ghost/internal/orchestrator"
+	"github.com/wcatz/ghost/internal/reflection"
 	"github.com/wcatz/ghost/internal/scheduler"
 	"github.com/wcatz/ghost/internal/selfupdate"
 	"github.com/wcatz/ghost/internal/server"
@@ -72,6 +73,9 @@ func main() {
 			return
 		case "hook":
 			runHook()
+			return
+		case "reflect":
+			runReflect()
 			return
 		case "upgrade":
 			runUpgrade()
@@ -479,6 +483,223 @@ func runMCPStatus() {
 	}
 }
 
+// runReflect manually triggers memory consolidation for a project.
+// Defaults to dry-run (preview only). Use --apply to save results.
+// Use --restore to undo the last consolidation from snapshot.
+func runReflect() {
+	// Extract project name and flags from args (allow flags before or after project name).
+	var projectName, tierValue string
+	var apply, restore bool
+	tierValue = "auto"
+	for i := 2; i < len(os.Args); i++ {
+		switch {
+		case os.Args[i] == "--tier" && i+1 < len(os.Args):
+			tierValue = os.Args[i+1]
+			i++ // skip value
+		case strings.HasPrefix(os.Args[i], "--tier="):
+			tierValue = strings.TrimPrefix(os.Args[i], "--tier=")
+		case os.Args[i] == "--apply":
+			apply = true
+		case os.Args[i] == "--restore":
+			restore = true
+		case !strings.HasPrefix(os.Args[i], "-"):
+			projectName = os.Args[i]
+		}
+	}
+	if projectName == "" {
+		fmt.Fprintln(os.Stderr, `Usage: ghost reflect <project> [flags]
+
+Flags:
+  --tier string   Consolidation tier: auto, haiku, ollama, sqlite (default "auto")
+  --apply         Save results (default is dry-run/preview only)
+  --restore       Undo the last consolidation from snapshot`)
+		os.Exit(1)
+	}
+
+	cfg, logger, store, _ := bootstrap()
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Resolve project name to ID.
+	projectID, err := store.ResolveProjectByName(ctx, projectName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if projectID == "" {
+		fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
+		os.Exit(1)
+	}
+
+	// Handle --restore.
+	if restore {
+		n, err := store.RestoreSnapshot(ctx, projectID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Restored %d memories from snapshot for %s\n", n, projectName)
+		return
+	}
+
+	// Build consolidator for the requested tier.
+	var consolidator reflection.Consolidator
+	switch tierValue {
+	case "haiku":
+		if cfg.API.Key == "" {
+			fmt.Fprintln(os.Stderr, "error: haiku tier requires ANTHROPIC_API_KEY")
+			os.Exit(1)
+		}
+		client := ai.NewClient(cfg.API.Key, logger)
+		consolidator = reflection.NewHaikuConsolidator(client)
+	case "ollama":
+		url := cfg.Embedding.OllamaURL
+		if url == "" {
+			url = "http://localhost:11434"
+		}
+		consolidator = reflection.NewOllamaConsolidator(url, cfg.Reflection.OllamaModel)
+	case "sqlite":
+		consolidator = reflection.NewSQLiteConsolidator()
+	default: // "auto"
+		var tiers []reflection.Consolidator
+		if cfg.API.Key != "" {
+			client := ai.NewClient(cfg.API.Key, logger)
+			tiers = append(tiers, reflection.NewHaikuConsolidator(client))
+		}
+		if cfg.Embedding.OllamaURL != "" {
+			tiers = append(tiers, reflection.NewOllamaConsolidator(cfg.Embedding.OllamaURL, cfg.Reflection.OllamaModel))
+		}
+		tiers = append(tiers, reflection.NewSQLiteConsolidator())
+		consolidator = reflection.NewTieredConsolidator(tiers, logger)
+	}
+
+	// Check availability.
+	if !consolidator.Available(ctx) {
+		fmt.Fprintf(os.Stderr, "error: consolidator %q is not available\n", consolidator.Name())
+		os.Exit(1)
+	}
+
+	if !apply {
+		fmt.Println("DRY RUN (use --apply to save results)")
+		fmt.Println()
+	}
+	fmt.Printf("Project:      %s (%s)\n", projectName, projectID)
+	fmt.Printf("Consolidator: %s\n", consolidator.Name())
+
+	// Gather input.
+	existingMemories, err := store.GetAll(ctx, projectID, 200)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: get memories: %v\n", err)
+		os.Exit(1)
+	}
+	currentContext, _ := store.GetLearnedContext(ctx, projectID)
+	exchanges, _ := store.GetRecentExchanges(ctx, projectID, 15)
+
+	fmt.Printf("Memories:     %d existing\n", len(existingMemories))
+	fmt.Println("Running consolidation...")
+
+	input := reflection.ReflectionInput{
+		RecentExchanges:  exchanges,
+		ExistingMemories: existingMemories,
+		CurrentContext:   currentContext,
+		ProjectName:      projectName,
+	}
+
+	consolidateCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+
+	result, err := consolidator.Consolidate(consolidateCtx, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: consolidation failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Filter empty-content memories.
+	var validMemories []reflection.ReflectMemory
+	for _, m := range result.Memories {
+		if strings.TrimSpace(m.Content) != "" {
+			validMemories = append(validMemories, m)
+		}
+	}
+	result.Memories = validMemories
+
+	// Summary.
+	catCounts := make(map[string]int)
+	for _, m := range result.Memories {
+		catCounts[m.Category]++
+	}
+	var parts []string
+	for cat, n := range catCounts {
+		parts = append(parts, fmt.Sprintf("%d %s", n, cat))
+	}
+	fmt.Printf("Result:       %d memories (%s)\n", len(result.Memories), strings.Join(parts, ", "))
+	fmt.Println()
+
+	// Show each memory.
+	for i, m := range result.Memories {
+		truncated := m.Content
+		if len(truncated) > 120 {
+			truncated = truncated[:120] + "..."
+		}
+		fmt.Printf("  [%s] (%.1f) %s\n", m.Category, m.Importance, truncated)
+		if i < len(result.Memories)-1 {
+			// space between entries for readability
+		}
+	}
+	fmt.Println()
+
+	if len(result.Memories) == 0 {
+		fmt.Println("No memories returned from consolidation.")
+		return
+	}
+
+	// Empty-set guard.
+	var existingNonManual int
+	for _, m := range existingMemories {
+		if m.Source != "manual" {
+			existingNonManual++
+		}
+	}
+	if existingNonManual >= 6 && len(result.Memories) < existingNonManual/2 {
+		fmt.Fprintf(os.Stderr, "WARNING: consolidation returned %d memories vs %d existing non-manual (>50%% reduction)\n",
+			len(result.Memories), existingNonManual)
+	}
+
+	if !apply {
+		fmt.Println("Dry run complete. Re-run with --apply to save these results.")
+		return
+	}
+
+	// Apply results.
+	dbMemories := make([]memory.Memory, len(result.Memories))
+	for i, m := range result.Memories {
+		dbMemories[i] = memory.Memory{
+			ProjectID:  projectID,
+			Category:   m.Category,
+			Content:    m.Content,
+			Importance: m.Importance,
+			Source:     "reflection",
+			Tags:       m.Tags,
+		}
+	}
+
+	if err := store.ReplaceNonManual(ctx, projectID, dbMemories); err != nil {
+		fmt.Fprintf(os.Stderr, "error: save memories: %v\n", err)
+		os.Exit(1)
+	}
+
+	summary := fmt.Sprintf("%d memories consolidated (%s)", len(dbMemories), strings.Join(parts, ", "))
+	fmt.Printf("Applied: %s\n", summary)
+	fmt.Println("(use --restore to undo)")
+
+	if result.LearnedContext != "" {
+		if err := store.UpdateLearnedContext(ctx, projectID, result.LearnedContext, summary); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: update learned context: %v\n", err)
+		}
+	}
+}
+
 // printUsage displays the top-level help.
 func printUsage() {
 	fmt.Fprintf(os.Stderr, `ghost %s — memory-first AI assistant
@@ -492,6 +713,7 @@ Commands:
   mcp                         Start MCP server on stdio (used by Claude Code)
   mcp init [--dry-run]        Configure Claude Code integration
   mcp status                  Check Claude Code integration health
+  reflect <project> [flags]   Memory consolidation (dry-run by default, --apply to save)
   upgrade                     Update ghost to the latest release
   version                     Print version
 

--- a/internal/memory/schema.go
+++ b/internal/memory/schema.go
@@ -204,6 +204,19 @@ CREATE TABLE IF NOT EXISTS decisions (
     updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_decisions_project ON decisions(project_id, status);
+
+CREATE TABLE IF NOT EXISTS memory_snapshots (
+    id            TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    snapshot_id   TEXT NOT NULL,
+    project_id    TEXT NOT NULL,
+    category      TEXT NOT NULL,
+    content       TEXT NOT NULL,
+    importance    REAL NOT NULL,
+    source        TEXT NOT NULL,
+    tags          TEXT DEFAULT '[]',
+    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_snapshots_project ON memory_snapshots(project_id, snapshot_id);
 `
 
 // OpenDB opens or creates the SQLite database and runs migrations.

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -472,6 +472,17 @@ func (s *Store) ReplaceNonManual(ctx context.Context, projectID string, memories
 	}
 	defer tx.Rollback()
 
+	// Snapshot existing non-manual memories before deleting.
+	snapshotID := fmt.Sprintf("%s-%d", projectID, time.Now().Unix())
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO memory_snapshots (snapshot_id, project_id, category, content, importance, source, tags)
+		SELECT ?, project_id, category, content, importance, source, tags
+		FROM memories WHERE project_id = ? AND source != 'manual'
+	`, snapshotID, projectID)
+	if err != nil {
+		return fmt.Errorf("snapshot memories: %w", err)
+	}
+
 	_, err = tx.ExecContext(ctx, `DELETE FROM memories WHERE project_id = ? AND source != 'manual'`, projectID)
 	if err != nil {
 		return fmt.Errorf("delete old memories: %w", err)
@@ -488,7 +499,63 @@ func (s *Store) ReplaceNonManual(ctx context.Context, projectID string, memories
 		}
 	}
 
+	s.logger.Info("memories snapshotted before replace", "project_id", projectID, "snapshot_id", snapshotID)
 	return tx.Commit()
+}
+
+// RestoreSnapshot restores memories from the most recent snapshot for a project.
+// Returns the number of memories restored.
+func (s *Store) RestoreSnapshot(ctx context.Context, projectID string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Find the latest snapshot.
+	var snapshotID string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT snapshot_id FROM memory_snapshots
+		WHERE project_id = ?
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, projectID).Scan(&snapshotID)
+	if err == sql.ErrNoRows {
+		return 0, fmt.Errorf("no snapshots found for project %s", projectID)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("find snapshot: %w", err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Delete current non-manual memories.
+	_, err = tx.ExecContext(ctx, `DELETE FROM memories WHERE project_id = ? AND source != 'manual'`, projectID)
+	if err != nil {
+		return 0, fmt.Errorf("delete current: %w", err)
+	}
+
+	// Restore from snapshot.
+	res, err := tx.ExecContext(ctx, `
+		INSERT INTO memories (project_id, category, content, source, importance, tags)
+		SELECT project_id, category, content, source, importance, tags
+		FROM memory_snapshots WHERE snapshot_id = ?
+	`, snapshotID)
+	if err != nil {
+		return 0, fmt.Errorf("restore snapshot: %w", err)
+	}
+
+	// Clean up the used snapshot.
+	_, _ = tx.ExecContext(ctx, `DELETE FROM memory_snapshots WHERE snapshot_id = ?`, snapshotID)
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
+	}
+
+	n, _ := res.RowsAffected()
+	s.logger.Info("memories restored from snapshot", "project_id", projectID, "snapshot_id", snapshotID, "count", n)
+	return int(n), nil
 }
 
 // CountMemories returns the total number of memories for a project.

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -528,7 +528,7 @@ func (s *Store) RestoreSnapshot(ctx context.Context, projectID string) (int, err
 	if err != nil {
 		return 0, fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer tx.Rollback() //nolint:errcheck
 
 	// Delete current non-manual memories.
 	_, err = tx.ExecContext(ctx, `DELETE FROM memories WHERE project_id = ? AND source != 'manual'`, projectID)

--- a/internal/reflection/tier_ollama.go
+++ b/internal/reflection/tier_ollama.go
@@ -22,7 +22,7 @@ func NewOllamaConsolidator(baseURL, model string) *OllamaConsolidator {
 	return &OllamaConsolidator{
 		baseURL: baseURL,
 		model:   model,
-		client:  &http.Client{Timeout: 90 * time.Second},
+		client:  &http.Client{}, // timeout controlled by context
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `ghost reflect <project>` CLI subcommand for manual memory consolidation
- Defaults to **dry-run** (preview only) — must pass `--apply` to save results
- Adds `--restore` to undo last consolidation from automatic snapshot backup
- `ReplaceNonManual` now snapshots all memories before deleting (protects both CLI and automatic consolidation paths)
- Ollama tier uses context-based timeout instead of hardcoded 90s

## Usage
```bash
# Preview what consolidation would produce (safe, no changes saved)
ghost reflect ghost --tier ollama

# Apply consolidation results (with automatic backup)
ghost reflect ghost --tier ollama --apply

# Undo the last consolidation
ghost reflect ghost --restore
```

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `ghost reflect ghost --tier sqlite` shows dry-run output without saving
- [x] `ghost reflect ghost --restore` errors cleanly when no snapshot exists
- [x] Empty-set guard warns on >50% reduction in dry-run output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ghost reflect <project>` command for manual memory consolidation (dry-run by default).
  * `--apply` persists consolidation results; `--restore` reverts to the most recent snapshot and reports restored count.
  * Command shows categorized preview counts, per-memory previews, and warns when many non-manual memories would be removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->