### PR TITLE
fix(memory): address CodeRabbit #117 findings

### DIFF
--- a/internal/memory/schema.go
+++ b/internal/memory/schema.go
@@ -208,7 +208,7 @@ CREATE INDEX IF NOT EXISTS idx_decisions_project ON decisions(project_id, status
 CREATE TABLE IF NOT EXISTS memory_snapshots (
     id            TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
     snapshot_id   TEXT NOT NULL,
-    project_id    TEXT NOT NULL,
+    project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
     category      TEXT NOT NULL,
     content       TEXT NOT NULL,
     importance    REAL NOT NULL,

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -470,7 +470,7 @@ func (s *Store) ReplaceNonManual(ctx context.Context, projectID string, memories
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer tx.Rollback() //nolint:errcheck
 
 	// Snapshot existing non-manual memories before deleting.
 	snapshotID := fmt.Sprintf("%s-%d", projectID, time.Now().Unix())
@@ -497,6 +497,20 @@ func (s *Store) ReplaceNonManual(ctx context.Context, projectID string, memories
 		if err != nil {
 			return fmt.Errorf("insert memory: %w", err)
 		}
+	}
+
+	// Prune old snapshots — keep only the 3 most recent per project.
+	_, err = tx.ExecContext(ctx, `
+		DELETE FROM memory_snapshots
+		WHERE project_id = ? AND snapshot_id NOT IN (
+			SELECT DISTINCT snapshot_id FROM memory_snapshots
+			WHERE project_id = ?
+			ORDER BY created_at DESC
+			LIMIT 3
+		)
+	`, projectID, projectID)
+	if err != nil {
+		s.logger.Warn("prune old snapshots", "error", err, "project_id", projectID)
 	}
 
 	s.logger.Info("memories snapshotted before replace", "project_id", projectID, "snapshot_id", snapshotID)
@@ -547,7 +561,9 @@ func (s *Store) RestoreSnapshot(ctx context.Context, projectID string) (int, err
 	}
 
 	// Clean up the used snapshot.
-	_, _ = tx.ExecContext(ctx, `DELETE FROM memory_snapshots WHERE snapshot_id = ?`, snapshotID)
+	if _, err := tx.ExecContext(ctx, `DELETE FROM memory_snapshots WHERE snapshot_id = ?`, snapshotID); err != nil {
+		s.logger.Warn("failed to delete used snapshot", "snapshot_id", snapshotID, "error", err)
+	}
 
 	if err := tx.Commit(); err != nil {
 		return 0, fmt.Errorf("commit: %w", err)


### PR DESCRIPTION
## Summary
- Add foreign key constraint on `memory_snapshots.project_id` → prevents orphaned rows on project delete
- Prune old snapshots to keep only 3 most recent per project → prevents unbounded disk growth
- Log errors on snapshot cleanup delete in `RestoreSnapshot` instead of silently discarding
- Add `//nolint:errcheck` on deferred `tx.Rollback()` in `ReplaceNonManual` to match existing pattern

Addresses all actionable findings from CodeRabbit review on #117.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `go build ./cmd/ghost` compiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and logging in memory operations for better visibility into potential issues.

* **Chores**
  * Improved data integrity with automatic cleanup of orphaned memory snapshots when associated projects are deleted.
  * Optimized storage utilization by automatically retaining only the 3 most recent memory snapshots per project to reduce storage overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->