### PR TITLE
feat(reflection): global scope detection for cross-project memories

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -636,13 +636,36 @@ Flags:
 	fmt.Printf("Result:       %d memories (%s)\n", len(result.Memories), strings.Join(parts, ", "))
 	fmt.Println()
 
-	// Show each memory.
+	// Split by scope.
+	var projectMems, globalMems []reflection.ReflectMemory
 	for _, m := range result.Memories {
-		truncated := m.Content
-		if len(truncated) > 120 {
-			truncated = truncated[:120] + "..."
+		if m.Scope == "global" {
+			globalMems = append(globalMems, m)
+		} else {
+			projectMems = append(projectMems, m)
 		}
-		fmt.Printf("  [%s] (%.1f) %s\n", m.Category, m.Importance, truncated)
+	}
+
+	// Show each memory.
+	if len(projectMems) > 0 {
+		fmt.Printf("  Project-scoped (%d):\n", len(projectMems))
+		for _, m := range projectMems {
+			truncated := m.Content
+			if len(truncated) > 120 {
+				truncated = truncated[:120] + "..."
+			}
+			fmt.Printf("    [%s] (%.1f) %s\n", m.Category, m.Importance, truncated)
+		}
+	}
+	if len(globalMems) > 0 {
+		fmt.Printf("  Global-scoped (%d):\n", len(globalMems))
+		for _, m := range globalMems {
+			truncated := m.Content
+			if len(truncated) > 120 {
+				truncated = truncated[:120] + "..."
+			}
+			fmt.Printf("    [%s] (%.1f) %s\n", m.Category, m.Importance, truncated)
+		}
 	}
 	fmt.Println()
 
@@ -651,16 +674,19 @@ Flags:
 		return
 	}
 
-	// Empty-set guard.
+	// Empty-set guard (based on project-scoped only).
 	var existingNonManual int
 	for _, m := range existingMemories {
 		if m.Source != "manual" {
 			existingNonManual++
 		}
 	}
-	if existingNonManual >= 6 && len(result.Memories) < existingNonManual/2 {
-		fmt.Fprintf(os.Stderr, "WARNING: consolidation returned %d memories vs %d existing non-manual (>50%% reduction)\n",
-			len(result.Memories), existingNonManual)
+	if existingNonManual >= 6 && len(projectMems) < existingNonManual/2 {
+		fmt.Fprintf(os.Stderr, "WARNING: consolidation returned %d project memories vs %d existing non-manual (>50%% reduction)\n",
+			len(projectMems), existingNonManual)
+		if len(globalMems) > 0 {
+			fmt.Fprintf(os.Stderr, "  (%d memories classified as global — check scope accuracy)\n", len(globalMems))
+		}
 	}
 
 	if !apply {
@@ -668,31 +694,50 @@ Flags:
 		return
 	}
 
-	// Apply results.
-	dbMemories := make([]memory.Memory, len(result.Memories))
-	for i, m := range result.Memories {
-		dbMemories[i] = memory.Memory{
-			ProjectID:  projectID,
-			Category:   m.Category,
-			Content:    m.Content,
-			Importance: m.Importance,
-			Source:     "reflection",
-			Tags:       m.Tags,
+	// Apply global memories via upsert.
+	if len(globalMems) > 0 {
+		if err := store.EnsureProject(ctx, "_global", "_global", "global"); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: ensure _global project: %v\n", err)
 		}
+		for _, m := range globalMems {
+			_, _, err := store.Upsert(ctx, "_global", m.Category, m.Content, "reflection", m.Importance, m.Tags)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: upsert global memory: %v\n", err)
+			}
+		}
+		fmt.Printf("Upserted %d global memories\n", len(globalMems))
 	}
 
-	if err := store.ReplaceNonManual(ctx, projectID, dbMemories); err != nil {
-		fmt.Fprintf(os.Stderr, "error: save memories: %v\n", err)
-		os.Exit(1)
-	}
+	// Apply project memories via replace.
+	if len(projectMems) > 0 {
+		dbMemories := make([]memory.Memory, len(projectMems))
+		for i, m := range projectMems {
+			dbMemories[i] = memory.Memory{
+				ProjectID:  projectID,
+				Category:   m.Category,
+				Content:    m.Content,
+				Importance: m.Importance,
+				Source:     "reflection",
+				Tags:       m.Tags,
+			}
+		}
 
-	summary := fmt.Sprintf("%d memories consolidated (%s)", len(dbMemories), strings.Join(parts, ", "))
-	fmt.Printf("Applied: %s\n", summary)
-	fmt.Println("(use --restore to undo)")
+		if err := store.ReplaceNonManual(ctx, projectID, dbMemories); err != nil {
+			fmt.Fprintf(os.Stderr, "error: save memories: %v\n", err)
+			os.Exit(1)
+		}
 
-	if result.LearnedContext != "" {
-		if err := store.UpdateLearnedContext(ctx, projectID, result.LearnedContext, summary); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: update learned context: %v\n", err)
+		summary := fmt.Sprintf("%d memories consolidated (%s)", len(dbMemories), strings.Join(parts, ", "))
+		if len(globalMems) > 0 {
+			summary += fmt.Sprintf(", %d promoted to global", len(globalMems))
+		}
+		fmt.Printf("Applied: %s\n", summary)
+		fmt.Println("(use --restore to undo)")
+
+		if result.LearnedContext != "" {
+			if err := store.UpdateLearnedContext(ctx, projectID, result.LearnedContext, summary); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: update learned context: %v\n", err)
+			}
 		}
 	}
 }

--- a/internal/reflection/consolidator_test.go
+++ b/internal/reflection/consolidator_test.go
@@ -172,6 +172,77 @@ func TestTokenize(t *testing.T) {
 	}
 }
 
+func TestInferGlobalScope(t *testing.T) {
+	tests := []struct {
+		name     string
+		category string
+		content  string
+		want     string
+	}{
+		{"preference always global", "preference", "use tabs not spaces", "global"},
+		{"architecture is project", "architecture", "ghost uses 3-block prompt caching", "project"},
+		{"cross-repo workflow", "fact", "deploy to infra cluster from any repo", "global"},
+		{"ssh host", "fact", "SSH into node3 via bastion", "global"},
+		{"always use pattern", "convention", "always use nerdctl not docker", "global"},
+		{"project convention", "convention", "commit messages use feat/fix prefix", "project"},
+		{"all repos", "pattern", "run go vet across all repos before release", "global"},
+		{"dev machine", "fact", "dev machine runs Asahi Fedora on Apple Silicon", "global"},
+		{"plain project fact", "fact", "FTS5 uses porter stemmer tokenizer", "project"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferGlobalScope(tt.category, tt.content)
+			if got != tt.want {
+				t.Errorf("inferGlobalScope(%q, %q) = %q, want %q", tt.category, tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSQLiteConsolidator_SetsScope(t *testing.T) {
+	sc := NewSQLiteConsolidator()
+
+	input := ReflectionInput{
+		ExistingMemories: []memory.Memory{
+			{Category: "preference", Content: "use nerdctl not docker", Importance: 0.9, Tags: []string{}},
+			{Category: "architecture", Content: "ghost uses SQLite with FTS5", Importance: 0.8, Tags: []string{}},
+		},
+	}
+
+	result, err := sc.Consolidate(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, m := range result.Memories {
+		if m.Category == "preference" && m.Scope != "global" {
+			t.Errorf("preference should be global, got %q", m.Scope)
+		}
+		if m.Category == "architecture" && m.Scope != "project" {
+			t.Errorf("architecture should be project, got %q", m.Scope)
+		}
+	}
+}
+
+func TestParseReflectionResponse_NormalizesScope(t *testing.T) {
+	input := `{"learned_context":"ctx","memories":[
+		{"category":"fact","content":"with scope","importance":0.8,"tags":[],"scope":"global"},
+		{"category":"fact","content":"no scope","importance":0.7,"tags":[]},
+		{"category":"fact","content":"bad scope","importance":0.6,"tags":[],"scope":"invalid"}
+	]}`
+
+	result := parseReflectionResponse(input)
+	if result.Memories[0].Scope != "global" {
+		t.Errorf("expected global scope preserved, got %q", result.Memories[0].Scope)
+	}
+	if result.Memories[1].Scope != "project" {
+		t.Errorf("expected missing scope normalized to project, got %q", result.Memories[1].Scope)
+	}
+	if result.Memories[2].Scope != "project" {
+		t.Errorf("expected invalid scope normalized to project, got %q", result.Memories[2].Scope)
+	}
+}
+
 func TestHaikuConsolidator_NilClient(t *testing.T) {
 	h := NewHaikuConsolidator(nil)
 	if h.Available(context.Background()) {

--- a/internal/reflection/engine.go
+++ b/internal/reflection/engine.go
@@ -27,6 +27,7 @@ type memoryStore interface {
 	ReplaceNonManual(ctx context.Context, projectID string, memories []memory.Memory) error
 	UpdateLearnedContext(ctx context.Context, projectID, learnedContext, summary string) error
 	Upsert(ctx context.Context, projectID, category, content, source string, importance float32, tags []string) (string, bool, error)
+	EnsureProject(ctx context.Context, id, path, name string) error
 }
 
 // Engine manages periodic reflection for memory consolidation.
@@ -112,6 +113,31 @@ func (e *Engine) MaybeReflect(ctx context.Context, projectID string, projCtx *pr
 	result.Memories = validMemories
 
 	if len(result.Memories) > 0 {
+		// Split memories by scope: project-scoped stay here, global-scoped go to _global.
+		var projectMemories []ReflectMemory
+		var globalMemories []ReflectMemory
+		for _, m := range result.Memories {
+			if m.Scope == "global" {
+				globalMemories = append(globalMemories, m)
+			} else {
+				projectMemories = append(projectMemories, m)
+			}
+		}
+
+		// Upsert global memories into _global project (additive, not replacing).
+		if len(globalMemories) > 0 {
+			if err := e.store.EnsureProject(reflectCtx, "_global", "_global", "global"); err != nil {
+				e.logger.Error("ensure _global project", "error", err)
+			}
+			for _, m := range globalMemories {
+				_, _, err := e.store.Upsert(reflectCtx, "_global", m.Category, m.Content, "reflection", m.Importance, m.Tags)
+				if err != nil {
+					e.logger.Error("upsert global memory", "error", err, "content", m.Content)
+				}
+			}
+			e.logger.Info("global memories upserted", "project_id", projectID, "count", len(globalMemories))
+		}
+
 		// Guard against dramatic reduction — count existing non-manual memories.
 		var existingNonManual int
 		for _, m := range existingMemories {
@@ -119,43 +145,49 @@ func (e *Engine) MaybeReflect(ctx context.Context, projectID string, projCtx *pr
 				existingNonManual++
 			}
 		}
-		if existingNonManual >= 6 && len(result.Memories) < existingNonManual/2 {
+		if existingNonManual >= 6 && len(projectMemories) < existingNonManual/2 {
 			e.logger.Warn("reflection returned too few memories — skipping replace to prevent data loss",
 				"project_id", projectID,
 				"existing_non_manual", existingNonManual,
-				"reflection_returned", len(result.Memories),
+				"reflection_returned", len(projectMemories),
+				"global_extracted", len(globalMemories),
 			)
 			return
 		}
 
-		dbMemories := make([]memory.Memory, len(result.Memories))
-		for i, m := range result.Memories {
-			dbMemories[i] = memory.Memory{
-				ProjectID:  projectID,
-				Category:   m.Category,
-				Content:    m.Content,
-				Importance: m.Importance,
-				Source:     "reflection",
-				Tags:       m.Tags,
+		if len(projectMemories) > 0 {
+			dbMemories := make([]memory.Memory, len(projectMemories))
+			for i, m := range projectMemories {
+				dbMemories[i] = memory.Memory{
+					ProjectID:  projectID,
+					Category:   m.Category,
+					Content:    m.Content,
+					Importance: m.Importance,
+					Source:     "reflection",
+					Tags:       m.Tags,
+				}
 			}
-		}
-		if err := e.store.ReplaceNonManual(reflectCtx, projectID, dbMemories); err != nil {
-			e.logger.Error("save ghost memories", "error", err, "project_id", projectID)
-		} else {
-			e.logger.Info("ghost memories updated", "project_id", projectID, "count", len(dbMemories))
+			if err := e.store.ReplaceNonManual(reflectCtx, projectID, dbMemories); err != nil {
+				e.logger.Error("save ghost memories", "error", err, "project_id", projectID)
+			} else {
+				e.logger.Info("ghost memories updated", "project_id", projectID, "count", len(dbMemories))
 
-			// Build summary.
-			catCounts := make(map[string]int)
-			for _, m := range dbMemories {
-				catCounts[m.Category]++
-			}
-			var parts []string
-			for cat, n := range catCounts {
-				parts = append(parts, fmt.Sprintf("%d %s", n, cat))
-			}
-			summary := fmt.Sprintf("%d memories consolidated (%s)", len(dbMemories), strings.Join(parts, ", "))
-			if err := e.store.UpdateLearnedContext(reflectCtx, projectID, result.LearnedContext, summary); err != nil {
-				e.logger.Error("save learned context", "error", err, "project_id", projectID)
+				// Build summary.
+				catCounts := make(map[string]int)
+				for _, m := range dbMemories {
+					catCounts[m.Category]++
+				}
+				var parts []string
+				for cat, n := range catCounts {
+					parts = append(parts, fmt.Sprintf("%d %s", n, cat))
+				}
+				summary := fmt.Sprintf("%d memories consolidated (%s)", len(dbMemories), strings.Join(parts, ", "))
+				if len(globalMemories) > 0 {
+					summary += fmt.Sprintf(", %d promoted to global", len(globalMemories))
+				}
+				if err := e.store.UpdateLearnedContext(reflectCtx, projectID, result.LearnedContext, summary); err != nil {
+					e.logger.Error("save learned context", "error", err, "project_id", projectID)
+				}
 			}
 		}
 	} else if result.LearnedContext != "" {
@@ -187,7 +219,7 @@ func parseReflectionResponse(text string) ReflectionResult {
 		return ReflectionResult{LearnedContext: text}
 	}
 
-	// Validate importance ranges.
+	// Validate importance ranges and scope.
 	for i := range result.Memories {
 		if result.Memories[i].Importance < 0 {
 			result.Memories[i].Importance = 0
@@ -197,6 +229,9 @@ func parseReflectionResponse(text string) ReflectionResult {
 		}
 		if result.Memories[i].Tags == nil {
 			result.Memories[i].Tags = []string{}
+		}
+		if result.Memories[i].Scope != "global" {
+			result.Memories[i].Scope = "project"
 		}
 	}
 

--- a/internal/reflection/engine_test.go
+++ b/internal/reflection/engine_test.go
@@ -27,6 +27,8 @@ type mockMemStore struct {
 	existingMemories []memory.Memory
 	replacedWith     []memory.Memory // captures what was passed to ReplaceNonManual
 	replaceCalled    bool
+	upsertedGlobals  []memory.Memory // captures global upserts
+	ensuredProjects  []string        // captures EnsureProject calls
 }
 
 func (m *mockMemStore) IncrementInteraction(_ context.Context, _ string) (int, error) {
@@ -56,8 +58,23 @@ func (m *mockMemStore) UpdateLearnedContext(_ context.Context, _, _, _ string) e
 	return nil
 }
 
-func (m *mockMemStore) Upsert(_ context.Context, _, _, _, _ string, _ float32, _ []string) (string, bool, error) {
+func (m *mockMemStore) Upsert(_ context.Context, projectID, category, content, source string, importance float32, tags []string) (string, bool, error) {
+	if projectID == "_global" {
+		m.upsertedGlobals = append(m.upsertedGlobals, memory.Memory{
+			ProjectID:  projectID,
+			Category:   category,
+			Content:    content,
+			Source:     source,
+			Importance: importance,
+			Tags:       tags,
+		})
+	}
 	return "id", false, nil
+}
+
+func (m *mockMemStore) EnsureProject(_ context.Context, id, _, _ string) error {
+	m.ensuredProjects = append(m.ensuredProjects, id)
+	return nil
 }
 
 func TestParseReflectionResponse_FiltersEmptyContent(t *testing.T) {
@@ -221,6 +238,98 @@ func TestEngineCountsOnlyNonManual(t *testing.T) {
 
 	if !store.replaceCalled {
 		t.Fatal("ReplaceNonManual should be called — only 2 non-manual, threshold not met")
+	}
+}
+
+func TestEngineRoutesGlobalMemories(t *testing.T) {
+	// Consolidator returns 3 project + 2 global memories.
+	store := &mockMemStore{
+		interactionCount: 9,
+		existingMemories: []memory.Memory{
+			{Source: "reflection", Content: "existing"},
+		},
+	}
+
+	response := mustJSON(t, ReflectionResult{
+		LearnedContext: "ctx",
+		Memories: []ReflectMemory{
+			{Category: "architecture", Content: "ghost uses SQLite", Importance: 0.8, Tags: []string{"db"}, Scope: "project"},
+			{Category: "pattern", Content: "always run go vet", Importance: 0.7, Tags: []string{"go"}, Scope: "project"},
+			{Category: "convention", Content: "commit prefix feat/fix", Importance: 0.6, Tags: []string{"git"}, Scope: "project"},
+			{Category: "preference", Content: "always use nerdctl not docker", Importance: 0.9, Tags: []string{"containers"}, Scope: "global"},
+			{Category: "fact", Content: "deploy infra from any repo", Importance: 0.8, Tags: []string{"deploy"}, Scope: "global"},
+		},
+	})
+
+	client := &mockConsolidator{response: response}
+	e := NewEngine(client, store, testLogger(), 10)
+	e.MaybeReflect(context.Background(), "proj1", testProjectCtx())
+
+	// Project memories should be replaced (3 project-scoped).
+	if !store.replaceCalled {
+		t.Fatal("expected ReplaceNonManual to be called for project memories")
+	}
+	if len(store.replacedWith) != 3 {
+		t.Fatalf("expected 3 project memories, got %d", len(store.replacedWith))
+	}
+
+	// Global memories should be upserted to _global.
+	if len(store.upsertedGlobals) != 2 {
+		t.Fatalf("expected 2 global upserts, got %d", len(store.upsertedGlobals))
+	}
+	if store.upsertedGlobals[0].Content != "always use nerdctl not docker" {
+		t.Errorf("unexpected global content: %s", store.upsertedGlobals[0].Content)
+	}
+
+	// EnsureProject should have been called for _global.
+	found := false
+	for _, p := range store.ensuredProjects {
+		if p == "_global" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected EnsureProject to be called for _global")
+	}
+}
+
+func TestEngineDataLossGuardAccountsForGlobalSplit(t *testing.T) {
+	// 10 existing non-manual. Consolidator returns 3 project + 6 global = 9 total.
+	// But only 3 project-scoped < 10/2=5 → should block replace.
+	existing := make([]memory.Memory, 10)
+	for i := range existing {
+		existing[i] = memory.Memory{Source: "reflection", Content: "memory"}
+	}
+
+	store := &mockMemStore{
+		interactionCount: 9,
+		existingMemories: existing,
+	}
+
+	mems := []ReflectMemory{
+		{Category: "fact", Content: "p1", Importance: 0.8, Tags: []string{}, Scope: "project"},
+		{Category: "fact", Content: "p2", Importance: 0.7, Tags: []string{}, Scope: "project"},
+		{Category: "fact", Content: "p3", Importance: 0.6, Tags: []string{}, Scope: "project"},
+		{Category: "preference", Content: "g1", Importance: 0.9, Tags: []string{}, Scope: "global"},
+		{Category: "preference", Content: "g2", Importance: 0.8, Tags: []string{}, Scope: "global"},
+		{Category: "preference", Content: "g3", Importance: 0.7, Tags: []string{}, Scope: "global"},
+		{Category: "preference", Content: "g4", Importance: 0.6, Tags: []string{}, Scope: "global"},
+		{Category: "preference", Content: "g5", Importance: 0.5, Tags: []string{}, Scope: "global"},
+		{Category: "preference", Content: "g6", Importance: 0.4, Tags: []string{}, Scope: "global"},
+	}
+	response := mustJSON(t, ReflectionResult{LearnedContext: "ctx", Memories: mems})
+
+	client := &mockConsolidator{response: response}
+	e := NewEngine(client, store, testLogger(), 10)
+	e.MaybeReflect(context.Background(), "proj1", testProjectCtx())
+
+	if store.replaceCalled {
+		t.Fatal("ReplaceNonManual should NOT be called — 3 project < 10/2 guard")
+	}
+
+	// Global memories should still be upserted even when project replace is blocked.
+	if len(store.upsertedGlobals) != 6 {
+		t.Fatalf("expected 6 global upserts even with blocked replace, got %d", len(store.upsertedGlobals))
 	}
 }
 

--- a/internal/reflection/prompt.go
+++ b/internal/reflection/prompt.go
@@ -29,6 +29,7 @@ type ReflectMemory struct {
 	Content    string   `json:"content"`
 	Importance float32  `json:"importance"`
 	Tags       []string `json:"tags"`
+	Scope      string   `json:"scope,omitempty"` // "project" (default) or "global"
 }
 
 // BuildReflectionPrompt assembles the reflection prompt from project history.
@@ -92,8 +93,9 @@ Produce a JSON object with two fields:
    - Merge duplicates into one stronger memory (higher importance)
    - Keep identity facts (architecture, conventions) — never drop these
    - Drop stale situational memories (old gotchas that were fixed)
-   - Each memory: "category" (architecture/decision/pattern/convention/gotcha/dependency/preference/fact), "content" (1-2 sentences), "importance" (0.0-1.0), "tags" (1-3 keywords)
+   - Each memory: "category" (architecture/decision/pattern/convention/gotcha/dependency/preference/fact), "content" (1-2 sentences), "importance" (0.0-1.0), "tags" (1-3 keywords), "scope" ("project" or "global")
    - Aim for 10-25 high-quality memories, not 50 repetitive ones
+   - Scope: most memories are "project". Mark as "global" ONLY if the knowledge applies across ALL repositories — examples: user preferences, cross-repo workflows (deploying from one repo to another), personal tooling choices, SSH hosts, infrastructure topology. Project-specific architecture, patterns, or conventions are always "project".
 
 Return ONLY the JSON object, no other text.`)
 

--- a/internal/reflection/tier_ollama.go
+++ b/internal/reflection/tier_ollama.go
@@ -74,9 +74,10 @@ var reflectionSchema = json.RawMessage(`{
 					"category": {"type": "string", "enum": ["architecture","decision","pattern","convention","gotcha","dependency","preference","fact"]},
 					"content": {"type": "string"},
 					"importance": {"type": "number"},
-					"tags": {"type": "array", "items": {"type": "string"}}
+					"tags": {"type": "array", "items": {"type": "string"}},
+					"scope": {"type": "string", "enum": ["project","global"]}
 				},
-				"required": ["category", "content", "importance", "tags"]
+				"required": ["category", "content", "importance", "tags", "scope"]
 			}
 		}
 	},

--- a/internal/reflection/tier_sqlite.go
+++ b/internal/reflection/tier_sqlite.go
@@ -83,6 +83,7 @@ func (s *SQLiteConsolidator) Consolidate(_ context.Context, input ReflectionInpu
 			Content:    best.Content,
 			Importance: best.Importance,
 			Tags:       best.Tags,
+			Scope:      inferGlobalScope(best.Category, best.Content),
 		})
 	}
 
@@ -103,6 +104,37 @@ func tokenize(s string) map[string]bool {
 		}
 	}
 	return tokens
+}
+
+// inferGlobalScope uses keyword heuristics to detect memories that apply across
+// all repositories rather than being project-specific. Used by the SQLite tier
+// which cannot use LLM classification.
+func inferGlobalScope(category, content string) string {
+	// Preferences and certain facts are strong global signals.
+	if category == "preference" {
+		return "global"
+	}
+
+	lower := strings.ToLower(content)
+
+	// Cross-repo workflow indicators.
+	globalPatterns := []string{
+		"across all", "all repos", "all projects", "every repo", "every project",
+		"cross-repo", "cross-project", "from any repo",
+		"deploy to", "deploy from", "push to infra",
+		"ssh ", "ssh into", "hostname",
+		"always use", "never use", "prefer ",
+		"personal tool", "dev machine", "workstation",
+		"infrastructure topology", "cluster ",
+		"api key", "credential", "token ",
+	}
+	for _, p := range globalPatterns {
+		if strings.Contains(lower, p) {
+			return "global"
+		}
+	}
+
+	return "project"
 }
 
 // jaccard computes the Jaccard similarity coefficient between two token sets.


### PR DESCRIPTION
## Summary
- Memories are now classified as `"project"` or `"global"` scope during consolidation
- Global-scoped memories (user preferences, cross-repo workflows, infra topology, SSH hosts) are upserted into `_global` project instead of staying project-scoped
- All three consolidation tiers support scope: Haiku/Ollama via prompt instructions, SQLite via keyword heuristics (`inferGlobalScope`)
- Engine splits results at routing time — globals go to `_global` via Upsert, project memories replace via `ReplaceNonManual`
- Data loss guard counts only project-scoped memories (global extraction doesn't inflate the denominator)
- `ghost reflect` CLI preview now shows scope breakdown

## How it works
| Tier | Scope detection |
|------|----------------|
| Haiku | LLM classifies via prompt instructions |
| Ollama | JSON schema enforces `"scope": "project"\|"global"` enum |
| SQLite | `inferGlobalScope()` keyword heuristic — preferences always global, plus patterns like "deploy to", "ssh", "always use", "all repos", "dev machine" |

## Files changed
- `internal/reflection/prompt.go` — `Scope` field on `ReflectMemory`, prompt instructions
- `internal/reflection/tier_ollama.go` — Schema adds scope enum
- `internal/reflection/tier_sqlite.go` — `inferGlobalScope()` heuristic
- `internal/reflection/engine.go` — Split routing, `EnsureProject` in interface
- `cmd/ghost/main.go` — CLI preview shows scope, apply splits globals
- `internal/reflection/engine_test.go` — 2 new tests (routing, guard interaction)
- `internal/reflection/consolidator_test.go` — 3 new tests (heuristic, SQLite scope, parse normalization)

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass (5 new tests)
- [x] `go build ./cmd/ghost` compiles
- [ ] Manual: `ghost reflect ghost --tier sqlite` shows scope breakdown
- [ ] Manual: `ghost reflect ghost --tier ollama --apply` promotes globals