### PR TITLE
feat(memory): seed global memories, simulation test, README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,80 +6,18 @@
 [![Go](https://img.shields.io/github/go-mod/go-version/wcatz/ghost)](go.mod)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-Ghost is a memory-first autonomous agent. It persists what it learns about your projects in SQLite — architecture decisions, patterns, conventions, gotchas — and carries that context into an agentic tool loop that can act on your behalf. It runs as a daemon with an HTTP API, MCP server, VSCode extension, Telegram bot, and terminal REPL.
+MCP memory server for Claude Code, Cursor, and any MCP client. Ghost gives your AI assistant persistent, structured memory across sessions — it remembers architecture decisions, patterns, conventions, and gotchas so you don't have to repeat yourself.
 
-Pure Go. No CGO. Single binary.
+Pure Go. No CGO. Single binary. No external services required.
 
-## What It Does
-
-- **Agentic tool loop** — Claude's tool_use drives a read-act-reflect cycle with configurable approval gates
-- **Persistent memory** across sessions — Ghost knows what you worked on last week
-- **Claude Code memory import** — auto-imports Claude Code's memory files on first project contact, no manual migration
-- **3-block prompt caching** — 90%+ cache hit rates, ~76% savings on input tokens
-- **Hybrid search** — FTS5 keyword + vector cosine similarity via Reciprocal Rank Fusion
-- **Free embeddings** — `nomic-embed-text:v1.5` runs locally through Ollama, no API costs
-- **Tiered consolidation** — memory dedup via Haiku API or pure SQLite (works without API credits)
-- **Time-decay scoring** — stale memories fade automatically by category half-life
-- **Cost tracking** — per-session and monthly cost aggregation with cache savings, API vs subscription comparison
-- **Google Calendar + Gmail** — meeting notifications, email summaries via OAuth2
-- **CalDAV calendar** — alternative to Google (iCloud, Fastmail, etc.)
-- **GitHub notifications** — P0-P4 priority-classified alerts forwarded to Telegram
-- **Tool approval forwarding** — approve Ghost's actions from phone via Telegram, auto-cleanup on resolution
-- **Voice input** — push-to-talk with Whisper/AssemblyAI STT and Piper/ElevenLabs TTS
-- **Task management** — create, list, complete tasks via MCP; tracked in SQLite
-- **Decision records** — architectural decisions with alternatives and rationale via MCP
-- **Session resume** — conversations persist to SQLite, reload on restart
-- **Context compression** — Haiku summarizes older messages when context gets long
-
-## Install
-
-Requires Go 1.25+.
+## Quick Start
 
 ```bash
 go install github.com/wcatz/ghost/cmd/ghost@latest
-```
-
-Or build from source:
-
-```bash
-git clone https://github.com/wcatz/ghost.git
-cd ghost
-make build
-```
-
-### Pre-built binaries
-
-Download from [GitHub Releases](https://github.com/wcatz/ghost/releases) — available for linux, macOS, and Windows (amd64 + arm64).
-
-### Update
-
-```bash
-ghost upgrade
-```
-
-Downloads the latest release from GitHub, replaces the running binary in-place (wherever it lives), and prints the version diff. No package manager required.
-
-### Docker
-
-```bash
-docker run -e ANTHROPIC_API_KEY="sk-ant-..." ghcr.io/wcatz/ghost:latest serve
-```
-
-### VSCode Extension
-
-Download the `.vsix` from [GitHub Releases](https://github.com/wcatz/ghost/releases) and install:
-
-```bash
-code --install-extension ghost-*.vsix
-```
-
-## Quick Start — Claude Code / Cursor
-
-Ghost's primary interface is as an MCP server. One command configures everything:
-
-```bash
 ghost mcp init
 ```
+
+That's it. Restart Claude Code and Ghost is active. Here's what `ghost mcp init` does:
 
 ```
 [1/5] Checking prerequisites...
@@ -102,28 +40,26 @@ ghost mcp init
 Done! Restart Claude Code to activate.
 ```
 
-**What this does:**
-
-| Step | Effect |
-|------|--------|
-| MCP registration | Runs `claude mcp add` so Claude Code discovers Ghost's 13 tools |
+| Step | What happens |
+|------|-------------|
+| MCP registration | `claude mcp add ghost` — Claude Code discovers Ghost's 13 tools |
 | Permissions | Pre-approves all `mcp__ghost__*` tools — no per-call prompts |
-| SessionStart hook | At every session start, Claude sees a reminder to call `ghost_project_context` |
-| Memory import | Reads Claude Code's `~/.claude/projects/*/memory/*.md` files into Ghost (deduplicated) |
-| Project redirects | Writes `MEMORY.md` files pointing Claude to Ghost instead of its built-in memory |
+| SessionStart hook | Every session, Claude is reminded to call `ghost_project_context` |
+| Memory import | Migrates Claude Code's `~/.claude/projects/*/memory/*.md` into Ghost (deduplicated) |
+| Project redirects | Writes `MEMORY.md` pointing Claude to Ghost instead of its built-in memory |
 
-After setup, Claude Code will automatically load your project context and save discoveries during work. No manual prompting needed.
+After setup, Claude automatically loads your project context at session start and saves discoveries during work. No manual prompting needed.
 
 ```bash
-ghost mcp status     # verify integration health
-ghost mcp init --dry-run  # preview changes without modifying files
+ghost mcp status          # verify integration health
+ghost mcp init --dry-run  # preview changes without writing
 ```
 
-Idempotent — safe to re-run after updates or installs.
+Idempotent — safe to re-run after updates.
 
-### Manual MCP setup (Cursor, other clients)
+### Other MCP clients (Cursor, Goose, etc.)
 
-If you're not using Claude Code, add Ghost to your MCP config directly:
+Add Ghost to your MCP config:
 
 ```json
 {
@@ -137,21 +73,186 @@ If you're not using Claude Code, add Ghost to your MCP config directly:
 }
 ```
 
-### Standalone usage
+## How It Works
+
+Ghost is a memory pipeline with four stages:
+
+```
+Save → Search → Consolidate → Decay
+```
+
+**Save** — Claude (or you) saves memories via MCP tools. Each memory has a category, importance score (0.0-1.0), and tags. FTS-based upsert deduplicates on save — if a similar memory already exists in the same category, it strengthens instead of creating a duplicate.
+
+**Search** — FTS5 full-text search with optional vector similarity (Ollama embeddings). Cross-project search finds knowledge from other repos. Global memories (`_global`) are included in every project's context.
+
+**Consolidate** — Periodic reflection merges duplicates, prunes noise, and promotes cross-project knowledge to global scope. Two tiers:
+
+| Tier | Backend | Cost | How it works |
+|------|---------|------|-------------|
+| Haiku | Anthropic API | ~$0.001/run | LLM reads all memories + recent conversations, outputs consolidated set |
+| SQLite | Local | Free | Jaccard token similarity, merges >50% overlap, always available |
+
+A quality gate rejects garbage output (< 30% of input) and falls through to the next tier.
+
+**Decay** — Time-based scoring fades stale memories by category:
+
+| Category | Decay | What it captures |
+|----------|-------|---------|
+| preference | none | How you like to work |
+| convention | none | Naming, formatting, workflow rules |
+| fact | none | Endpoints, ports, credentials, constants |
+| architecture | 45-day | System design, component relationships |
+| pattern | 45-day | Recurring approaches, idioms |
+| decision | 30-day | Choices made and why |
+| gotcha | 30-day | Bugs, edge cases, surprises |
+| dependency | 30-day | Library versions, API quirks |
+
+## MCP Tools
+
+Ghost exposes 13 tools to any MCP client:
+
+| Tool | What it does |
+|------|-------------|
+| `ghost_project_context` | Load top memories ranked by importance + time decay |
+| `ghost_memory_save` | Store a memory with category, importance, tags (upserts) |
+| `ghost_memory_search` | FTS5 + vector hybrid search |
+| `ghost_memories_list` | List memories, optionally filtered by category |
+| `ghost_memory_delete` | Delete by ID |
+| `ghost_list_projects` | All known projects with memory counts |
+| `ghost_search_all` | Cross-project memory search |
+| `ghost_save_global` | Save a memory that applies to all projects |
+| `ghost_task_create` | Track bugs, features, follow-ups |
+| `ghost_task_list` | List tasks by project and status |
+| `ghost_task_complete` | Mark done with optional notes |
+| `ghost_decision_record` | Architectural decision with rationale and alternatives |
+| `ghost_health` | System health (memory count, embedding status, costs) |
+
+**Resources:**
+
+| Resource | Description |
+|----------|-------------|
+| `ghost://project/{id}/context` | Project context (memories + learned context) |
+| `ghost://memories/global` | Global memories accessible to all projects |
+
+The MCP server ships with embedded instructions that teach Claude when to save, which categories to use, and how to leverage cross-project search — so it works proactively without configuration.
+
+## Install
+
+Requires Go 1.25+.
+
+```bash
+go install github.com/wcatz/ghost/cmd/ghost@latest
+```
+
+Or build from source:
+
+```bash
+git clone https://github.com/wcatz/ghost.git && cd ghost && make build
+```
+
+### Pre-built binaries
+
+Download from [GitHub Releases](https://github.com/wcatz/ghost/releases) — linux, macOS, Windows (amd64 + arm64).
+
+### Update
+
+```bash
+ghost upgrade    # self-update from GitHub Releases
+```
+
+### Docker
+
+```bash
+docker run -v ghost-data:/data ghcr.io/wcatz/ghost:latest mcp
+```
+
+---
+
+## Beyond MCP — Optional Features
+
+Everything below is optional. Ghost works as a pure MCP memory server with zero configuration beyond `ghost mcp init`. These features activate when you run `ghost serve` as a daemon.
+
+### HTTP API
+
+REST API on `127.0.0.1:2187`, authenticated via Bearer token when configured.
+
+**Memory endpoints:**
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/v1/memories/search` | Search memories (FTS5) |
+| POST | `/api/v1/memories/` | Create/upsert memory |
+| GET | `/api/v1/memories/{projectID}` | List project memories |
+| DELETE | `/api/v1/memories/{memoryID}` | Delete memory |
+| GET | `/api/v1/projects` | List all projects |
+
+**Session endpoints (requires `ANTHROPIC_API_KEY`):**
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/v1/sessions/` | Create chat session |
+| POST | `/api/v1/sessions/{id}/send` | Send message (SSE streaming) |
+| POST | `/api/v1/sessions/{id}/approve` | Approve/deny pending tool |
+| POST | `/api/v1/sessions/{id}/mode` | Change operating mode |
+| POST | `/api/v1/sessions/{id}/auto-approve` | Toggle auto-approve |
+| GET | `/api/v1/sessions/{id}/history` | Conversation history |
+| GET | `/api/v1/sessions/` | List active sessions |
+| DELETE | `/api/v1/sessions/{id}` | Delete session |
+| GET | `/api/v1/health` | Health check |
+| GET | `/api/v1/costs/monthly` | Monthly cost by model |
+
+**SSE stream events:**
+
+| Event | Description |
+|-------|-------------|
+| `text` | Assistant text response |
+| `thinking` | Extended thinking output |
+| `tool_use_start` / `tool_use_end` | Tool invocation lifecycle |
+| `tool_result` | Execution result with duration |
+| `tool_diff` | File diff output |
+| `approval_required` | Tool needs approval (from any client) |
+| `approval_resolved` | Approval handled |
+| `done` | Stream complete with usage stats |
+
+### Telegram Bot
+
+Remote access to Ghost from your phone. Run `ghost serve` with `telegram.token` configured.
+
+| Command | Description |
+|---------|-------------|
+| `/sessions` | Active sessions with inline picker |
+| `/chat <id> <msg>` | Chat with a Ghost session (streamed) |
+| `/new` | Create new session |
+| `/yolo` | Toggle auto-approve for a session |
+| `/memory search <q>` | Search memories |
+| `/notifications` | GitHub notifications (P0-P4 priority) |
+| `/meetings` | Today's calendar with Meet links |
+| `/emails` | Unread Gmail summaries |
+| `/briefing` | Daily briefing |
+| `/cost` | Session and monthly cost |
+| `/remind <msg>` | Set a reminder |
+
+**Tool approval forwarding** — when Ghost needs permission to run a tool (bash, file writes, git), it sends an approval request to Telegram with Allow/Deny buttons. Tap to approve from your phone. Approvals resolved from any client (VSCode, TUI, Telegram) auto-delete the message on other clients.
+
+### VSCode Extension
+
+Chat interface in the editor. Download `.vsix` from [Releases](https://github.com/wcatz/ghost/releases), open with `Alt+G`.
+
+- SSE streaming with thinking blocks, tool progress, inline diffs
+- Tool approval overlay (Allow/Deny)
+- Memory browser with search
+- Cost tracking (monthly + session)
+- Auto-approve toggle, image paste, `@file.ext` references
+- Session resume across restarts
+
+### Interactive REPL
 
 ```bash
 export ANTHROPIC_API_KEY="sk-ant-..."
-
-ghost                                  # interactive REPL
-ghost "explain the authentication flow" # one-shot query
-echo "explain this" | ghost            # pipe mode
-ghost serve                            # daemon (HTTP API + all subsystems)
-ghost upgrade                          # self-update to latest release
+ghost                    # interactive TUI
+ghost "question"         # one-shot
+echo "question" | ghost  # pipe mode
 ```
-
-## Runtime Modes
-
-### `ghost` — Interactive REPL
 
 | Flag | Description |
 |------|-------------|
@@ -160,189 +261,25 @@ ghost upgrade                          # self-update to latest release
 | `-project` | Project path (repeatable) |
 | `-yolo` | Skip all tool approvals |
 | `-continue` | Resume last conversation |
-| `-no-memory` | Disable automatic memory extraction |
-| `-no-tui` | Force legacy REPL (no bubbletea) |
-| `-v`, `version` | Print version and exit |
 
-**Slash commands:**
+**Keybindings:** `ctrl+k` command palette, `ctrl+y` copy last code block, `ctrl+space` push-to-talk, `esc` interrupt.
 
-| Command | Description |
-|---------|-------------|
-| `/model <name>` | Switch model (sonnet/haiku/opus) |
-| `/continue` | Continue from where left off |
-| `/compact` | Compress conversation history |
-| `/tokens` | Token estimates + cache stats |
-| `/export` | Export conversation as markdown |
-| `/sessions` | List sessions with counts |
-| `/new` | Start fresh session |
-| `/resume` | Resume last session |
-| `/memory` | List all memories |
-| `/memory search <q>` | Search memories |
-| `/memory add` | Add a manual memory |
-| `/cost` | Session cost breakdown |
-| `/context` | Show project context |
-| `/image <path>` | Send image to Claude |
-| `/reflect` | Force memory consolidation |
-| `/briefing` | Ask Ghost for a briefing |
-| `/voice` | Voice mode info |
-| `/health` | Memory, embeddings, cost |
-| `/history` | Conversation stats |
-| `/theme <name>` | Switch glamour theme |
-| `/remind <t> <msg>` | Set a reminder |
-| `/reminders` | List pending reminders |
-| `/switch <name>` | Switch project |
-| `/projects` | List project sessions |
-| `/clear` | Clear conversation |
-| `/quit` | Exit ghost |
+### Daemon Subsystems
 
-**Keybindings:** `ctrl+k` command palette, `ctrl+y` copy last code block, `ctrl+space` push-to-talk, `esc` interrupt, `?` help overlay.
+`ghost serve` runs all subsystems:
 
-### `ghost serve` — Daemon
-
-Headless background service with HTTP API and all subsystems.
-
-| Subsystem | What it does |
-|-----------|-------------|
-| HTTP API | REST API on `127.0.0.1:2187` |
-| Embedding worker | Vectorizes memories via Ollama |
-| Scheduler | Cron jobs + reminders |
-| Telegram bot | Remote access, approvals, alerts |
-| GitHub monitor | Notification polling, P0-P4 priority |
-| Google Calendar | Meeting alerts (10min + 5min) via Telegram |
-| Gmail | Unread email summaries |
-| Morning briefing | Cron-triggered daily summary |
-| Cost report | Monthly cost report to Telegram |
-
-### `ghost mcp` — MCP Server
-
-Exposes Ghost's memory to any MCP client via stdio. See [Quick Start](#quick-start--claude-code--cursor) for setup.
-
-**Tools (13):**
-
-| Tool | Description |
-|------|-------------|
-| `ghost_project_context` | Load top memories ranked by importance + recency |
-| `ghost_memory_save` | Store with category, importance, tags |
-| `ghost_memory_search` | FTS5 + vector hybrid search |
-| `ghost_memories_list` | List with optional category filter |
-| `ghost_memory_delete` | Delete by ID |
-| `ghost_list_projects` | Discover all known projects with memory counts |
-| `ghost_search_all` | Cross-project memory search |
-| `ghost_save_global` | Save memory accessible to all projects |
-| `ghost_task_create` | Create a task with priority and status |
-| `ghost_task_list` | List tasks by project and status |
-| `ghost_task_complete` | Mark a task as done |
-| `ghost_decision_record` | Record an architectural decision with rationale |
-| `ghost_health` | System stats (memory count, embeddings, costs) |
-
-**Resources:**
-
-| Resource | Description |
-|----------|-------------|
-| `ghost://project/{id}/context` | Push-based project context (memories + learned context) |
-| `ghost://memories/global` | Global memories accessible to all projects |
-
-The MCP server ships with comprehensive instructions that teach Claude when and how to save memories proactively, which categories to use, and how to leverage cross-project search.
-
-## HTTP API
-
-All endpoints under `/api/v1/`, authenticated via Bearer token when `server.auth_token` is configured.
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/health` | Health check |
-| POST | `/memories/search` | Search memories (FTS5) |
-| POST | `/memories/` | Create memory |
-| GET | `/memories/{projectID}` | List memories for project |
-| DELETE | `/memories/{memoryID}` | Delete memory |
-| GET | `/projects` | List all projects |
-| GET | `/costs/monthly` | Monthly cost aggregation by model |
-| GET | `/transcribe/token` | AssemblyAI temporary token |
-| POST | `/sessions/` | Create chat session |
-| GET | `/sessions/` | List sessions |
-| DELETE | `/sessions/{id}` | Delete session |
-| POST | `/sessions/{id}/send` | Send message (SSE stream) |
-| POST | `/sessions/{id}/approve` | Approve/deny pending tool |
-| POST | `/sessions/{id}/mode` | Change session mode |
-| POST | `/sessions/{id}/auto-approve` | Toggle auto-approve |
-| GET | `/sessions/{id}/history` | Get conversation history |
-
-## VSCode Extension
-
-Chat interface directly in the editor. Open with `Alt+G`.
-
-- Sidebar chat panel + editor tab chat
-- SSE streaming with thinking, tool progress, inline diffs
-- Markdown rendering with syntax highlighting + copy buttons
-- Cost tracking — monthly in header, session in footer
-- Auto-approve toggle (YOLO mode)
-- Image paste/attach support
-- Slash commands (`/mode`, `/clear`, `/cost`, `/auto-approve`)
-- Memory browser with search
-- Tool approval overlay with Allow/Deny
-- Session resume across restarts
-- `@file.ext` references to attach file contents
-
-## Telegram Bot
-
-| Command | Description |
-|---------|-------------|
-| `/status` | System status |
-| `/notifications` | GitHub notifications with "Open" buttons |
-| `/meetings` | Today's calendar with "Join Meet" buttons |
-| `/emails` | Unread Gmail with "Open" buttons |
-| `/sessions` | Active sessions with inline picker |
-| `/chat <id> <msg>` | Message a Ghost session |
-| `/memory search` | Search memories |
-| `/remind <msg>` | Set a reminder |
-| `/briefing` | Daily briefing with progressive loading |
-| `/mode` | List or switch session mode |
-| `/cost` | Session cost and monthly summary |
-| `/help` | Commands list |
-
-Tool approvals forward to Telegram with Allow/Deny buttons. Approvals resolved from any client (VSCode, TUI) auto-delete the Telegram message. Notifications are silent when the user is active in VSCode.
-
-## Google Integration
-
-OAuth2 for Google Calendar + Gmail.
-
-1. Create a Google Cloud project, enable Calendar API + Gmail API
-2. Create OAuth2 Desktop credentials
-3. Save to `~/.config/ghost/google-credentials.json`
-4. On first `ghost serve`, authorize via the printed URL
-
-CalDAV is also supported as an alternative calendar source (iCloud, Fastmail, etc.) — configure under `calendar:` in config.
-
-## Memory System
-
-| Category | Decay | Purpose |
-|----------|-------|---------|
-| preference | none | Developer preferences |
-| convention | none | Style and naming |
-| fact | none | Durable project facts |
-| architecture | 45-day | Codebase structure |
-| pattern | 45-day | Recurring code patterns |
-| decision | 30-day | Why things were done |
-| gotcha | 30-day | Bugs and edge cases |
-| dependency | 30-day | Libraries and versions |
-
-### Tiered Consolidation
-
-Memory consolidation runs periodically to merge duplicates, prune stale entries, and maintain quality. Two tiers are available — Ghost tries the highest quality tier and falls back automatically:
-
-| Tier | Backend | Cost | Quality | Requirements |
-|------|---------|------|---------|-------------|
-| 1 | Haiku API | ~$0.001/run | Best | Anthropic API key |
-| 0 | SQLite (Jaccard dedup) | Free | Mechanical | None (always available) |
-
-Default is `auto` — uses the best available tier. A quality gate rejects garbage results and falls through to the next tier. Configure explicitly:
-
-```yaml
-reflection:
-  backend: "auto"              # auto, haiku, sqlite, disabled
-```
-
-Users without API credits get free mechanical dedup via the SQLite tier — no external services needed.
+| Subsystem | What it does | Requires |
+|-----------|-------------|----------|
+| HTTP API | REST + SSE on `:2187` | nothing |
+| Embedding worker | Vectorizes memories locally | Ollama |
+| Telegram bot | Remote access + approvals | `telegram.token` |
+| GitHub monitor | P0-P4 notification alerts | `github.token` |
+| Google Calendar | Meeting alerts via Telegram | OAuth2 credentials |
+| Gmail | Email summaries | OAuth2 credentials |
+| CalDAV | Alternative calendar (iCloud, etc.) | `calendar.url` |
+| Scheduler | Cron jobs + reminders | nothing |
+| Morning briefing | Daily summary to Telegram | `briefing.enabled` |
+| Voice | STT/TTS (Whisper/AssemblyAI + Piper/ElevenLabs) | provider config |
 
 ## Configuration
 
@@ -356,6 +293,12 @@ Config loads in layers (later overrides earlier):
 6. `GHOST_*` environment variables
 7. CLI flags
 
+**Minimal config (MCP only — no daemon features):**
+
+No config file needed. Ghost stores memories in `~/.local/share/ghost/ghost.db`.
+
+**Full config (daemon with all subsystems):**
+
 ```yaml
 api:
   model_quality: "claude-opus-4-6-20250514"
@@ -363,7 +306,7 @@ api:
 
 server:
   listen_addr: "127.0.0.1:2187"
-  auth_token: ""                     # generate: openssl rand -hex 32
+  auth_token: ""                     # openssl rand -hex 32
 
 embedding:
   enabled: true
@@ -371,15 +314,15 @@ embedding:
   model: "nomic-embed-text:v1.5"
 
 reflection:
-  backend: "auto"                      # auto, haiku, sqlite, disabled
-
-github:
-  token: "ghp_..."
-  interval: 60
+  backend: "auto"                    # auto, haiku, sqlite, disabled
 
 telegram:
   token: "123456:ABC..."
   allowed_ids: "12345678"
+
+github:
+  token: "ghp_..."
+  interval: 60
 
 google:
   credentials_file: "~/.config/ghost/google-credentials.json"
@@ -387,10 +330,6 @@ google:
 briefing:
   enabled: true
   schedule: "0 8 * * 1-5"
-
-cost_report:
-  enabled: false
-  schedule: "0 9 1 * *"             # 9am on 1st of month
 ```
 
 See `internal/config/config.example.yaml` for all options including voice, display, and CalDAV.
@@ -400,32 +339,30 @@ See `internal/config/config.example.yaml` for all options including voice, displ
 ```
 cmd/ghost/main.go          CLI + daemon bootstrap
 internal/
+  memory/                  SQLite + FTS5 + vector search + time-decay scoring
+  reflection/              Tiered consolidation (Haiku → SQLite) + auto-extraction
+  mcpserver/               MCP server (stdio, 13 tools + 2 resources)
+  mcpinit/                 Claude Code integration setup (init, status, hook)
+  claudeimport/            Auto-import Claude Code memory files
   ai/                      Claude API client, streaming, tool_use, cost tracking
-  memory/                  SQLite + FTS5 + vector search + time-decay
-  tool/                    Tool registry + built-in executors (file, grep, glob, git, bash, memory)
-  orchestrator/            Multi-project sessions, context compression, multi-turn caching
-  claudeimport/            Auto-import Claude Code memory files on first project contact
-  reflection/              Tiered memory consolidation (Haiku → SQLite) + auto-extraction
+  tool/                    Tool registry + executors (file, grep, glob, git, bash, memory)
+  orchestrator/            Multi-project sessions, context compression, caching
   prompt/                  3-block cached system prompt
   mode/                    Operating modes (chat, code, debug, review, plan, refactor)
   project/                 Auto-detection (language, tests, git)
   config/                  Layered YAML/env/flag config (koanf)
+  server/                  HTTP REST API + SSE streaming (chi)
   tui/                     Terminal REPL (bubbletea)
-  server/                  HTTP REST API (chi)
-  mcpserver/               MCP server (stdio, 13 tools + resources)
-  mcpinit/                 Claude Code integration setup (init, status, hook)
-  selfupdate/              Self-update from GitHub releases
-  telegram/                Bot, approvals, session management
+  telegram/                Bot, session management, approval forwarding
   google/                  Calendar + Gmail OAuth2
-  calendar/                CalDAV client
   github/                  Notification monitor (P0-P4 priority)
   scheduler/               Cron + reminders (gocron)
-  briefing/                Daily briefing
-  embedding/               Ollama async worker
+  briefing/                Daily briefing generator
+  embedding/               Ollama async vectorization worker
   voice/                   STT/TTS pipeline (Whisper, AssemblyAI, Piper, ElevenLabs)
-  mdv2/                    MarkdownV2 escaping for Telegram
+  selfupdate/              Self-update from GitHub releases
   provider/                Interface contracts
-migrations/                Reference SQL schema (runtime: internal/memory/schema.go)
+  mdv2/                    MarkdownV2 escaping for Telegram
 vscode-ghost/              VSCode extension (TypeScript)
 ```
 

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -863,6 +863,12 @@ func bootstrap() (*config.Config, *slog.Logger, *memory.Store, *sql.DB) {
 	}
 
 	store := memory.NewStore(db, logger)
+
+	// Ensure seed global memories exist (pinned, manual source — consolidation-proof).
+	if err := store.SeedGlobalMemories(context.Background()); err != nil {
+		logger.Warn("seed global memories", "error", err)
+	}
+
 	return cfg, logger, store, db
 }
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -60,6 +60,67 @@ func NewStore(db *sql.DB, logger *slog.Logger) *Store {
 	return &Store{db: db, logger: logger}
 }
 
+// seedGlobalMemory defines a memory that Ghost ships with out of the box.
+// These are inserted as source='manual', pinned=1, so consolidation never
+// touches them.
+type seedGlobalMemory struct {
+	Category   string
+	Content    string
+	Importance float32
+	Tags       []string
+}
+
+// defaultSeedMemories are baked into every Ghost installation.
+var defaultSeedMemories = []seedGlobalMemory{
+	{
+		Category:   "preference",
+		Content:    "NEVER add Co-Authored-By or any AI attribution to commit messages. All commits belong to the user.",
+		Importance: 1.0,
+		Tags:       []string{"git", "commits", "non-negotiable"},
+	},
+}
+
+// SeedGlobalMemories ensures the _global project exists and inserts any
+// missing seed memories. Seeds are pinned and source='manual' so they
+// survive consolidation. Idempotent — skips memories whose content already
+// exists.
+func (s *Store) SeedGlobalMemories(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Ensure _global project.
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO projects (id, path, name) VALUES ('_global', '_global', 'global')
+		ON CONFLICT(id) DO NOTHING
+	`)
+	if err != nil {
+		return fmt.Errorf("ensure _global project: %w", err)
+	}
+	_, _ = s.db.ExecContext(ctx, `INSERT OR IGNORE INTO ghost_state (project_id) VALUES ('_global')`)
+
+	for _, seed := range defaultSeedMemories {
+		// Skip if content already exists in _global (exact match).
+		var exists int
+		err := s.db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM memories WHERE project_id = '_global' AND content = ?`,
+			seed.Content).Scan(&exists)
+		if err == nil && exists > 0 {
+			continue
+		}
+
+		tags, _ := json.Marshal(seed.Tags)
+		_, err = s.db.ExecContext(ctx, `
+			INSERT INTO memories (project_id, category, content, source, importance, tags, pinned)
+			VALUES ('_global', ?, ?, 'manual', ?, ?, 1)
+		`, seed.Category, seed.Content, seed.Importance, string(tags))
+		if err != nil {
+			s.logger.Warn("seed memory insert failed", "content", seed.Content, "error", err)
+		}
+	}
+
+	return nil
+}
+
 // Close closes the underlying database.
 func (s *Store) Close() error {
 	return s.db.Close()

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1279,6 +1279,84 @@ func TestMergeProject_SameID(t *testing.T) {
 	}
 }
 
+func TestSeedGlobalMemories(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Seed should create _global project and insert seed memories.
+	if err := s.SeedGlobalMemories(ctx); err != nil {
+		t.Fatalf("SeedGlobalMemories: %v", err)
+	}
+
+	// Verify _global project exists.
+	projects, _ := s.ListProjects(ctx)
+	found := false
+	for _, p := range projects {
+		if p.ID == "_global" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("_global project not created")
+	}
+
+	// Verify seed memories are present, pinned, and manual source.
+	mems, err := s.GetAll(ctx, "_global", 50)
+	if err != nil {
+		t.Fatalf("GetAll _global: %v", err)
+	}
+	if len(mems) == 0 {
+		t.Fatal("no seed memories found")
+	}
+
+	var coAuthorFound bool
+	for _, m := range mems {
+		if strings.Contains(m.Content, "Co-Authored-By") {
+			coAuthorFound = true
+			if m.Source != "manual" {
+				t.Errorf("seed memory source = %q, want 'manual'", m.Source)
+			}
+			if !m.Pinned {
+				t.Error("seed memory should be pinned")
+			}
+			if m.Importance != 1.0 {
+				t.Errorf("seed memory importance = %v, want 1.0", m.Importance)
+			}
+		}
+	}
+	if !coAuthorFound {
+		t.Error("Co-Authored-By seed memory not found")
+	}
+
+	// Run again — should be idempotent (no duplicates).
+	if err := s.SeedGlobalMemories(ctx); err != nil {
+		t.Fatalf("SeedGlobalMemories (2nd call): %v", err)
+	}
+	mems2, _ := s.GetAll(ctx, "_global", 50)
+	if len(mems2) != len(mems) {
+		t.Errorf("idempotency broken: %d memories after 2nd seed (was %d)", len(mems2), len(mems))
+	}
+
+	// Verify consolidation cannot remove it: ReplaceNonManual skips manual source.
+	replaceMems := []Memory{
+		{ProjectID: "_global", Category: "fact", Content: "some new fact", Source: "reflection", Importance: 0.5},
+	}
+	if err := s.ReplaceNonManual(ctx, "_global", replaceMems); err != nil {
+		t.Fatalf("ReplaceNonManual: %v", err)
+	}
+
+	memsAfter, _ := s.GetAll(ctx, "_global", 50)
+	var seedSurvived bool
+	for _, m := range memsAfter {
+		if strings.Contains(m.Content, "Co-Authored-By") {
+			seedSurvived = true
+		}
+	}
+	if !seedSurvived {
+		t.Error("seed memory was deleted by ReplaceNonManual — consolidation protection broken")
+	}
+}
+
 func TestEnsureProject_AutoMerge(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()

--- a/internal/simulation/simulation_test.go
+++ b/internal/simulation/simulation_test.go
@@ -1,0 +1,535 @@
+package simulation_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"math/rand"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wcatz/ghost/internal/memory"
+	"github.com/wcatz/ghost/internal/reflection"
+)
+
+// ── Scenario data ──────────────────────────────────────────────────────────
+
+type simDay struct {
+	day      int
+	memories []memory.Memory
+}
+
+func tags(t ...string) []string { return t }
+
+// scenario returns 30 days of realistic developer activity on a Go web project.
+// Intentionally includes near-duplicates, evolving understanding, global facts,
+// and noisy low-value memories to stress-test dedup + consolidation.
+func scenario() []simDay {
+	return []simDay{
+		// === Week 1: Project setup, initial discoveries ===
+		{day: 1, memories: []memory.Memory{
+			{Category: "architecture", Content: "Project uses Go 1.24 with Chi router, SQLite for persistence, and HTMX for frontend interactivity", Importance: 0.9, Source: "chat", Tags: tags("go", "chi", "sqlite", "htmx")},
+			{Category: "convention", Content: "All handlers live in internal/handler/ with one file per resource (users.go, posts.go, etc)", Importance: 0.7, Source: "chat", Tags: tags("handler", "convention")},
+			{Category: "dependency", Content: "Using modernc.org/sqlite pure-Go driver, not mattn/go-sqlite3 which requires CGO", Importance: 0.8, Source: "chat", Tags: tags("sqlite", "driver")},
+		}},
+		{day: 2, memories: []memory.Memory{
+			{Category: "architecture", Content: "Database migrations are embedded via go:embed in internal/db/schema.go and run on startup", Importance: 0.8, Source: "chat", Tags: tags("migration", "embed")},
+			{Category: "pattern", Content: "Error handling pattern: wrap with fmt.Errorf and %w verb, return to handler which maps to HTTP status", Importance: 0.6, Source: "chat", Tags: tags("errors", "pattern")},
+			{Category: "fact", Content: "CI runs on GitHub Actions with build-and-test job, uses golangci-lint", Importance: 0.5, Source: "chat", Tags: tags("ci", "github-actions")},
+		}},
+		{day: 3, memories: []memory.Memory{
+			{Category: "preference", Content: "User prefers table-driven tests with subtests using t.Run, not separate test functions", Importance: 0.7, Source: "chat", Tags: tags("testing", "preference")},
+			{Category: "convention", Content: "Commit messages follow conventional commits: feat(), fix(), chore(), docs:", Importance: 0.8, Source: "chat", Tags: tags("git", "commits")},
+		}},
+		{day: 4, memories: []memory.Memory{
+			{Category: "gotcha", Content: "SQLite RETURNING clause requires modernc.org/sqlite v1.29+ — earlier versions silently return empty", Importance: 0.9, Source: "chat", Tags: tags("sqlite", "gotcha")},
+			{Category: "architecture", Content: "Config loaded from YAML file with envconfig overlay: config.yaml → env vars → CLI flags", Importance: 0.7, Source: "chat", Tags: tags("config", "yaml")},
+		}},
+		{day: 5, memories: []memory.Memory{
+			{Category: "pattern", Content: "All database queries use context.Context for cancellation, passed from HTTP request context", Importance: 0.6, Source: "chat", Tags: tags("context", "database")},
+			{Category: "decision", Content: "Chose Chi over Gin because Chi is stdlib-compatible (net/http handlers) and has no global state", Importance: 0.8, Source: "chat", Tags: tags("chi", "gin", "router")},
+			{Category: "fact", Content: "Dev server runs on port 8080, production behind Caddy reverse proxy on port 443", Importance: 0.5, Source: "chat", Tags: tags("server", "caddy")},
+		}},
+
+		// === Week 2: Feature development, first bugs ===
+		{day: 8, memories: []memory.Memory{
+			{Category: "architecture", Content: "Authentication uses session cookies stored in SQLite sessions table, 24h expiry with rolling refresh", Importance: 0.9, Source: "chat", Tags: tags("auth", "session", "cookies")},
+			{Category: "gotcha", Content: "Chi middleware order matters: Logger must come before Recoverer, Auth before route handlers", Importance: 0.8, Source: "chat", Tags: tags("chi", "middleware", "order")},
+			// Near-duplicate of day 1 architecture — should merge
+			{Category: "architecture", Content: "The project uses Go with Chi router for HTTP, SQLite for data persistence, HTMX on the frontend", Importance: 0.7, Source: "chat", Tags: tags("go", "chi", "sqlite")},
+		}},
+		{day: 9, memories: []memory.Memory{
+			{Category: "pattern", Content: "Repository pattern: each domain has a Store interface in internal/domain/ implemented by SQLite in internal/db/", Importance: 0.7, Source: "chat", Tags: tags("repository", "interface")},
+			{Category: "gotcha", Content: "HTMX hx-swap='innerHTML' breaks event listeners — must use hx-swap='morph' or re-attach in htmx:afterSwap", Importance: 0.8, Source: "chat", Tags: tags("htmx", "swap", "events")},
+		}},
+		{day: 10, memories: []memory.Memory{
+			{Category: "dependency", Content: "HTMX v2.0.4 loaded from /static/htmx.min.js, not CDN — for offline dev and version pinning", Importance: 0.6, Source: "chat", Tags: tags("htmx", "static")},
+			{Category: "decision", Content: "Decided to use server-side rendering with html/template instead of a JS framework — simpler stack, faster loads", Importance: 0.7, Source: "chat", Tags: tags("ssr", "template", "decision")},
+			// Duplicate preference — should strengthen
+			{Category: "preference", Content: "User prefers table-driven tests using t.Run subtests over individual test functions", Importance: 0.6, Source: "chat", Tags: tags("testing")},
+		}},
+		{day: 11, memories: []memory.Memory{
+			{Category: "gotcha", Content: "html/template auto-escapes but NOT in <script> tags — must use json.Marshal for inline JS data", Importance: 0.9, Source: "chat", Tags: tags("template", "xss", "security")},
+			{Category: "pattern", Content: "Error handling: wrap errors with context using fmt.Errorf('verb noun: %w', err), handlers map to HTTP codes", Importance: 0.6, Source: "chat", Tags: tags("errors")},
+		}},
+		{day: 12, memories: []memory.Memory{
+			{Category: "architecture", Content: "Background job runner uses a goroutine pool with buffered channels, graceful shutdown via context cancellation", Importance: 0.8, Source: "chat", Tags: tags("goroutine", "jobs", "shutdown")},
+			{Category: "fact", Content: "Production database is at /var/lib/myapp/data.db, dev uses ./data/dev.db relative to project root", Importance: 0.5, Source: "chat", Tags: tags("database", "paths")},
+		}},
+
+		// === Week 3: Deeper work, more patterns, some global knowledge ===
+		{day: 15, memories: []memory.Memory{
+			{Category: "gotcha", Content: "SQLite WAL mode required for concurrent reads during writes — set via PRAGMA journal_mode=WAL on open", Importance: 0.9, Source: "chat", Tags: tags("sqlite", "wal", "concurrency")},
+			// Global-scoped: user convention across all projects
+			{Category: "preference", Content: "Always use feature branches and PRs, never commit directly to main across all projects", Importance: 1.0, Source: "chat", Tags: tags("git", "workflow")},
+		}},
+		{day: 16, memories: []memory.Memory{
+			{Category: "architecture", Content: "Email notifications use a queue table + background worker, not synchronous sends in handlers", Importance: 0.7, Source: "chat", Tags: tags("email", "queue", "async")},
+			{Category: "pattern", Content: "All SQL queries use parameterized statements via ?, never string concatenation — prevents SQL injection", Importance: 0.8, Source: "chat", Tags: tags("sql", "security")},
+		}},
+		{day: 17, memories: []memory.Memory{
+			// Near-duplicate of day 4 config architecture
+			{Category: "architecture", Content: "Configuration layering: YAML file is base, environment variables override, CLI flags override both", Importance: 0.7, Source: "chat", Tags: tags("config")},
+			{Category: "gotcha", Content: "Chi URL params via chi.URLParam(r, 'id') return empty string (not error) for missing params — must validate", Importance: 0.7, Source: "chat", Tags: tags("chi", "params")},
+		}},
+		{day: 18, memories: []memory.Memory{
+			{Category: "decision", Content: "Chose SQLite over Postgres for simplicity — single binary deployment, no separate database server needed", Importance: 0.8, Source: "chat", Tags: tags("sqlite", "postgres", "decision")},
+			{Category: "dependency", Content: "Using slog (Go 1.21+) for structured logging instead of zerolog or zap — stdlib preference", Importance: 0.6, Source: "chat", Tags: tags("logging", "slog")},
+		}},
+		{day: 19, memories: []memory.Memory{
+			{Category: "pattern", Content: "Middleware chain: Logger → Recoverer → CORS → Auth → RateLimit → handler. Order is load-bearing.", Importance: 0.8, Source: "chat", Tags: tags("middleware", "chain")},
+			{Category: "fact", Content: "Rate limiter uses token bucket at 100 req/min per IP, stored in-memory with sync.Map", Importance: 0.6, Source: "chat", Tags: tags("ratelimit", "tokenbucket")},
+			// Global knowledge: SSH access
+			{Category: "fact", Content: "Production server SSH: ssh deploy@prod.example.com — used for all projects' deployments", Importance: 0.7, Source: "chat", Tags: tags("ssh", "deploy")},
+		}},
+
+		// === Week 4: Maturity, refactoring, knowledge solidifies ===
+		{day: 22, memories: []memory.Memory{
+			{Category: "architecture", Content: "API versioning via URL prefix /api/v1/ — v2 will coexist, not replace", Importance: 0.7, Source: "chat", Tags: tags("api", "versioning")},
+			// Evolved understanding — should replace earlier simpler version
+			{Category: "architecture", Content: "Auth flow: login POST → bcrypt verify → create session row → set HttpOnly Secure cookie → 302 redirect. Session table has user_id FK, expires_at, created_at.", Importance: 0.9, Source: "chat", Tags: tags("auth", "session", "bcrypt")},
+		}},
+		{day: 23, memories: []memory.Memory{
+			{Category: "gotcha", Content: "go:embed directive must be in the same package as the embedded files — can't embed from parent directory", Importance: 0.7, Source: "chat", Tags: tags("embed", "gotcha")},
+			{Category: "pattern", Content: "Repository interface pattern: domain defines Store interface, internal/db implements it, handler depends on interface", Importance: 0.7, Source: "chat", Tags: tags("repository", "interface", "di")},
+		}},
+		{day: 24, memories: []memory.Memory{
+			{Category: "decision", Content: "Decided against adding Redis — SQLite handles current traffic (< 1000 rps), adding Redis would complicate deployment", Importance: 0.7, Source: "chat", Tags: tags("redis", "sqlite", "scaling")},
+			{Category: "convention", Content: "All handler functions follow signature: func(w http.ResponseWriter, r *http.Request) — stdlib compatible", Importance: 0.6, Source: "chat", Tags: tags("handler", "signature")},
+		}},
+		{day: 25, memories: []memory.Memory{
+			// Duplicate of existing Chi middleware gotcha
+			{Category: "gotcha", Content: "Chi middleware ordering is critical — Logger must be outermost, Auth must wrap protected routes only", Importance: 0.8, Source: "chat", Tags: tags("chi", "middleware")},
+			{Category: "fact", Content: "Test coverage target is 70%, currently at 65%. Missing coverage mostly in email worker and auth middleware.", Importance: 0.5, Source: "chat", Tags: tags("testing", "coverage")},
+		}},
+		{day: 26, memories: []memory.Memory{
+			{Category: "architecture", Content: "Graceful shutdown: main() listens for SIGINT/SIGTERM, cancels root context, waits for HTTP server and job worker", Importance: 0.8, Source: "chat", Tags: tags("shutdown", "signal")},
+			{Category: "pattern", Content: "Database transactions: store methods that touch multiple tables accept *sql.Tx, callers manage begin/commit/rollback", Importance: 0.7, Source: "chat", Tags: tags("transactions", "database")},
+		}},
+
+		// === Days 28-30: Late additions, some noise ===
+		{day: 28, memories: []memory.Memory{
+			{Category: "fact", Content: "Docker image is 12MB using multi-stage build: Go builder → scratch with just the binary + migrations", Importance: 0.6, Source: "chat", Tags: tags("docker", "image")},
+			{Category: "dependency", Content: "Using modernc.org/sqlite v1.34.0 — pure Go, no CGO required, works on ARM64 and cross-compiles", Importance: 0.7, Source: "chat", Tags: tags("sqlite", "version")},
+		}},
+		{day: 29, memories: []memory.Memory{
+			// Near-duplicate of multiple earlier architecture memories
+			{Category: "architecture", Content: "Tech stack: Go 1.24, Chi router, SQLite (modernc), HTMX frontend, html/template SSR", Importance: 0.6, Source: "chat", Tags: tags("stack", "overview")},
+			{Category: "gotcha", Content: "Must call rows.Close() after database queries or SQLite connection pool exhausts — use defer immediately after QueryContext", Importance: 0.8, Source: "chat", Tags: tags("sqlite", "rows", "leak")},
+		}},
+		{day: 30, memories: []memory.Memory{
+			{Category: "preference", Content: "User always prefers to review diffs before committing — never auto-commit without showing changes", Importance: 0.8, Source: "chat", Tags: tags("git", "review")},
+			{Category: "fact", Content: "Backup script runs nightly via cron: sqlite3 data.db '.backup /backups/data-$(date +%Y%m%d).db'", Importance: 0.5, Source: "chat", Tags: tags("backup", "cron")},
+		}},
+	}
+}
+
+// ── Simulation ─────────────────────────────────────────────────────────────
+
+func TestSimulateMonthOfUsage(t *testing.T) {
+	db, err := memory.OpenDB(":memory:")
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer db.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	store := memory.NewStore(db, logger)
+	ctx := context.Background()
+
+	projectID := "sim-project"
+	if err := store.EnsureProject(ctx, projectID, "/tmp/sim", "sim-webapp"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+	if err := store.EnsureProject(ctx, "_global", "_global", "global"); err != nil {
+		t.Fatalf("EnsureProject _global: %v", err)
+	}
+
+	days := scenario()
+	rng := rand.New(rand.NewSource(42))
+
+	var totalSaved, totalMerged int
+
+	t.Log("╔══════════════════════════════════════════════════════════════╗")
+	t.Log("║        30-DAY MEMORY SYSTEM SIMULATION                     ║")
+	t.Log("║  Simulates a developer's month of work on a Go web app     ║")
+	t.Log("║  Tests: Upsert dedup → Consolidation → Time decay → Search ║")
+	t.Log("╚══════════════════════════════════════════════════════════════╝")
+
+	consolidationDays := map[int]bool{15: true, 30: true}
+
+	for _, day := range days {
+		baseTime := time.Date(2026, 2, 1, 9, 0, 0, 0, time.UTC).AddDate(0, 0, day.day-1)
+
+		for _, m := range day.memories {
+			id, merged, err := store.Upsert(ctx, projectID, m.Category, m.Content, m.Source, m.Importance, m.Tags)
+			if err != nil {
+				t.Fatalf("Day %d Upsert: %v", day.day, err)
+			}
+
+			// Backdate to simulate real passage of time.
+			ts := baseTime.Add(time.Duration(rng.Intn(8)) * time.Hour).Format(time.RFC3339)
+			_, err = db.ExecContext(ctx, `UPDATE memories SET created_at = ?, updated_at = ? WHERE id = ?`, ts, ts, id)
+			if err != nil {
+				t.Fatalf("backdate: %v", err)
+			}
+
+			if merged {
+				totalMerged++
+			} else {
+				totalSaved++
+			}
+		}
+
+		t.Logf("\n  Day %2d: +%d memories (%d new, %d merged so far)", day.day, len(day.memories), totalSaved, totalMerged)
+
+		// Run consolidation at checkpoints.
+		if consolidationDays[day.day] {
+			runConsolidation(t, db, store, ctx, projectID, day.day)
+		}
+	}
+
+	// ── Final report ───────────────────────────────────────────────────────
+	t.Log("\n" + strings.Repeat("═", 65))
+	t.Log("  FINAL REPORT — Day 30 (post-consolidation)")
+	t.Log(strings.Repeat("═", 65))
+
+	all, _ := store.GetAll(ctx, projectID, 200)
+	globals, _ := store.GetAll(ctx, "_global", 200)
+
+	t.Logf("\n  Project memories: %d", len(all))
+	t.Logf("  Global memories:  %d", len(globals))
+	t.Logf("  Total input saves: %d (%d new + %d FTS-merged)", totalSaved+totalMerged, totalSaved, totalMerged)
+	t.Logf("  Compression ratio: %.0f%% (52 inputs → %d stored)", float64(len(all)+len(globals))/52*100, len(all)+len(globals))
+
+	// Category distribution
+	cats := make(map[string]int)
+	for _, m := range all {
+		cats[m.Category]++
+	}
+	t.Log("\n  Category distribution (project):")
+	catOrder := []string{"architecture", "decision", "pattern", "convention", "gotcha", "dependency", "preference", "fact"}
+	for _, cat := range catOrder {
+		if n, ok := cats[cat]; ok {
+			bar := strings.Repeat("█", n*2)
+			t.Logf("    %-15s %s %d", cat, bar, n)
+		}
+	}
+
+	// Global memories
+	if len(globals) > 0 {
+		t.Log("\n  Global memories (_global):")
+		for i, m := range globals {
+			t.Logf("    %d. [%s] (%.1f) %.65s", i+1, m.Category, m.Importance, m.Content)
+		}
+	}
+
+	// Top 10 by time-decay score (simulating "now" = day 31)
+	top, _ := store.GetTopMemories(ctx, projectID, 10)
+	t.Log("\n  Top 10 by time-decay score:")
+	for i, m := range top {
+		age := daysSinceCreated(m.CreatedAt)
+		t.Logf("    %2d. [%-12s] imp=%.1f age=%2dd  %.60s", i+1, m.Category, m.Importance, age, m.Content)
+	}
+
+	// Importance distribution
+	var impBuckets [5]int
+	for _, m := range all {
+		bucket := int(m.Importance * 5)
+		if bucket >= 5 {
+			bucket = 4
+		}
+		impBuckets[bucket]++
+	}
+	t.Log("\n  Importance distribution:")
+	labels := []string{"0.0-0.2", "0.2-0.4", "0.4-0.6", "0.6-0.8", "0.8-1.0"}
+	for i, count := range impBuckets {
+		bar := strings.Repeat("█", count*3)
+		t.Logf("    %s: %s (%d)", labels[i], bar, count)
+	}
+
+	// Search quality
+	t.Log("\n  Search quality:")
+	searchTests := []struct {
+		query    string
+		wantHits bool
+		desc     string
+	}{
+		{"SQLite WAL concurrent", true, "specific gotcha"},
+		{"authentication session cookies", true, "auth architecture"},
+		{"Chi middleware order", true, "middleware gotcha"},
+		{"HTMX swap morph", true, "frontend gotcha"},
+		{"repository interface pattern", true, "code pattern"},
+		{"kubernetes pods", false, "unrelated concept"},
+		{"React components", false, "wrong framework"},
+	}
+	searchPass := 0
+	for _, st := range searchTests {
+		results, _ := store.SearchFTS(ctx, projectID, st.query, 5)
+		found := len(results) > 0
+		status := "PASS"
+		if found != st.wantHits {
+			status := "FAIL"
+			t.Errorf("    [%s] %s: query=%q found=%d want_hits=%v", status, st.desc, st.query, len(results), st.wantHits)
+		} else {
+			searchPass++
+		}
+		t.Logf("    [%s] %-25s query=%-35q hits=%d", status, st.desc, st.query, len(results))
+	}
+	t.Logf("  Search accuracy: %d/%d passed", searchPass, len(searchTests))
+
+	// Overlap analysis
+	t.Log("\n  Post-consolidation overlap analysis:")
+	overlaps := analyzeOverlaps(t, all)
+
+	// Snapshot health
+	var snapCount int
+	db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT snapshot_id) FROM memory_snapshots WHERE project_id = ?`, projectID).Scan(&snapCount)
+	t.Logf("\n  Snapshots retained: %d (max 3)", snapCount)
+
+	// ── Assertions ─────────────────────────────────────────────────────────
+	t.Log("\n" + strings.Repeat("─", 65))
+	t.Log("  ASSERTIONS")
+	t.Log(strings.Repeat("─", 65))
+
+	if len(all)+len(globals) > 40 {
+		t.Errorf("  FAIL: Memory bloat — %d total memories from 52 inputs (expected < 40)", len(all)+len(globals))
+	} else {
+		t.Logf("  PASS: No memory bloat (%d total from 52 inputs)", len(all)+len(globals))
+	}
+
+	if totalMerged < 3 {
+		t.Errorf("  FAIL: Only %d FTS merges — expected ≥ 3 given intentional duplicates", totalMerged)
+	} else {
+		t.Logf("  PASS: FTS dedup working (%d merges)", totalMerged)
+	}
+
+	if len(globals) == 0 {
+		t.Error("  FAIL: No global memories detected — scope classification broken")
+	} else {
+		t.Logf("  PASS: Global scope detection working (%d globals)", len(globals))
+	}
+
+	if overlaps > 5 {
+		t.Errorf("  FAIL: %d overlapping pairs remain after consolidation", overlaps)
+	} else {
+		t.Logf("  PASS: Low overlap (%d pairs > 30%% Jaccard)", overlaps)
+	}
+
+	if searchPass < len(searchTests)-1 {
+		t.Errorf("  FAIL: Search accuracy %d/%d", searchPass, len(searchTests))
+	} else {
+		t.Logf("  PASS: Search accuracy %d/%d", searchPass, len(searchTests))
+	}
+
+	if snapCount < 1 || snapCount > 3 {
+		t.Errorf("  FAIL: Snapshot count %d (expected 1-3)", snapCount)
+	} else {
+		t.Logf("  PASS: Snapshot retention correct (%d)", snapCount)
+	}
+}
+
+// runConsolidation executes SQLite-tier consolidation and applies results.
+func runConsolidation(t *testing.T, db *sql.DB, store *memory.Store, ctx context.Context, projectID string, day int) {
+	t.Helper()
+
+	all, err := store.GetAll(ctx, projectID, 200)
+	if err != nil {
+		t.Fatalf("GetAll for consolidation: %v", err)
+	}
+	beforeCount := len(all)
+
+	t.Logf("\n  ┌─── Consolidation cycle (Day %d) ───────────────────────────┐", day)
+	t.Logf("  │ Input: %d memories                                        │", beforeCount)
+
+	// Build reflection input.
+	input := reflection.ReflectionInput{
+		ExistingMemories: all,
+		CurrentContext:   fmt.Sprintf("Go web app, day %d of development", day),
+		ProjectName:      "sim-webapp",
+		ProjectLanguage:  "go",
+	}
+
+	consolidator := reflection.NewSQLiteConsolidator()
+	result, err := consolidator.Consolidate(ctx, input)
+	if err != nil {
+		t.Fatalf("Consolidation failed: %v", err)
+	}
+
+	// Split by scope.
+	var projectMemories []reflection.ReflectMemory
+	var globalMemories []reflection.ReflectMemory
+	for _, m := range result.Memories {
+		if m.Scope == "global" {
+			globalMemories = append(globalMemories, m)
+		} else {
+			projectMemories = append(projectMemories, m)
+		}
+	}
+
+	t.Logf("  │ Output: %d project + %d global = %d total                 │",
+		len(projectMemories), len(globalMemories), len(result.Memories))
+	t.Logf("  │ Compression: %d → %d (%.0f%% reduction)                    │",
+		beforeCount, len(projectMemories),
+		(1-float64(len(projectMemories))/float64(beforeCount))*100)
+
+	// Data loss guard check.
+	var existingNonManual int
+	for _, m := range all {
+		if m.Source != "manual" {
+			existingNonManual++
+		}
+	}
+	if existingNonManual >= 6 && len(projectMemories) < existingNonManual/2 {
+		t.Logf("  │ ⚠ DATA LOSS GUARD would block this! (%d < %d/2)          │",
+			len(projectMemories), existingNonManual)
+		t.Logf("  └──────────────────────────────────────────────────────────┘")
+		return
+	}
+
+	// Apply: upsert globals to _global.
+	for _, m := range globalMemories {
+		_, _, err := store.Upsert(ctx, "_global", m.Category, m.Content, "reflection", m.Importance, m.Tags)
+		if err != nil {
+			t.Logf("  │ Global upsert error: %v", err)
+		}
+	}
+
+	// Apply: replace project memories.
+	if len(projectMemories) > 0 {
+		dbMems := make([]memory.Memory, len(projectMemories))
+		for i, m := range projectMemories {
+			dbMems[i] = memory.Memory{
+				ProjectID:  projectID,
+				Category:   m.Category,
+				Content:    m.Content,
+				Importance: m.Importance,
+				Source:     "reflection",
+				Tags:       m.Tags,
+			}
+		}
+		if err := store.ReplaceNonManual(ctx, projectID, dbMems); err != nil {
+			t.Fatalf("ReplaceNonManual: %v", err)
+		}
+
+		// Backdate replaced memories to preserve time-decay simulation.
+		// New reflection memories get "now" timestamps — backdate to mid-period.
+		midpoint := time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC).AddDate(0, 0, day/2)
+		_, err = db.ExecContext(ctx, `UPDATE memories SET created_at = ? WHERE project_id = ? AND source = 'reflection'`,
+			midpoint.Format(time.RFC3339), projectID)
+		if err != nil {
+			t.Logf("  │ Backdate warning: %v", err)
+		}
+	}
+
+	afterAll, _ := store.GetAll(ctx, projectID, 200)
+	afterGlobals, _ := store.GetAll(ctx, "_global", 200)
+
+	// Show what survived.
+	t.Logf("  │                                                          │")
+	t.Logf("  │ After apply: %d project, %d global                        │", len(afterAll), len(afterGlobals))
+
+	cats := make(map[string]int)
+	for _, m := range afterAll {
+		cats[m.Category]++
+	}
+	catParts := make([]string, 0)
+	for cat, n := range cats {
+		catParts = append(catParts, fmt.Sprintf("%s:%d", cat, n))
+	}
+	sort.Strings(catParts)
+	t.Logf("  │ Categories: %s", strings.Join(catParts, " "))
+	t.Logf("  └──────────────────────────────────────────────────────────┘")
+}
+
+// ── Analysis helpers ───────────────────────────────────────────────────────
+
+func analyzeOverlaps(t *testing.T, memories []memory.Memory) int {
+	t.Helper()
+	count := 0
+	for i := 0; i < len(memories); i++ {
+		for j := i + 1; j < len(memories); j++ {
+			if memories[i].Category != memories[j].Category {
+				continue
+			}
+			sim := jaccardSimilarity(memories[i].Content, memories[j].Content)
+			if sim > 0.3 {
+				count++
+				t.Logf("    OVERLAP (%.0f%%) [%s]:", sim*100, memories[i].Category)
+				t.Logf("      A: %.70s", memories[i].Content)
+				t.Logf("      B: %.70s", memories[j].Content)
+			}
+		}
+	}
+	if count == 0 {
+		t.Log("    No significant overlaps (> 30% Jaccard) — clean memory set")
+	}
+	return count
+}
+
+func jaccardSimilarity(a, b string) float64 {
+	tokA := tokenize(a)
+	tokB := tokenize(b)
+	if len(tokA) == 0 || len(tokB) == 0 {
+		return 0
+	}
+	intersection := 0
+	for w := range tokA {
+		if tokB[w] {
+			intersection++
+		}
+	}
+	union := len(tokA) + len(tokB) - intersection
+	if union == 0 {
+		return 0
+	}
+	return float64(intersection) / float64(union)
+}
+
+func tokenize(s string) map[string]bool {
+	tokens := make(map[string]bool)
+	for _, w := range strings.Fields(strings.ToLower(s)) {
+		w = strings.Trim(w, ".,;:!?()[]{}\"'`—–-/")
+		if len(w) > 1 {
+			tokens[w] = true
+		}
+	}
+	return tokens
+}
+
+func daysSinceCreated(createdAt string) int {
+	t, err := time.Parse(time.RFC3339, createdAt)
+	if err != nil {
+		return -1
+	}
+	return int(math.Round(time.Since(t).Hours() / 24))
+}
+
+// Ensure json import is used (for potential future expansions).
+var _ = json.Marshal

--- a/internal/simulation/simulation_test.go
+++ b/internal/simulation/simulation_test.go
@@ -157,7 +157,7 @@ func TestSimulateMonthOfUsage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDB: %v", err)
 	}
-	defer db.Close()
+	defer db.Close() //nolint:errcheck
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	store := memory.NewStore(db, logger)
@@ -310,7 +310,9 @@ func TestSimulateMonthOfUsage(t *testing.T) {
 
 	// Snapshot health
 	var snapCount int
-	db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT snapshot_id) FROM memory_snapshots WHERE project_id = ?`, projectID).Scan(&snapCount)
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT snapshot_id) FROM memory_snapshots WHERE project_id = ?`, projectID).Scan(&snapCount); err != nil {
+		t.Logf("  snapshot count query: %v", err)
+	}
 	t.Logf("\n  Snapshots retained: %d (max 3)", snapCount)
 
 	// ── Assertions ─────────────────────────────────────────────────────────

--- a/internal/simulation/simulation_test.go
+++ b/internal/simulation/simulation_test.go
@@ -295,7 +295,7 @@ func TestSimulateMonthOfUsage(t *testing.T) {
 		found := len(results) > 0
 		status := "PASS"
 		if found != st.wantHits {
-			status := "FAIL"
+			status = "FAIL"
 			t.Errorf("    [%s] %s: query=%q found=%d want_hits=%v", status, st.desc, st.query, len(results), st.wantHits)
 		} else {
 			searchPass++


### PR DESCRIPTION
## Summary
- **Seed global memories** — `SeedGlobalMemories()` inserts pinned, manual-source memories into `_global` on every startup. These are consolidation-proof (source=manual skipped by ReplaceNonManual), always rank highest (pinned=1, importance=1.0), and never time-decay (preference category). First seed: no Co-Authored-By in commits.
- **README rewrite** — restructured to lead with Ghost as an MCP memory server. Quick Start is first section, "How It Works" explains the 4-stage pipeline (Save→Search→Consolidate→Decay), optional features (HTTP API, Telegram, VSCode, REPL) clearly separated below the fold.
- **30-day simulation test** — integration test in `internal/simulation/` that fast-forwards 30 days of developer activity through the real memory store. Exercises FTS dedup (34 merges from 52 inputs), SQLite consolidation at day 15 and 30, time-decay scoring, global scope detection, search accuracy (7/7), overlap analysis, and snapshot retention.

## Test plan
- [x] `go test ./...` all passing
- [x] `go vet ./...` clean
- [x] Simulation test validates: no memory bloat, FTS dedup working, global scope detection, low overlap, search accuracy 7/7, snapshot retention 1-3
- [x] Seed memory test validates: pinned, manual source, importance 1.0, idempotent, survives ReplaceNonManual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured README to present Ghost as an MCP memory server, added a "How It Works" pipeline (Save → Search → Consolidate → Decay), focused Quick Start on MCP init, reorganized HTTP API and optional features, and trimmed non‑MCP runtime docs.

* **New Features**
  * Global seeded memories now initialize on startup to ensure baseline memories are present.

* **Tests**
  * Added idempotency and behavior tests for global seeding and a 30‑day end‑to‑end simulation of the memory/consolidation pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->