### PR TITLE
docs(readme): clear image float before Why Ghost

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 MCP memory server for Claude Code, Cursor, and any MCP client. Pure Go. Single binary. No external services required.
 
+<br clear="right"/>
+
 ## Why Ghost?
 
 Claude Code's built-in memory is a markdown file with a **200-line cap**. No search. No categories. No importance ranking. Every project is siloed. After ten sessions the file is 30% redundant, and the architecture decision you saved last week gets silently truncated because it landed on line 201.


### PR DESCRIPTION
The ghost logo float was bleeding into the Why Ghost section, breaking the horizontal rule. Added `<br clear="right"/>` to clear it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved README layout to enhance content flow and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->