### PR TITLE
feat(hook): inject project + global memories at session start

### DIFF
--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -1,20 +1,161 @@
 package mcpinit
 
 import (
+	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wcatz/ghost/internal/config"
+	_ "modernc.org/sqlite"
 )
+
+type sessionStartInput struct {
+	CWD    string `json:"cwd"`
+	Source string `json:"source"`
+}
 
 // HandleSessionStartHook is invoked by Claude Code at session start via:
 //
 //	ghost hook session-start
 //
-// Its stdout becomes visible in Claude's context, reinforcing Ghost usage.
-// Zero DB access, zero network — runs in ~1ms.
+// Its stdout becomes visible in Claude's context as a system-reminder.
+// It automatically loads project context from the ghost DB based on cwd.
 func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
-	_, _ = io.Copy(io.Discard, stdin) // drain stdin
-	fmt.Fprintln(stdout, "Ghost memory is active. Before starting work:")
-	fmt.Fprintln(stdout, "1. Call ghost_list_projects to discover known projects")
-	fmt.Fprintln(stdout, "2. Call ghost_project_context with the project name")
-	fmt.Fprintln(stdout, "3. Save discoveries with ghost_memory_save during work")
+	data, _ := io.ReadAll(stdin)
+
+	var input sessionStartInput
+	_ = json.Unmarshal(data, &input)
+
+	cwd := input.CWD
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+
+	project, memories, learned := loadSessionContext(cwd)
+	if project == "" {
+		// No matching project — fall back to static reminder
+		fmt.Fprintln(stdout, "Ghost memory is active. Before starting work:")
+		fmt.Fprintln(stdout, "1. Call ghost_list_projects to discover known projects")
+		fmt.Fprintln(stdout, "2. Call ghost_project_context with the project name")
+		fmt.Fprintln(stdout, "3. Save discoveries with ghost_memory_save during work")
+		return
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "## Ghost context: %s\n\n", project)
+
+	if learned != "" {
+		fmt.Fprintf(&sb, "**Summary:** %s\n\n", learned)
+	}
+
+	if len(memories) > 0 {
+		fmt.Fprintf(&sb, "**Memories:**\n")
+		for _, m := range memories {
+			fmt.Fprintf(&sb, "- [%s] %s\n", m[0], m[1])
+		}
+	}
+
+	if dataDir, err2 := config.DataDir(); err2 == nil {
+		if globals := loadGlobalMemories(filepath.Join(dataDir, "ghost.db")); len(globals) > 0 {
+			fmt.Fprintf(&sb, "\n**Global (applies to all projects):**\n")
+			for _, m := range globals {
+				fmt.Fprintf(&sb, "- [%s] %s\n", m[0], m[1])
+			}
+		}
+	}
+
+	fmt.Fprintf(&sb, "\nSave new discoveries with ghost_memory_save during work.")
+	fmt.Fprintln(stdout, sb.String())
+}
+
+func loadGlobalMemories(dbPath string) [][2]string {
+	db, err := sql.Open("sqlite", dbPath+"?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(1000)")
+	if err != nil {
+		return nil
+	}
+	defer db.Close() //nolint:errcheck
+
+	rows, err := db.Query(`
+		SELECT category, content FROM memories
+		WHERE project_id = '_global'
+		ORDER BY pinned DESC, importance DESC, updated_at DESC
+		LIMIT 15
+	`)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var out [][2]string
+	for rows.Next() {
+		var cat, content string
+		if err := rows.Scan(&cat, &content); err != nil {
+			continue
+		}
+		if len(content) > 300 {
+			content = content[:300] + "…"
+		}
+		out = append(out, [2]string{cat, content})
+	}
+	return out
+}
+
+func loadSessionContext(cwd string) (project string, memories [][2]string, learned string) {
+	dataDir, err := config.DataDir()
+	if err != nil {
+		return
+	}
+	dbPath := filepath.Join(dataDir, "ghost.db")
+	db, err := sql.Open("sqlite", dbPath+"?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(1000)")
+	if err != nil {
+		return
+	}
+	defer db.Close()
+
+	// Find matching project: try full path prefix first, then cwd basename name match
+	cwdBase := filepath.Base(cwd)
+	var projectID string
+	row := db.QueryRow(`
+		SELECT id, name FROM projects
+		WHERE (? LIKE path || '%' AND LENGTH(path) > 10)
+		   OR name = ?
+		ORDER BY LENGTH(path) DESC LIMIT 1
+	`, cwd, cwdBase)
+	if err := row.Scan(&projectID, &project); err != nil {
+		return
+	}
+
+	// Get learned context summary
+	_ = db.QueryRow(
+		`SELECT learned_context FROM ghost_state WHERE project_id = ?`, projectID,
+	).Scan(&learned)
+
+	// Get top memories: pinned first, then by importance
+	rows, err := db.Query(`
+		SELECT category, content FROM memories
+		WHERE project_id = ?
+		ORDER BY pinned DESC, importance DESC, updated_at DESC
+		LIMIT 25
+	`, projectID)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cat, content string
+		if err := rows.Scan(&cat, &content); err != nil {
+			continue
+		}
+		// Truncate very long memories to keep the hook output manageable
+		if len(content) > 300 {
+			content = content[:300] + "…"
+		}
+		memories = append(memories, [2]string{cat, content})
+	}
+	return
 }

--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -69,7 +69,7 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 	}
 
 	fmt.Fprintf(&sb, "\nSave new discoveries with ghost_memory_save during work.")
-	fmt.Fprintln(stdout, sb.String())
+	_, _ = fmt.Fprintln(stdout, sb.String())
 }
 
 func loadGlobalMemories(dbPath string) [][2]string {

--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -38,10 +38,10 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 	project, memories, learned := loadSessionContext(cwd)
 	if project == "" {
 		// No matching project — fall back to static reminder
-		fmt.Fprintln(stdout, "Ghost memory is active. Before starting work:")
-		fmt.Fprintln(stdout, "1. Call ghost_list_projects to discover known projects")
-		fmt.Fprintln(stdout, "2. Call ghost_project_context with the project name")
-		fmt.Fprintln(stdout, "3. Save discoveries with ghost_memory_save during work")
+		_, _ = fmt.Fprintln(stdout, "Ghost memory is active. Before starting work:")
+		_, _ = fmt.Fprintln(stdout, "1. Call ghost_list_projects to discover known projects")
+		_, _ = fmt.Fprintln(stdout, "2. Call ghost_project_context with the project name")
+		_, _ = fmt.Fprintln(stdout, "3. Save discoveries with ghost_memory_save during work")
 		return
 	}
 
@@ -114,7 +114,7 @@ func loadSessionContext(cwd string) (project string, memories [][2]string, learn
 	if err != nil {
 		return
 	}
-	defer db.Close()
+	defer db.Close() //nolint:errcheck
 
 	// Find matching project: try full path prefix first, then cwd basename name match
 	cwdBase := filepath.Base(cwd)
@@ -144,7 +144,7 @@ func loadSessionContext(cwd string) (project string, memories [][2]string, learn
 	if err != nil {
 		return
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck
 
 	for rows.Next() {
 		var cat, content string

--- a/internal/mcpinit/init.go
+++ b/internal/mcpinit/init.go
@@ -311,15 +311,19 @@ func writeRedirects(w io.Writer, projects []projectInfo, dryRun bool) {
 		dir := filepath.Join(home, ".claude", "projects", encoded, "memory")
 		target := filepath.Join(dir, "MEMORY.md")
 
-		// Check if redirect already exists.
+		// Check if redirect already exists and is current.
 		if data, err := os.ReadFile(target); err == nil {
-			if strings.Contains(string(data), "stored in Ghost") {
+			content := string(data)
+			if strings.Contains(content, "stored in Ghost") && !strings.Contains(content, "ghost_list_projects") {
 				fmt.Fprintf(w, "  ✓ %s — redirect exists\n", p.Name)
 				continue
 			}
-			// File exists with other content — don't clobber.
-			fmt.Fprintf(w, "  - %s — MEMORY.md exists (not overwriting)\n", p.Name)
-			continue
+			if !strings.Contains(content, "stored in Ghost") {
+				// File exists with other content — don't clobber.
+				fmt.Fprintf(w, "  - %s — MEMORY.md exists (not overwriting)\n", p.Name)
+				continue
+			}
+			// Old Ghost redirect with stale tool-call instructions — update it.
 		}
 
 		if dryRun {
@@ -335,10 +339,12 @@ func writeRedirects(w io.Writer, projects []projectInfo, dryRun bool) {
 		safeName := sanitizeName(p.Name)
 		content := fmt.Sprintf(`# %s Project Memory
 
-All project knowledge is stored in Ghost. At session start, run:
-1. `+"`ghost_list_projects`"+` to discover projects
-2. `+"`ghost_project_context`"+` with project_id "%s" to load accumulated knowledge
-`, safeName, safeName)
+All project knowledge is stored in Ghost and injected automatically at session start via the SessionStart hook.
+Project context (memories + summary) is already in your system prompt — no tool calls needed to load it.
+
+Use `+"`ghost_memory_save`"+` to save new discoveries during work.
+Use `+"`ghost_memory_search`"+` to search for specific facts.
+`, safeName)
 
 		if err := os.WriteFile(target, []byte(content), 0644); err != nil {
 			fmt.Fprintf(w, "  ! %s — write error: %v\n", p.Name, err)

--- a/internal/mcpinit/init.go
+++ b/internal/mcpinit/init.go
@@ -320,7 +320,7 @@ func writeRedirects(w io.Writer, projects []projectInfo, dryRun bool) {
 			}
 			if !strings.Contains(content, "stored in Ghost") {
 				// File exists with other content — don't clobber.
-				fmt.Fprintf(w, "  - %s — MEMORY.md exists (not overwriting)\n", p.Name)
+				_, _ = fmt.Fprintf(w, "  - %s — MEMORY.md exists (not overwriting)\n", p.Name)
 				continue
 			}
 			// Old Ghost redirect with stale tool-call instructions — update it.


### PR DESCRIPTION
Closes #127

## What

The `session-start` hook now queries `ghost.db` directly and writes full project context into Claude's stdin before the first message — no tool calls required.

**Before:** Hook output a static reminder telling Claude to call `ghost_project_context`. Claude sometimes ignored it.

**After:** Hook outputs project memories + learned summary + global memories (`_global`) directly. Context is always present from message one.

## Output format

```
## Ghost context: ghost

**Summary:** <learned_context>

**Memories:**
- [decision] ...
- [architecture] ...

**Global (applies to all projects):**
- [preference] NEVER add Co-Authored-By...
- [convention] ...

Save new discoveries with ghost_memory_save during work.
```

Falls back to static reminder if project not found or DB unavailable.