### PR TITLE
fix(mcp): audit fixes — stale instructions, validation, safety gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Done! Restart Claude Code to activate.
 | Prerequisites | Finds `ghost` and `claude` binaries on your PATH |
 | MCP registration | `claude mcp add ghost` — Claude Code discovers Ghost's 13 tools |
 | Permissions | Pre-approves all `mcp__ghost__*` tools — no per-call prompts |
-| SessionStart hook | Every session, Claude sees a reminder to call `ghost_project_context` |
+| SessionStart hook | Injects project memories + global preferences directly into Claude's context |
 | Memory import | Migrates Claude Code's `~/.claude/projects/*/memory/*.md` into Ghost (deduplicated) |
 | Project redirects | Writes `MEMORY.md` pointing Claude to Ghost instead of its built-in memory |
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ ghost mcp init
   + 13 mcp__ghost__* tools added to allow list
 
 [4/6] Configuring SessionStart hook...
-  + ghost hook session-start — reminds Claude to load context
+  + ghost hook session-start — injects project context at startup
 
 [5/6] Importing Claude Code memories...
   ✓ myproject — 8 memories imported

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -448,7 +448,7 @@ func runMCP() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	srv := mcpserver.New(store, logger)
+	srv := mcpserver.New(store, logger, version)
 
 	// Wire embedding for hybrid search if configured.
 	if cfg.Embedding.Enabled {

--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/wcatz/ghost/internal/config"
 	_ "modernc.org/sqlite"
@@ -34,14 +35,16 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 	if cwd == "" {
 		cwd, _ = os.Getwd()
 	}
+	// Resolve symlinks so cwd matches the canonical path stored in the DB.
+	if resolved, err := filepath.EvalSymlinks(cwd); err == nil {
+		cwd = resolved
+	}
 
 	project, memories, learned := loadSessionContext(cwd)
 	if project == "" {
-		// No matching project — fall back to static reminder
-		_, _ = fmt.Fprintln(stdout, "Ghost memory is active. Before starting work:")
-		_, _ = fmt.Fprintln(stdout, "1. Call ghost_list_projects to discover known projects")
-		_, _ = fmt.Fprintln(stdout, "2. Call ghost_project_context with the project name")
-		_, _ = fmt.Fprintln(stdout, "3. Save discoveries with ghost_memory_save during work")
+		// No matching project — tell Claude context is available via tools
+		_, _ = fmt.Fprintln(stdout, "Ghost memory is active but no project matched this directory.")
+		_, _ = fmt.Fprintln(stdout, "Save discoveries with ghost_memory_save during work.")
 		return
 	}
 
@@ -96,9 +99,7 @@ func loadGlobalMemories(dbPath string) [][2]string {
 		if err := rows.Scan(&cat, &content); err != nil {
 			continue
 		}
-		if len(content) > 300 {
-			content = content[:300] + "…"
-		}
+		content = truncateUTF8(content, 300)
 		out = append(out, [2]string{cat, content})
 	}
 	return out
@@ -152,10 +153,21 @@ func loadSessionContext(cwd string) (project string, memories [][2]string, learn
 			continue
 		}
 		// Truncate very long memories to keep the hook output manageable
-		if len(content) > 300 {
-			content = content[:300] + "…"
-		}
+		content = truncateUTF8(content, 300)
 		memories = append(memories, [2]string{cat, content})
 	}
 	return
+}
+
+// truncateUTF8 truncates s to at most maxBytes bytes without breaking
+// multi-byte UTF-8 characters, appending "…" if truncated.
+func truncateUTF8(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	// Walk backward from maxBytes to find a valid rune boundary.
+	for maxBytes > 0 && !utf8.RuneStart(s[maxBytes]) {
+		maxBytes--
+	}
+	return s[:maxBytes] + "…"
 }

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -14,11 +14,8 @@ func TestHandleSessionStartHook(t *testing.T) {
 	HandleSessionStartHook(strings.NewReader(`{"event":"SessionStart"}`), &out)
 
 	output := out.String()
-	if !strings.Contains(output, "ghost_list_projects") {
-		t.Error("hook output should mention ghost_list_projects")
-	}
-	if !strings.Contains(output, "ghost_project_context") {
-		t.Error("hook output should mention ghost_project_context")
+	if !strings.Contains(output, "Ghost memory is active") {
+		t.Error("hook output should mention Ghost memory is active")
 	}
 	if !strings.Contains(output, "ghost_memory_save") {
 		t.Error("hook output should mention ghost_memory_save")

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -65,13 +65,14 @@ type Server struct {
 const mcpInstructions = `Ghost is a persistent memory daemon that remembers project knowledge across sessions. It is your primary memory system — use it proactively.
 
 ## Workflow
-1. At session start, call ghost_list_projects to discover known projects.
-2. Call ghost_project_context with the project name to load accumulated knowledge.
-3. During work, save important discoveries with ghost_memory_save. Do NOT wait until the end of the session.
-4. Use ghost_memory_search to recall specific facts.
-5. No special action needed at session end — Ghost persists automatically.
+1. At session start, Ghost's SessionStart hook has ALREADY injected your project context (memories + global preferences) into this conversation. READ IT — do not call ghost_project_context redundantly.
+2. During work, save important discoveries with ghost_memory_save. Do NOT wait until the end of the session.
+3. Use ghost_memory_search to recall specific facts not in the injected context.
+4. No special action needed at session end — Ghost persists automatically.
 
 Ghost auto-imports Claude Code memory files (~/.claude/projects/*/memory/*.md) on first project contact. No manual migration is needed. Ghost has built-in upsert/merge deduplication — it is always safe to save, even if similar knowledge already exists.
+
+IMPORTANT: Global memories (preferences, conventions) are included in the SessionStart hook output under "Global (applies to all projects)". These are non-negotiable rules from the user. Follow them.
 
 ## When to Save (Proactive Triggers)
 Save immediately when any of these happen:
@@ -117,7 +118,10 @@ Save immediately when any of these happen:
 Pass the project name (e.g. "ghost", "roller") as project_id. Ghost resolves names to internal IDs automatically.`
 
 // New creates and configures the MCP server with all Ghost tools.
-func New(store provider.MemoryStore, logger *slog.Logger) *Server {
+func New(store provider.MemoryStore, logger *slog.Logger, version string) *Server {
+	if version == "" {
+		version = "dev"
+	}
 	s := &Server{
 		store:  store,
 		logger: logger,
@@ -125,7 +129,7 @@ func New(store provider.MemoryStore, logger *slog.Logger) *Server {
 
 	s.mcp = mcp.NewServer(&mcp.Implementation{
 		Name:    "ghost",
-		Version: "0.1.0",
+		Version: version,
 	}, &mcp.ServerOptions{
 		Instructions: mcpInstructions,
 		Logger:       logger,
@@ -193,6 +197,9 @@ func (s *Server) registerTools() {
 		}
 		if args.Limit <= 0 {
 			args.Limit = 10
+		}
+		if args.Limit > 100 {
+			args.Limit = 100
 		}
 		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
 
@@ -293,7 +300,7 @@ func (s *Server) registerTools() {
 
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_project_context",
-		Description: "Get Ghost's accumulated knowledge about a project: top memories ranked by importance and recency, plus any learned context summaries. Use this at the start of a session to recall what Ghost knows.",
+		Description: "Get Ghost's accumulated knowledge about a project: top memories ranked by importance and recency, plus global memories and learned context. Usually NOT needed at session start — the SessionStart hook already injects this. Use when switching projects mid-session or refreshing after saves.",
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint:  true,
 			OpenWorldHint: boolPtr(false),
@@ -304,6 +311,9 @@ func (s *Server) registerTools() {
 		}
 		if args.Limit <= 0 {
 			args.Limit = 20
+		}
+		if args.Limit > 100 {
+			args.Limit = 100
 		}
 		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
 
@@ -370,6 +380,9 @@ func (s *Server) registerTools() {
 		}
 		if args.Limit <= 0 {
 			args.Limit = 30
+		}
+		if args.Limit > 100 {
+			args.Limit = 100
 		}
 		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
 
@@ -442,6 +455,9 @@ func (s *Server) registerTools() {
 		if args.Limit <= 0 {
 			args.Limit = 10
 		}
+		if args.Limit > 100 {
+			args.Limit = 100
+		}
 		memories, err := s.store.SearchFTSAll(ctx, args.Query, args.Limit)
 		if err != nil {
 			return nil, nil, fmt.Errorf("search failed: %w", err)
@@ -478,6 +494,13 @@ func (s *Server) registerTools() {
 		}
 		if args.Category == "" {
 			args.Category = "fact"
+		}
+		validCategories := map[string]bool{
+			"architecture": true, "decision": true, "pattern": true, "convention": true,
+			"gotcha": true, "dependency": true, "preference": true, "fact": true,
+		}
+		if !validCategories[args.Category] {
+			return nil, nil, fmt.Errorf("invalid category %q — must be one of: architecture, decision, pattern, convention, gotcha, dependency, preference, fact", args.Category)
 		}
 		importance := defaultImportance(args.Importance, 0.8)
 		if args.Tags == nil {
@@ -681,7 +704,7 @@ func (s *Server) registerTools() {
 	// ghost_list_projects — list all known projects.
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_list_projects",
-		Description: "List all projects Ghost knows about with their names, IDs, paths, and memory counts. Use at session start to find the project_id for the current codebase.",
+		Description: "List all projects Ghost knows about with their names, IDs, paths, and memory counts.",
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint:  true,
 			OpenWorldHint: boolPtr(false),
@@ -805,6 +828,15 @@ func (s *Server) buildProjectContext(ctx context.Context, projectID string) (str
 	if learned != "" {
 		sb.WriteString("\n\n## Learned Context\n\n")
 		sb.WriteString(learned)
+	}
+
+	// Include global memories (preferences, conventions) that apply to all projects.
+	if projectID != "_global" {
+		globals, gErr := s.store.GetTopMemories(ctx, "_global", 15)
+		if gErr == nil && len(globals) > 0 {
+			sb.WriteString("\n\n## Global (applies to all projects)\n\n")
+			sb.WriteString(formatMemories(globals))
+		}
 	}
 
 	if sb.Len() == 0 {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -136,7 +136,7 @@ func TestNew_CreatesServer(t *testing.T) {
 	store := testStore(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	srv := New(store, logger)
+	srv := New(store, logger, "test")
 	if srv == nil {
 		t.Fatal("New returned nil")
 	}
@@ -151,7 +151,7 @@ func TestNew_CreatesServer(t *testing.T) {
 func TestSetEmbedder(t *testing.T) {
 	store := testStore(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	srv := New(store, logger)
+	srv := New(store, logger, "test")
 
 	ch := make(chan string, 1)
 	mockEmbed := &mockEmbedder{}
@@ -176,7 +176,7 @@ func (m *mockEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 func TestBuildProjectContext_WithMemories(t *testing.T) {
 	store := testStore(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	srv := New(store, logger)
+	srv := New(store, logger, "test")
 
 	ctx := context.Background()
 	// Seed a memory for the test project (ID "abc123").
@@ -199,7 +199,7 @@ func TestBuildProjectContext_WithMemories(t *testing.T) {
 func TestBuildProjectContext_Empty(t *testing.T) {
 	store := testStore(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	srv := New(store, logger)
+	srv := New(store, logger, "test")
 
 	ctx := context.Background()
 	text, err := srv.buildProjectContext(ctx, "abc123")
@@ -214,7 +214,7 @@ func TestBuildProjectContext_Empty(t *testing.T) {
 func TestBuildProjectContext_IncludesGlobal(t *testing.T) {
 	store := testStore(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	srv := New(store, logger)
+	srv := New(store, logger, "test")
 
 	ctx := context.Background()
 	// Seed a global memory — must ensure _global project exists first.
@@ -238,7 +238,7 @@ func TestBuildProjectContext_IncludesGlobal(t *testing.T) {
 func TestBuildProjectContext_IncludesLearnedContext(t *testing.T) {
 	store := testStore(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	srv := New(store, logger)
+	srv := New(store, logger, "test")
 
 	ctx := context.Background()
 	if err := store.UpdateLearnedContext(ctx, "abc123", "This is the learned summary.", ""); err != nil {
@@ -263,7 +263,7 @@ func TestBuildProjectContext_IncludesLearnedContext(t *testing.T) {
 func TestNew_RegistersResources(t *testing.T) {
 	store := testStore(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	srv := New(store, logger)
+	srv := New(store, logger, "test")
 
 	ctx := context.Background()
 
@@ -321,7 +321,7 @@ func TestSaveAndSearch_EndToEnd(t *testing.T) {
 func TestSaveAndSearch_WithEmbedder(t *testing.T) {
 	store := testStore(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	srv := New(store, logger)
+	srv := New(store, logger, "test")
 
 	ch := make(chan string, 1)
 	srv.SetEmbedder(&mockEmbedder{}, ch)


### PR DESCRIPTION
## Summary

- MCP instructions no longer tell Claude to call tools at session start (hook injects context)
- `ghost_project_context` and `ghost_list_projects` descriptions updated
- `buildProjectContext` now includes `_global` memories
- `ghost_save_global` gets category validation (was missing)
- All Limit params capped at 100
- MCP server version from build, not hardcoded 0.1.0
- Hook: symlink resolution, UTF-8 safe truncation, updated fallback message
- Tests updated to match new behavior

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] 5 parallel audit agents verified all fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project context now includes a "Global" section with preferences that apply to all projects.
  * Added a 100-result limit to search and list operations for improved performance.

* **Bug Fixes**
  * Fixed memory content truncation to properly handle UTF-8 characters without breaking text boundaries.

* **Documentation**
  * Clarified that the SessionStart hook automatically injects project memories and global preferences into Claude's context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->