### PR TITLE
feat(mcp): phase 1 — new tools, resources, enriched hook

### DIFF
--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -40,7 +40,7 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 		cwd = resolved
 	}
 
-	project, memories, learned := loadSessionContext(cwd)
+	project, memories, learned, tasks, decisions, interactionCount := loadSessionContext(cwd)
 	if project == "" {
 		// No matching project — tell Claude context is available via tools
 		_, _ = fmt.Fprintln(stdout, "Ghost memory is active but no project matched this directory.")
@@ -62,6 +62,23 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 		}
 	}
 
+	if len(tasks) > 0 {
+		fmt.Fprintf(&sb, "\n**Open Tasks:**\n")
+		for _, t := range tasks {
+			fmt.Fprintf(&sb, "- [%s] %s\n", t[0], t[1])
+			if t[2] != "" {
+				fmt.Fprintf(&sb, "  %s\n", t[2])
+			}
+		}
+	}
+
+	if len(decisions) > 0 {
+		fmt.Fprintf(&sb, "\n**Recent Decisions:**\n")
+		for _, d := range decisions {
+			fmt.Fprintf(&sb, "- **%s**: %s\n", d[0], d[1])
+		}
+	}
+
 	if dataDir, err2 := config.DataDir(); err2 == nil {
 		if globals := loadGlobalMemories(filepath.Join(dataDir, "ghost.db")); len(globals) > 0 {
 			fmt.Fprintf(&sb, "\n**Global (applies to all projects):**\n")
@@ -69,6 +86,10 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 				fmt.Fprintf(&sb, "- [%s] %s\n", m[0], m[1])
 			}
 		}
+	}
+
+	if interactionCount > 0 {
+		fmt.Fprintf(&sb, "\n**Session #%d** with this project.\n", interactionCount)
 	}
 
 	fmt.Fprintf(&sb, "\nSave new discoveries with ghost_memory_save during work.")
@@ -105,7 +126,7 @@ func loadGlobalMemories(dbPath string) [][2]string {
 	return out
 }
 
-func loadSessionContext(cwd string) (project string, memories [][2]string, learned string) {
+func loadSessionContext(cwd string) (project string, memories [][2]string, learned string, tasks [][3]string, decisions [][2]string, interactionCount int) {
 	dataDir, err := config.DataDir()
 	if err != nil {
 		return
@@ -156,6 +177,51 @@ func loadSessionContext(cwd string) (project string, memories [][2]string, learn
 		content = truncateUTF8(content, 300)
 		memories = append(memories, [2]string{cat, content})
 	}
+
+	// Get open tasks
+	taskRows, err := db.Query(`
+		SELECT status, priority, title, COALESCE(description, '')
+		FROM tasks
+		WHERE project_id = ? AND status IN ('pending', 'active', 'blocked')
+		ORDER BY priority ASC, created_at DESC
+		LIMIT 10
+	`, projectID)
+	if err == nil {
+		defer taskRows.Close() //nolint:errcheck
+		for taskRows.Next() {
+			var status, title, desc string
+			var priority int
+			if err := taskRows.Scan(&status, &priority, &title, &desc); err != nil {
+				continue
+			}
+			label := fmt.Sprintf("P%d %s", priority, title)
+			tasks = append(tasks, [3]string{status, label, truncateUTF8(desc, 200)})
+		}
+	}
+
+	// Get active decisions
+	decRows, err := db.Query(`
+		SELECT title, decision FROM decisions
+		WHERE project_id = ? AND status = 'active'
+		ORDER BY created_at DESC
+		LIMIT 5
+	`, projectID)
+	if err == nil {
+		defer decRows.Close() //nolint:errcheck
+		for decRows.Next() {
+			var title, decision string
+			if err := decRows.Scan(&title, &decision); err != nil {
+				continue
+			}
+			decisions = append(decisions, [2]string{title, truncateUTF8(decision, 200)})
+		}
+	}
+
+	// Get interaction count
+	_ = db.QueryRow(
+		`SELECT interaction_count FROM ghost_state WHERE project_id = ?`, projectID,
+	).Scan(&interactionCount)
+
 	return
 }
 

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -170,8 +170,8 @@ func TestRetryHint(t *testing.T) {
 
 func TestGhostPermissions_Complete(t *testing.T) {
 	// Verify the canonical list has the expected count.
-	if len(ghostPermissions) != 13 {
-		t.Errorf("expected 13 ghost permissions, got %d", len(ghostPermissions))
+	if len(ghostPermissions) != 16 {
+		t.Errorf("expected 16 ghost permissions, got %d", len(ghostPermissions))
 	}
 
 	// All should start with the correct prefix.

--- a/internal/mcpinit/settings.go
+++ b/internal/mcpinit/settings.go
@@ -12,10 +12,12 @@ import (
 // ghostPermissions is the canonical list of MCP tool permissions to allow.
 var ghostPermissions = []string{
 	"mcp__ghost__ghost_decision_record",
+	"mcp__ghost__ghost_decisions_list",
 	"mcp__ghost__ghost_health",
 	"mcp__ghost__ghost_list_projects",
 	"mcp__ghost__ghost_memories_list",
 	"mcp__ghost__ghost_memory_delete",
+	"mcp__ghost__ghost_memory_pin",
 	"mcp__ghost__ghost_memory_save",
 	"mcp__ghost__ghost_memory_search",
 	"mcp__ghost__ghost_project_context",
@@ -24,6 +26,7 @@ var ghostPermissions = []string{
 	"mcp__ghost__ghost_task_complete",
 	"mcp__ghost__ghost_task_create",
 	"mcp__ghost__ghost_task_list",
+	"mcp__ghost__ghost_task_update",
 }
 
 // hookEntry represents one matcher+hooks pair in settings.json.

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -231,6 +231,9 @@ func (s *Server) registerTools() {
 					filtered = append(filtered, m)
 				}
 			}
+			if len(filtered) > args.Limit {
+				filtered = filtered[:args.Limit]
+			}
 			memories = filtered
 		}
 

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -181,6 +181,7 @@ func (s *Server) registerTools() {
 	type searchArgs struct {
 		ProjectID string `json:"project_id" jsonschema:"Project ID to search within"`
 		Query     string `json:"query" jsonschema:"Search query (supports FTS5 syntax)"`
+		Category  string `json:"category,omitempty" jsonschema:"Filter results to this category (optional)"`
 		Limit     int    `json:"limit,omitempty" jsonschema:"Max results (default 10)"`
 	}
 
@@ -210,9 +211,27 @@ func (s *Server) registerTools() {
 				queryVec = vec
 			}
 		}
-		memories, err := s.store.SearchHybrid(ctx, args.ProjectID, args.Query, queryVec, args.Limit)
+		searchLimit := args.Limit
+		if args.Category != "" {
+			searchLimit = args.Limit * 3
+			if searchLimit > 100 {
+				searchLimit = 100
+			}
+		}
+		memories, err := s.store.SearchHybrid(ctx, args.ProjectID, args.Query, queryVec, searchLimit)
 		if err != nil {
 			return nil, nil, fmt.Errorf("search failed: %w", err)
+		}
+
+		// Post-filter by category if specified.
+		if args.Category != "" {
+			filtered := memories[:0]
+			for _, m := range memories {
+				if m.Category == args.Category {
+					filtered = append(filtered, m)
+				}
+			}
+			memories = filtered
 		}
 
 		if len(memories) == 0 {
@@ -730,6 +749,127 @@ func (s *Server) registerTools() {
 			Content: []mcp.Content{&mcp.TextContent{Text: sb.String()}},
 		}, nil, nil
 	})
+
+	// ghost_memory_pin — pin or unpin a memory.
+	type pinArgs struct {
+		MemoryID string `json:"memory_id" jsonschema:"ID of the memory to pin/unpin"`
+		Pinned   bool   `json:"pinned" jsonschema:"true to pin, false to unpin"`
+	}
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:        "ghost_memory_pin",
+		Description: "Pin or unpin a memory. Pinned memories always appear at the top of project context and survive reflection pruning.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(false),
+		},
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args pinArgs) (*mcp.CallToolResult, any, error) {
+		if args.MemoryID == "" {
+			return nil, nil, fmt.Errorf("memory_id is required")
+		}
+		if err := s.store.TogglePin(ctx, args.MemoryID, args.Pinned); err != nil {
+			return nil, nil, fmt.Errorf("toggle pin: %w", err)
+		}
+		action := "pinned"
+		if !args.Pinned {
+			action = "unpinned"
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Memory %s.", action)}},
+		}, nil, nil
+	})
+
+	// ghost_task_update — update a task's status, priority, or description.
+	type taskUpdateArgs struct {
+		TaskID      string `json:"task_id" jsonschema:"Task ID to update"`
+		Status      string `json:"status" jsonschema:"New status: pending, active, blocked, done"`
+		Priority    int    `json:"priority,omitempty" jsonschema:"Priority 0-4 (0=critical, 2=normal, 4=low)"`
+		Description string `json:"description,omitempty" jsonschema:"Updated description"`
+	}
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:        "ghost_task_update",
+		Description: "Update a task's status, priority, or description. Use to change status to active/blocked, reprioritize, or refine the description.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(false),
+		},
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args taskUpdateArgs) (*mcp.CallToolResult, any, error) {
+		if args.TaskID == "" {
+			return nil, nil, fmt.Errorf("task_id is required")
+		}
+		if args.Status == "" {
+			return nil, nil, fmt.Errorf("status is required (pending, active, blocked, done)")
+		}
+		validStatuses := map[string]bool{
+			"pending": true, "active": true, "blocked": true, "done": true,
+		}
+		if !validStatuses[args.Status] {
+			return nil, nil, fmt.Errorf("invalid status %q — must be one of: pending, active, blocked, done", args.Status)
+		}
+		if args.Priority < 0 || args.Priority > 4 {
+			args.Priority = 2
+		}
+		if err := s.store.UpdateTask(ctx, args.TaskID, args.Status, args.Priority, args.Description); err != nil {
+			return nil, nil, fmt.Errorf("update task: %w", err)
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "Task updated."}},
+		}, nil, nil
+	})
+
+	// ghost_decisions_list — list recorded decisions for a project.
+	type decisionsListArgs struct {
+		ProjectID string `json:"project_id" jsonschema:"Project ID or name"`
+		Status    string `json:"status,omitempty" jsonschema:"Filter by status: active, superseded, revisit (default: all)"`
+		Limit     int    `json:"limit,omitempty" jsonschema:"Max results (default 20)"`
+	}
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:        "ghost_decisions_list",
+		Description: "List recorded decisions for a project. Use to review past architectural and design choices, their rationale, and alternatives that were considered.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:  true,
+			OpenWorldHint: boolPtr(false),
+		},
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args decisionsListArgs) (*mcp.CallToolResult, any, error) {
+		if args.ProjectID == "" {
+			return nil, nil, fmt.Errorf("project_id is required")
+		}
+		if args.Limit <= 0 {
+			args.Limit = 20
+		}
+		if args.Limit > 100 {
+			args.Limit = 100
+		}
+		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
+
+		decisions, err := s.store.ListDecisions(ctx, args.ProjectID, args.Status, args.Limit)
+		if err != nil {
+			return nil, nil, fmt.Errorf("list decisions: %w", err)
+		}
+		if len(decisions) == 0 {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "No decisions found."}},
+			}, nil, nil
+		}
+
+		var sb strings.Builder
+		for _, d := range decisions {
+			fmt.Fprintf(&sb, "### %s\n", d.Title)
+			fmt.Fprintf(&sb, "**Decision:** %s\n", d.Decision)
+			fmt.Fprintf(&sb, "**Rationale:** %s\n", d.Rationale)
+			if len(d.Alternatives) > 0 {
+				fmt.Fprintf(&sb, "**Alternatives rejected:** %s\n", strings.Join(d.Alternatives, ", "))
+			}
+			fmt.Fprintf(&sb, "**Status:** %s | **ID:** `%s`\n\n", d.Status, d.ID)
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: sb.String()}},
+		}, nil, nil
+	})
 }
 
 // registerResources registers MCP resources for push-based context delivery.
@@ -795,6 +935,102 @@ func (s *Server) registerResources() {
 		} else {
 			text = "## Ghost Global Memories\n\n" + formatMemories(memories)
 		}
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{{
+				URI:      req.Params.URI,
+				MIMEType: "text/plain",
+				Text:     text,
+			}},
+		}, nil
+	})
+
+	// Resource template: ghost://project/{project_id}/decisions
+	s.mcp.AddResourceTemplate(&mcp.ResourceTemplate{
+		Name:        "Ghost Project Decisions",
+		URITemplate: "ghost://project/{project_id}/decisions",
+		Description: "Active architectural and design decisions for a project. " +
+			"Pin this resource to keep decision context visible across compaction.",
+		MIMEType: "text/plain",
+	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		u, err := url.Parse(req.Params.URI)
+		if err != nil {
+			return nil, fmt.Errorf("invalid resource URI %q: %w", req.Params.URI, err)
+		}
+		parts := strings.SplitN(strings.TrimPrefix(u.Path, "/"), "/", 2)
+		if len(parts) == 0 || parts[0] == "" {
+			return nil, fmt.Errorf("resource URI missing project_id: %s", req.Params.URI)
+		}
+		projectID := s.resolveProjectID(ctx, parts[0])
+
+		decisions, err := s.store.ListDecisions(ctx, projectID, "active", 20)
+		if err != nil {
+			return nil, fmt.Errorf("list decisions for %q: %w", projectID, err)
+		}
+
+		var text string
+		if len(decisions) == 0 {
+			text = "No active decisions for this project."
+		} else {
+			var sb strings.Builder
+			sb.WriteString("## Active Decisions\n\n")
+			for _, d := range decisions {
+				fmt.Fprintf(&sb, "- **%s**: %s (rationale: %s)\n", d.Title, d.Decision, d.Rationale)
+			}
+			text = sb.String()
+		}
+
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{{
+				URI:      req.Params.URI,
+				MIMEType: "text/plain",
+				Text:     text,
+			}},
+		}, nil
+	})
+
+	// Resource template: ghost://project/{project_id}/tasks
+	s.mcp.AddResourceTemplate(&mcp.ResourceTemplate{
+		Name:        "Ghost Project Tasks",
+		URITemplate: "ghost://project/{project_id}/tasks",
+		Description: "Open tasks (pending, active, blocked) for a project. " +
+			"Pin this resource to keep task context visible across compaction.",
+		MIMEType: "text/plain",
+	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		u, err := url.Parse(req.Params.URI)
+		if err != nil {
+			return nil, fmt.Errorf("invalid resource URI %q: %w", req.Params.URI, err)
+		}
+		parts := strings.SplitN(strings.TrimPrefix(u.Path, "/"), "/", 2)
+		if len(parts) == 0 || parts[0] == "" {
+			return nil, fmt.Errorf("resource URI missing project_id: %s", req.Params.URI)
+		}
+		projectID := s.resolveProjectID(ctx, parts[0])
+
+		var sb strings.Builder
+		sb.WriteString("## Open Tasks\n\n")
+		hasContent := false
+
+		for _, status := range []string{"active", "blocked", "pending"} {
+			tasks, err := s.store.ListTasks(ctx, projectID, status, 15)
+			if err != nil {
+				continue
+			}
+			for _, t := range tasks {
+				hasContent = true
+				fmt.Fprintf(&sb, "- [%s] P%d `%s` %s\n", t.Status, t.Priority, t.ID[:8], t.Title)
+				if t.Description != "" {
+					fmt.Fprintf(&sb, "  %s\n", t.Description)
+				}
+			}
+		}
+
+		var text string
+		if !hasContent {
+			text = "No open tasks for this project."
+		} else {
+			text = sb.String()
+		}
+
 		return &mcp.ReadResourceResult{
 			Contents: []*mcp.ResourceContents{{
 				URI:      req.Params.URI,


### PR DESCRIPTION
## Summary

Exposes existing store capabilities via MCP without schema changes.

**3 new tools** (16 total):
- `ghost_memory_pin` — pin/unpin memories
- `ghost_task_update` — update task status/priority/description
- `ghost_decisions_list` — list recorded decisions with rationale

**Category filter** on `ghost_memory_search` — optional `category` param, post-filter approach (no interface changes)

**2 new pinnable resources** (4 total):
- `ghost://project/{project_id}/decisions` — active decisions
- `ghost://project/{project_id}/tasks` — open tasks

**Enriched SessionStart hook** — now injects:
- Open tasks (pending/active/blocked)
- Recent active decisions
- Session interaction count

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] Hook tested: `echo '{"cwd":"..."}' | ghost hook session-start` shows session count
- [x] Permission count assertion updated (13 → 16)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory pinning, task update, decision listing, and improved memory search with category filtering.
  * Session UI now surfaces open tasks, recent active decisions, and interaction-counted session lines.
  * New project views for open tasks and active decisions.

* **Tests**
  * Updated unit test expectations to reflect new permissions.

* **Chores**
  * Added three new permission identifiers to the canonical allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->