### PR TITLE
chore(ci): remove VSCode extension job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,35 +62,3 @@ jobs:
           tags: |
             ghcr.io/wcatz/ghost:${{ steps.version.outputs.version }}
             ghcr.io/wcatz/ghost:latest
-
-  extension:
-    runs-on: ubuntu-latest
-    needs: release
-    defaults:
-      run:
-        working-directory: vscode-ghost
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: vscode-ghost/package-lock.json
-
-      - run: npm ci
-
-      - name: Sync version from tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          npm version "$VERSION" --no-git-tag-version
-
-      - name: Package .vsix
-        run: npx @vscode/vsce package --no-dependencies
-
-      - name: Attach .vsix to release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          gh release upload "$GITHUB_REF_NAME" "ghost-${VERSION}.vsix" --clobber


### PR DESCRIPTION
The VSCode extension (`vscode-ghost/`) was removed in v0.8.0 when Ghost was stripped to MCP-only. The release workflow's `extension` job was left behind and fails on every release tag because `vscode-ghost/package-lock.json` no longer exists.

Removes the `extension` job entirely.