### PR TITLE
fix(memory): normalize empty path to id in EnsureProject

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -157,6 +157,14 @@ func (s *Store) EnsureProject(ctx context.Context, id, path, name string) error 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Normalize empty path to id. MCP callers pass path="" because they
+	// don't know the filesystem path; using "" as path would collide across
+	// projects since projects.path has a UNIQUE constraint. Using id as path
+	// preserves the invariant already on disk for name-as-ID projects.
+	if path == "" {
+		path = id
+	}
+
 	// Check if another project already owns this path. If so, merge
 	// any orphaned child records into the canonical project and skip
 	// creating a duplicate. This self-heals duplicates caused by MCP
@@ -187,7 +195,9 @@ func (s *Store) EnsureProject(ctx context.Context, id, path, name string) error 
 
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO projects (id, path, name) VALUES (?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET path = excluded.path, updated_at = datetime('now')
+		ON CONFLICT(id) DO UPDATE SET
+			path = CASE WHEN excluded.path = excluded.id THEN projects.path ELSE excluded.path END,
+			updated_at = datetime('now')
 	`, id, path, name)
 	if err != nil {
 		return fmt.Errorf("ensure project: %w", err)

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1387,6 +1387,44 @@ func TestSeedGlobalMemories(t *testing.T) {
 	}
 }
 
+func TestEnsureProject_EmptyPath_NoUniqueConflict(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Simulate MCP calling EnsureProject with empty path for two different projects.
+	// Before the fix, passing path="" caused a UNIQUE constraint violation on
+	// projects.path when the second project was saved (both would have path="").
+	if err := s.EnsureProject(ctx, "a7293a04b38a", "", "dingo"); err != nil {
+		t.Fatalf("EnsureProject dingo: %v", err)
+	}
+	if err := s.EnsureProject(ctx, "b1234567890c", "", "roller"); err != nil {
+		t.Fatalf("EnsureProject roller: %v", err)
+	}
+
+	// Calling EnsureProject again for the same project must also be idempotent.
+	if err := s.EnsureProject(ctx, "a7293a04b38a", "", "dingo"); err != nil {
+		t.Fatalf("EnsureProject dingo (repeat): %v", err)
+	}
+
+	projects, err := s.ListProjects(ctx)
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	found := 0
+	for _, p := range projects {
+		if p.ID == "a7293a04b38a" || p.ID == "b1234567890c" {
+			// path must equal id for non-filesystem projects.
+			if p.Path != p.ID {
+				t.Errorf("project %s: expected path == id, got path=%q", p.ID, p.Path)
+			}
+			found++
+		}
+	}
+	if found != 2 {
+		t.Errorf("expected 2 projects, found %d", found)
+	}
+}
+
 func TestEnsureProject_AutoMerge(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fixes #153

`ghost_memory_save` was failing with `UNIQUE constraint failed: projects.path` when the MCP server called `EnsureProject` with `path=""`. Since `projects.path` has a UNIQUE constraint, any two projects called this way would collide.

- Normalize `path=""` to `path=id` at the top of `EnsureProject` — matches the invariant already on disk for name-as-ID projects (e.g. `id=a7293a04b38a, path=a7293a04b38a`)
- Guard the `ON CONFLICT DO UPDATE` so a synthetic `path=id` fallback never clobbers a real filesystem path already stored

## Test plan

- [ ] `TestEnsureProject_EmptyPath_NoUniqueConflict` — two projects with `path=""`, no conflict, idempotent repeat, `path==id` post-save
- [ ] `go test ./internal/memory/...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed constraint violations when creating projects without specifying a custom path
  * Improved handling of repeated project creation attempts to prevent errors
  * Projects now reliably use their ID as the default path when no custom path is provided

<!-- end of auto-generated comment: release notes by coderabbit.ai -->