### PR TITLE
fix(hook): inject global memories when no project matches cwd

### DIFF
--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -41,10 +41,27 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 	}
 
 	project, memories, learned, tasks, decisions, interactionCount := loadSessionContext(cwd)
+
+	// Load globals unconditionally — they apply to every session regardless of project match.
+	var globalSection string
+	if dataDir, err2 := config.DataDir(); err2 == nil {
+		if globals := loadGlobalMemories(filepath.Join(dataDir, "ghost.db")); len(globals) > 0 {
+			var gsb strings.Builder
+			fmt.Fprintf(&gsb, "\n**Global (applies to all projects):**\n")
+			for _, m := range globals {
+				fmt.Fprintf(&gsb, "- [%s] %s\n", m[0], m[1])
+			}
+			globalSection = gsb.String()
+		}
+	}
+
 	if project == "" {
 		// No matching project — tell Claude context is available via tools
 		_, _ = fmt.Fprintln(stdout, "Ghost memory is active but no project matched this directory.")
 		_, _ = fmt.Fprintln(stdout, "Save discoveries with ghost_memory_save during work.")
+		if globalSection != "" {
+			_, _ = fmt.Fprintln(stdout, globalSection)
+		}
 		return
 	}
 
@@ -80,14 +97,7 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 		}
 	}
 
-	if dataDir, err2 := config.DataDir(); err2 == nil {
-		if globals := loadGlobalMemories(filepath.Join(dataDir, "ghost.db")); len(globals) > 0 {
-			fmt.Fprintf(&sb, "\n**Global (applies to all projects):**\n")
-			for _, m := range globals {
-				fmt.Fprintf(&sb, "- [%s] %s\n", m[0], m[1])
-			}
-		}
-	}
+	fmt.Fprint(&sb, globalSection)
 
 	if interactionCount > 0 {
 		fmt.Fprintf(&sb, "\n**Session #%d** with this project.\n", interactionCount)

--- a/internal/mcpinit/hook_test.go
+++ b/internal/mcpinit/hook_test.go
@@ -2,7 +2,10 @@ package mcpinit
 
 import (
 	"database/sql"
+	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/wcatz/ghost/internal/memory"
@@ -93,5 +96,85 @@ func TestLookupProject_NoMatch(t *testing.T) {
 	id, name := lookupProject(db, "/home/user/other-project")
 	if id != "" || name != "" {
 		t.Errorf("no match: expected empty, got id=%q name=%q", id, name)
+	}
+}
+
+// openFileTestDB creates a real on-disk SQLite DB (needed for mode=ro callers like loadGlobalMemories).
+func openFileTestDB(t *testing.T) (db *sql.DB, path string) {
+	t.Helper()
+	dir := t.TempDir()
+	path = filepath.Join(dir, "ghost.db")
+	db, err := memory.OpenDB(path)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db, path
+}
+
+func TestLoadGlobalMemories(t *testing.T) {
+	db, dbPath := openFileTestDB(t)
+
+	// Seed the _global project row (FK required by memories table).
+	_, err := db.Exec(`INSERT INTO projects (id, path, name) VALUES ('_global', '_global', 'global')`)
+	if err != nil {
+		t.Fatalf("insert _global project: %v", err)
+	}
+	_, err = db.Exec(
+		`INSERT INTO memories (id, project_id, category, content, source) VALUES ('testid01', '_global', 'preference', 'never push to main', 'manual')`,
+	)
+	if err != nil {
+		t.Fatalf("insert global memory: %v", err)
+	}
+
+	globals := loadGlobalMemories(dbPath)
+	if len(globals) != 1 {
+		t.Fatalf("expected 1 global memory, got %d", len(globals))
+	}
+	if globals[0][0] != "preference" {
+		t.Errorf("category: got %q, want preference", globals[0][0])
+	}
+	if globals[0][1] != "never push to main" {
+		t.Errorf("content: got %q, want 'never push to main'", globals[0][1])
+	}
+}
+
+func TestHandleSessionStartHook_GlobalsOnNoMatch(t *testing.T) {
+	// config.DataDir() returns XDG_DATA_HOME/ghost — build that structure explicitly.
+	xdgHome := t.TempDir()
+	ghostDir := filepath.Join(xdgHome, "ghost")
+	if err := os.MkdirAll(ghostDir, 0o700); err != nil {
+		t.Fatalf("mkdir ghostDir: %v", err)
+	}
+	dbPath := filepath.Join(ghostDir, "ghost.db")
+
+	db, err := memory.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO projects (id, path, name) VALUES ('_global', '_global', 'global')`)
+	if err != nil {
+		t.Fatalf("insert _global project: %v", err)
+	}
+	_, err = db.Exec(
+		`INSERT INTO memories (id, project_id, category, content, source) VALUES ('testid02', '_global', 'convention', 'sign all commits with DCO', 'manual')`,
+	)
+	if err != nil {
+		t.Fatalf("insert global memory: %v", err)
+	}
+	_ = db.Close()
+
+	t.Setenv("XDG_DATA_HOME", xdgHome)
+
+	input, _ := json.Marshal(map[string]string{"cwd": "/tmp/no-project-here"})
+	var out strings.Builder
+	HandleSessionStartHook(strings.NewReader(string(input)), &out)
+
+	result := out.String()
+	if !strings.Contains(result, "Global (applies to all projects)") {
+		t.Errorf("globals section missing from no-match output; got:\n%s", result)
+	}
+	if !strings.Contains(result, "sign all commits with DCO") {
+		t.Errorf("global memory content missing from no-match output; got:\n%s", result)
 	}
 }


### PR DESCRIPTION
## Summary

- Moves global memory loading before the early-return in `HandleSessionStartHook` so globals are injected regardless of whether a project matched the cwd
- Reuses the pre-computed `globalSection` in the project-matched path (no second DB open)
- Adds `TestLoadGlobalMemories` — verifies direct reading of `_global` memories from a file DB
- Adds `TestHandleSessionStartHook_GlobalsOnNoMatch` — full integration test via `XDG_DATA_HOME` override

## Test plan

- [ ] All existing tests pass (`go test ./...`)
- [ ] `TestHandleSessionStartHook_GlobalsOnNoMatch` fails without the fix, passes with it
- [ ] Manual: open a shell in an unrecognised directory; session-start hook output includes the **Global** section

Closes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global memories that apply to all projects are now preloaded and shown consistently during session startup—appended to session output whether or not a project match is found.

* **Tests**
  * Added test coverage verifying global-memory loading and session-start output (including the no-match case).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wcatz/ghost/pull/159)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->