### PR TITLE
fix(docker): bump builder image to golang:1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
## Summary
- v0.9.1's docker job failed: `go.mod requires go >= 1.26.4 (running go 1.25.11; GOTOOLCHAIN=local)` — the builder image was pinned to `golang:1.25-alpine`
- Bumps the builder to `golang:1.26-alpine`; the binaries job (goreleaser via setup-go) was unaffected

Follow-up: v0.9.2 tag after merge so ghcr images publish.