### PR TITLE
fix(embedding): sweep all projects so backfill runs without saves

### DIFF
--- a/internal/embedding/worker.go
+++ b/internal/embedding/worker.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"log/slog"
 	"time"
+
+	"github.com/wcatz/ghost/internal/memory"
 )
 
 // memoryStore is the subset of provider.MemoryStore needed by the worker.
 type memoryStore interface {
+	ListProjects(ctx context.Context) ([]memory.Project, error)
 	UnembeddedMemoryIDs(ctx context.Context, projectID string, limit int) ([]string, error)
 	GetMemoryContent(ctx context.Context, id string) (string, error)
 	StoreEmbedding(ctx context.Context, memoryID string, vec []float32, model string) error
@@ -32,14 +35,12 @@ func NewWorker(client *Client, store memoryStore, logger *slog.Logger, interval 
 }
 
 // Run starts the worker loop. Blocks until ctx is cancelled.
+// Project IDs sent on the channel are processed immediately (new saves);
+// the periodic sweep covers ALL projects so pre-existing memories backfill
+// even when nothing is saved in the current session.
 func (w *Worker) Run(ctx context.Context, projectIDs <-chan string) {
-	// Process any project ID sent to us immediately.
-	// Also run a periodic sweep.
 	ticker := time.NewTicker(w.interval)
 	defer ticker.Stop()
-
-	// Track active projects for periodic sweeps.
-	projects := make(map[string]bool)
 
 	for {
 		select {
@@ -50,14 +51,29 @@ func (w *Worker) Run(ctx context.Context, projectIDs <-chan string) {
 			if !ok {
 				return
 			}
-			projects[pid] = true
 			w.processProject(ctx, pid)
 
 		case <-ticker.C:
-			for pid := range projects {
-				w.processProject(ctx, pid)
-			}
+			w.SweepOnce(ctx)
 		}
+	}
+}
+
+// SweepOnce embeds unembedded memories across all projects.
+func (w *Worker) SweepOnce(ctx context.Context) {
+	if !w.client.Alive(ctx) {
+		return
+	}
+	projects, err := w.store.ListProjects(ctx)
+	if err != nil {
+		w.logger.Error("embed: list projects", "error", err)
+		return
+	}
+	for _, p := range projects {
+		if ctx.Err() != nil {
+			return
+		}
+		w.processProject(ctx, p.ID)
 	}
 }
 

--- a/internal/embedding/worker_test.go
+++ b/internal/embedding/worker_test.go
@@ -4,19 +4,34 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/wcatz/ghost/internal/memory"
 )
 
 // --- Mock Store ---
 
 type mockStore struct {
 	mu         sync.Mutex
+	projects   []string             // project IDs returned by ListProjects
 	memories   map[string]string    // id -> content
 	embeddings map[string][]float32 // id -> vector
 	embModel   map[string]string    // id -> model
+}
+
+func (m *mockStore) ListProjects(_ context.Context) ([]memory.Project, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]memory.Project, len(m.projects))
+	for i, id := range m.projects {
+		out[i] = memory.Project{ID: id, Name: id}
+	}
+	return out, nil
 }
 
 func newMockStore() *mockStore {
@@ -254,4 +269,41 @@ func TestProcessProject_NoUnembedded(t *testing.T) {
 
 	// Should return early without error (no unembedded memories, plus Ollama not alive).
 	worker.processProject(context.Background(), "test-project")
+}
+
+// TestSweepOnce_BackfillsWithoutSaves is a regression test: the worker must
+// embed memories in ALL projects on its periodic sweep, not only projects
+// that were previously seen on the save-notification channel. Before the
+// fix, a fresh server never backfilled pre-existing memories.
+func TestSweepOnce_BackfillsWithoutSaves(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.WriteHeader(http.StatusOK)
+		case "/api/embed":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"embeddings":[[0.1,0.2,0.3]]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	store := newMockStore()
+	store.projects = []string{"proj-a"}
+	store.memories["mem-1"] = "pre-existing memory never saved this session"
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewClient(srv.URL, "test-model", 3)
+	worker := NewWorker(client, store, logger, time.Minute)
+
+	// No channel sends — the sweep alone must find and embed the memory.
+	worker.SweepOnce(context.Background())
+
+	store.mu.Lock()
+	_, hasEmb := store.embeddings["mem-1"]
+	store.mu.Unlock()
+	if !hasEmb {
+		t.Fatal("sweep did not embed a memory in a project never seen on the channel")
+	}
 }


### PR DESCRIPTION
## Summary
After restarting with v0.9.2, live diagnostics showed embedding backfill stalled at 19/140: the worker's periodic sweep only iterated projects previously seen on the save-notification channel (empty on a fresh server), so pre-existing memories never embedded unless each project happened to get a save.

- `Run` ticker now calls `SweepOnce`, which iterates `ListProjects` — same self-healing pattern as the linking worker
- Channel path unchanged (immediate embed on save)
- Regression test: an httptest Ollama + mock store proves a project never seen on the channel gets embedded by the sweep alone

## Test plan
- [x] go vet, full go test (new TestSweepOnce_BackfillsWithoutSaves)