### PR TITLE
feat: obsidian vault mirror — ghost obsidian export|sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 - MCP server via modelcontextprotocol/go-sdk (stdio transport)
 
 ## Architecture
-- `cmd/ghost/main.go` — CLI entrypoint; subcommands: mcp, hook, reflect, upgrade, version
+- `cmd/ghost/main.go` — CLI entrypoint; subcommands: mcp, hook, reflect, obsidian, upgrade, version
 - `internal/ai/` — Claude API client with streaming (Reflect method for consolidation)
 - `internal/memory/` — SQLite CRUD, FTS5 search, vector search, time-decay scoring
 - `internal/mcpserver/` — MCP server: 16 tools + 4 resources
@@ -15,6 +15,7 @@
 - `internal/claudeimport/` — One-time import of Claude Code auto-memory on first contact
 - `internal/embedding/` — Ollama async vectorization worker
 - `internal/linking/` — Background worker linking similar memories into a graph
+- `internal/obsidian/` — One-way Markdown vault mirror (`ghost obsidian export|sync`)
 - `internal/reflection/` — Memory consolidation: HaikuConsolidator + SQLiteConsolidator
 - `internal/provider/` — Interface contracts: LLMProvider, MemoryStore
 - `internal/config/` — Layered YAML + env config (koanf)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ Pinned memories get a 1.5× boost on top.
 
 Beyond memories: tasks (`pending`/`active`/`done`/`blocked`), decision records with rationale and alternatives (`active`/`superseded`/`revisit`), and a `_global` project whose memories are included in every project's context. Projects resolve by longest path-prefix match with a basename fallback, so worktrees and moved checkouts still find their memory.
 
+### Obsidian vault mirror
+
+Your memories are yours to browse. `ghost obsidian export` mirrors memories, decisions, and tasks into plain Markdown notes — one folder per project — that Obsidian opens as a vault, with memory links rendered as wikilinks so the graph view maps your knowledge. `ghost obsidian sync` keeps the mirror fresh by polling for database changes; `--project` scopes the mirror to a single project (plus Global). The mirror is strictly one-way: it reads the database read-only (safe alongside a live MCP server), and it only ever prunes stale notes inside a directory carrying the `.ghost-vault` marker — backing off entirely when a listing might be incomplete, so stale extras beat silent deletions.
+
+```bash
+ghost obsidian export --out ~/Documents/GhostVault   # one-shot mirror
+ghost obsidian sync --interval 30s                   # keep it fresh
+```
+
 ## MCP surface
 
 16 tools, 4 resources:
@@ -185,6 +194,8 @@ ghost mcp init [--dry-run]   # Configure Claude Code integration
 ghost mcp status             # Deep health checks (incl. Ollama reachability, model presence)
 ghost hook session-start     # SessionStart hook — prints exactly what gets injected
 ghost reflect <project>      # Memory consolidation (dry-run by default; --apply, --restore, --tier)
+ghost obsidian export        # Mirror memories to an Obsidian vault (one-way; --out, --project)
+ghost obsidian sync          # Keep the vault mirror fresh (--interval; polls for DB changes)
 ghost upgrade                # Self-update from GitHub Releases (linux/macOS; Windows: re-download)
 ghost version                # Print version
 ```

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -417,6 +417,14 @@ func runUpgrade() {
 	fmt.Printf("Updated: ghost %s → %s\n", version, latest)
 }
 
+// roDSN builds a read-only DSN for the given database path. The file: URI
+// form is required: modernc.org/sqlite honors mode=ro only on URI DSNs — a
+// bare path opens silently read-write (verified against v1.53.0; the _pragma
+// params, by contrast, apply either way).
+func roDSN(dbPath string) string {
+	return "file:" + dbPath + "?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(1000)"
+}
+
 // runObsidian implements `ghost obsidian export|sync` — a one-way mirror of
 // the store into an Obsidian-readable Markdown vault.
 func runObsidian() {
@@ -481,8 +489,8 @@ Flags:
 		fmt.Fprintf(os.Stderr, "error: no database at %s — run ghost mcp init or start a session first\n", dbPath)
 		os.Exit(1)
 	}
-	// Read-only: safe alongside a live MCP server (same pattern as the session hook).
-	db, err := sql.Open("sqlite", dbPath+"?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(1000)")
+	// Read-only: safe alongside a live MCP server.
+	db, err := sql.Open("sqlite", roDSN(dbPath))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: open %s: %v\n", dbPath, err)
 		os.Exit(1)
@@ -508,6 +516,10 @@ Flags:
 	d, err := time.ParseDuration(interval)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: bad --interval %q: %v\n", interval, err)
+		os.Exit(1)
+	}
+	if d <= 0 {
+		fmt.Fprintf(os.Stderr, "error: --interval must be positive, got %s\n", d)
 		os.Exit(1)
 	}
 	fmt.Printf("Syncing to %s every %s (Ctrl-C to stop)\n", out, d)

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -477,6 +477,10 @@ Flags:
 		os.Exit(1)
 	}
 	dbPath := filepath.Join(dataDir, "ghost.db")
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "error: no database at %s — run ghost mcp init or start a session first\n", dbPath)
+		os.Exit(1)
+	}
 	// Read-only: safe alongside a live MCP server (same pattern as the session hook).
 	db, err := sql.Open("sqlite", dbPath+"?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(1000)")
 	if err != nil {

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/wcatz/ghost/internal/mcpinit"
 	"github.com/wcatz/ghost/internal/mcpserver"
 	"github.com/wcatz/ghost/internal/memory"
+	"github.com/wcatz/ghost/internal/obsidian"
 	"github.com/wcatz/ghost/internal/reflection"
 	"github.com/wcatz/ghost/internal/selfupdate"
 )
@@ -54,6 +56,9 @@ func main() {
 			return
 		case "upgrade":
 			runUpgrade()
+			return
+		case "obsidian":
+			runObsidian()
 			return
 		}
 	}
@@ -412,6 +417,102 @@ func runUpgrade() {
 	fmt.Printf("Updated: ghost %s → %s\n", version, latest)
 }
 
+// runObsidian implements `ghost obsidian export|sync` — a one-way mirror of
+// the store into an Obsidian-readable Markdown vault.
+func runObsidian() {
+	if len(os.Args) < 3 || (os.Args[2] != "export" && os.Args[2] != "sync") {
+		fmt.Fprintln(os.Stderr, `Usage: ghost obsidian <export|sync> [flags]
+
+Flags:
+  --out string       Vault directory (default ~/Documents/GhostVault or obsidian.vault_dir)
+  --project string   Mirror a single project (plus Global)
+  --interval string  sync only: poll cadence (default 30s or obsidian.interval)`)
+		os.Exit(1)
+	}
+	mode := os.Args[2]
+	var out, project, interval string
+	for i := 3; i < len(os.Args); i++ {
+		switch {
+		case os.Args[i] == "--out" && i+1 < len(os.Args):
+			out = os.Args[i+1]
+			i++
+		case strings.HasPrefix(os.Args[i], "--out="):
+			out = strings.TrimPrefix(os.Args[i], "--out=")
+		case os.Args[i] == "--project" && i+1 < len(os.Args):
+			project = os.Args[i+1]
+			i++
+		case strings.HasPrefix(os.Args[i], "--project="):
+			project = strings.TrimPrefix(os.Args[i], "--project=")
+		case os.Args[i] == "--interval" && i+1 < len(os.Args):
+			interval = os.Args[i+1]
+			i++
+		case strings.HasPrefix(os.Args[i], "--interval="):
+			interval = strings.TrimPrefix(os.Args[i], "--interval=")
+		}
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if out == "" {
+		out = cfg.Obsidian.VaultDir
+	}
+	if out == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: cannot resolve home dir: %v\n", err)
+			os.Exit(1)
+		}
+		out = filepath.Join(home, "Documents", "GhostVault")
+	}
+	if interval == "" {
+		interval = cfg.Obsidian.Interval
+	}
+
+	dataDir, err := config.DataDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	dbPath := filepath.Join(dataDir, "ghost.db")
+	// Read-only: safe alongside a live MCP server (same pattern as the session hook).
+	db, err := sql.Open("sqlite", dbPath+"?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(1000)")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: open %s: %v\n", dbPath, err)
+		os.Exit(1)
+	}
+	// PRAGMA data_version (sync mode) is per-connection; pin the pool to one
+	// connection so polls compare against a stable baseline. memory.OpenDB does
+	// this for read-write opens — raw sql.Open here needs it explicitly.
+	db.SetMaxOpenConns(1)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	store := memory.NewStore(db, logger)
+	defer store.Close() //nolint:errcheck
+
+	ex := &obsidian.Exporter{Store: store, Logger: logger}
+	ctx := context.Background()
+	if mode == "export" {
+		if err := ex.Export(ctx, out, project); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Mirrored to %s\n", out)
+		return
+	}
+	d, err := time.ParseDuration(interval)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: bad --interval %q: %v\n", interval, err)
+		os.Exit(1)
+	}
+	fmt.Printf("Syncing to %s every %s (Ctrl-C to stop)\n", out, d)
+	if err := obsidian.Sync(ctx, ex, db, out, project, d); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
 // printUsage displays the top-level help.
 func printUsage() {
 	fmt.Fprintf(os.Stderr, `ghost %s — MCP memory server for Claude Code
@@ -424,6 +525,8 @@ Commands:
   mcp init [--dry-run]        Configure Claude Code integration
   mcp status                  Check Claude Code integration health
   reflect <project> [flags]   Memory consolidation (dry-run by default, --apply to save)
+  obsidian export [flags]     Mirror memories to an Obsidian vault (one-way)
+  obsidian sync [flags]       Keep the vault mirror fresh (polls for DB changes)
   upgrade                     Update ghost to the latest release
   version                     Print version
 

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+// TestRODSNIsReadOnly guards the obsidian commands' read-only guarantee:
+// modernc.org/sqlite honors mode=ro only on file: URI DSNs — with a bare
+// path the connection opens silently read-write (verified empirically
+// against v1.53.0), which is exactly the regression this test would catch.
+func TestRODSNIsReadOnly(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "ghost.db")
+	seed, err := memory.OpenDB(dbPath) // creates the schema read-write
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := sql.Open("sqlite", roDSN(dbPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	if _, err := db.Exec(`INSERT INTO projects (id, path, name) VALUES ('x', '/x', 'x')`); err == nil {
+		t.Fatal("write through the read-only DSN must fail")
+	}
+	// Reads must still work.
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM projects`).Scan(&n); err != nil {
+		t.Fatalf("read through the read-only DSN must work: %v", err)
+	}
+}

--- a/docs/superpowers/plans/2026-07-10-obsidian-vault-mirror.md
+++ b/docs/superpowers/plans/2026-07-10-obsidian-vault-mirror.md
@@ -1,0 +1,1070 @@
+# Obsidian Vault Mirror Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `ghost obsidian export|sync` mirrors memories, decisions, and tasks into a plain-Markdown folder Obsidian reads natively — one-way, prune-safe, zero new dependencies.
+
+**Architecture:** New `internal/obsidian/` package (render → vault-safety → export walk → poll loop) consuming the concrete `*memory.Store` over a read-only SQLite connection (hook.go pattern). CLI dispatch matches the existing hand-parsed-flags style in `cmd/ghost/main.go`. Spec: `docs/superpowers/specs/2026-07-10-obsidian-vault-mirror-design.md`.
+
+**Tech Stack:** Go 1.26, stdlib only (no fsnotify, no yaml dep — hand-rolled fixed-field frontmatter). Change detection via `PRAGMA data_version` (changes only when *another* connection commits — exactly right for a read-only watcher).
+
+**Verified API surface used (do not invent others):**
+- `memory.OpenDB(dbPath) (*sql.DB, error)` — schema.go:243; read-only DSN pattern: `sql.Open("sqlite", dbPath+"?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(1000)")` — hook.go:111
+- `memory.NewStore(db, *slog.Logger) *Store` — store.go:59
+- `Store.ListProjects(ctx) ([]memory.Project{ID,Path,Name,...})`
+- `Store.GetAll(ctx, projectID, limit) ([]memory.Memory{ID,ProjectID,Category,Content,Importance,Source,Tags,Pinned,CreatedAt,UpdatedAt,...})`
+- `Store.GetLinks(ctx, memoryID) ([]memory.Link{SourceID,TargetID,Relation,Strength,...})` — valid links only, both endpoints
+- `Store.ListTasks(ctx, projectID, status, limit)` / `Store.ListDecisions(ctx, projectID, status, limit)` — empty status = all
+- `Store.EnsureProject/Create/CreateLink/CreateTask/RecordDecision/Delete` (tests only)
+- `config.Load()`, `config.DataDir()`; timestamps are SQLite `YYYY-MM-DD HH:MM:SS` strings — date = `s[:10]`
+
+---
+
+### Task 1: ObsidianConfig
+
+**Files:**
+- Modify: `internal/config/config.go` (struct + defaults map)
+- Test: `internal/config/config_test.go` (append)
+
+- [ ] **Step 1: Write the failing test** (append to existing `config_test.go`, matching its existing style)
+
+```go
+func TestObsidianDefaults(t *testing.T) {
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Obsidian.VaultDir != "" {
+		t.Errorf("VaultDir default = %q, want empty (resolved at use time)", cfg.Obsidian.VaultDir)
+	}
+	if cfg.Obsidian.Interval != "30s" {
+		t.Errorf("Interval default = %q, want 30s", cfg.Obsidian.Interval)
+	}
+}
+```
+
+Note: `vault_dir` defaults to **empty** in config; the CLI resolves empty → `~/Documents/GhostVault` at run time (`os.UserHomeDir`), because compiled defaults can't expand `~`.
+
+- [ ] **Step 2: Run: `go test ./internal/config/ -run TestObsidianDefaults -v` — expect FAIL (`cfg.Obsidian undefined`)**
+
+- [ ] **Step 3: Implement.** In `config.go`: add to the `Config` struct `Obsidian ObsidianConfig \`koanf:"obsidian"\``; add:
+
+```go
+// ObsidianConfig controls the Obsidian vault mirror (ghost obsidian export|sync).
+type ObsidianConfig struct {
+	VaultDir string `koanf:"vault_dir"` // empty = ~/Documents/GhostVault, resolved by the CLI
+	Interval string `koanf:"interval"`  // sync poll cadence, time.ParseDuration format
+}
+```
+
+and to the `defaults` map: `"obsidian.vault_dir": "",` and `"obsidian.interval": "30s",`.
+
+- [ ] **Step 4: Run: `go test ./internal/config/ -v` — expect PASS (all, not just the new one)**
+- [ ] **Step 5: Commit: `git add internal/config/ && git commit -m "feat(obsidian): add obsidian config section"`**
+
+---
+
+### Task 2: Renderer — slug, frontmatter, memory notes
+
+**Files:**
+- Create: `internal/obsidian/render.go`, `internal/obsidian/render_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+package obsidian
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+func TestSlug(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Embedding backfill bug (fixed in v0.9.3): the worker's ticker", "embedding-backfill-bug-fixed-in-v093"},
+		{"???", "note"},
+		{"", "note"},
+		{"UPPER case Words here now okay more words ignored", "upper-case-words-here-now-okay"},
+	}
+	for _, c := range cases {
+		if got := slug(c.in); got != c.want {
+			t.Errorf("slug(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFileName(t *testing.T) {
+	m := memory.Memory{ID: "74a37cba00112233", Content: "Embedding backfill bug"}
+	if got := fileName(m); got != "embedding-backfill-bug-74a37cba.md" {
+		t.Errorf("fileName = %q", got)
+	}
+}
+
+func TestRenderMemory(t *testing.T) {
+	m := memory.Memory{
+		ID: "74a37cba00112233", ProjectID: "ghost", Category: "gotcha",
+		Content: "Embedding backfill bug: ticker only swept seen projects.",
+		Importance: 0.8, Source: "mcp", Tags: []string{"embedding", "backfill"},
+		Pinned: false, CreatedAt: "2026-07-06 12:00:00", UpdatedAt: "2026-07-08 09:30:00",
+	}
+	links := []memory.Link{{SourceID: m.ID, TargetID: "beef000011223344", Relation: "related", Strength: 0.83}}
+	fileFor := map[string]string{"beef000011223344": "other-note-beef0000.md"}
+	got := renderMemory(m, links, fileFor)
+	want := `---
+ghost_id: 74a37cba00112233
+type: memory
+category: gotcha
+importance: 0.8
+pinned: false
+project: ghost
+tags: [embedding, backfill]
+created: 2026-07-06
+updated: 2026-07-08
+source: mcp
+---
+> [!info] Mirrored from Ghost — edits here are not synced back.
+
+Embedding backfill bug: ticker only swept seen projects.
+
+## Related
+- [[other-note-beef0000]] — related (0.83)
+`
+	if got != want {
+		t.Errorf("renderMemory mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	// Link target absent from fileFor → plain ID, no broken wikilink.
+	got2 := renderMemory(m, links, map[string]string{})
+	if strings.Contains(got2, "[[") || !strings.Contains(got2, "beef0000") {
+		t.Errorf("missing target should render short ID without wikilink:\n%s", got2)
+	}
+}
+```
+
+- [ ] **Step 2: Run: `go test ./internal/obsidian/ -v` — expect FAIL (package doesn't exist / undefined)**
+
+- [ ] **Step 3: Implement `render.go`**
+
+```go
+// Package obsidian mirrors Ghost's store into a plain-Markdown folder that
+// Obsidian reads natively. Strictly one-way: Ghost → vault.
+package obsidian
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+const banner = "> [!info] Mirrored from Ghost — edits here are not synced back.\n"
+
+// slug derives a stable-ish, readable filename prefix from the first ~6
+// content words: lowercase, alnum-only, dash-joined, max 40 chars.
+func slug(content string) string {
+	var words []string
+	for _, w := range strings.Fields(strings.ToLower(content)) {
+		var b strings.Builder
+		for _, r := range w {
+			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+				b.WriteRune(r)
+			}
+		}
+		if b.Len() > 0 {
+			words = append(words, b.String())
+		}
+		if len(words) == 6 {
+			break
+		}
+	}
+	s := strings.Join(words, "-")
+	if len(s) > 40 {
+		s = strings.TrimRight(s[:40], "-")
+	}
+	if s == "" {
+		return "note"
+	}
+	return s
+}
+
+func id8(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
+func fileName(m memory.Memory) string {
+	return slug(m.Content) + "-" + id8(m.ID) + ".md"
+}
+
+func date(ts string) string {
+	if len(ts) >= 10 {
+		return ts[:10]
+	}
+	return ts
+}
+
+// fm writes one frontmatter line.
+func fm(b *strings.Builder, key, val string) {
+	fmt.Fprintf(b, "%s: %s\n", key, val)
+}
+
+func renderMemory(m memory.Memory, links []memory.Link, fileFor map[string]string) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	fm(&b, "ghost_id", m.ID)
+	fm(&b, "type", "memory")
+	fm(&b, "category", m.Category)
+	fm(&b, "importance", strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.2f", m.Importance), "0"), "."))
+	fm(&b, "pinned", fmt.Sprintf("%v", m.Pinned))
+	fm(&b, "project", m.ProjectID)
+	fm(&b, "tags", "["+strings.Join(m.Tags, ", ")+"]")
+	fm(&b, "created", date(m.CreatedAt))
+	fm(&b, "updated", date(m.UpdatedAt))
+	fm(&b, "source", m.Source)
+	b.WriteString("---\n")
+	b.WriteString(banner)
+	b.WriteString("\n")
+	b.WriteString(strings.TrimRight(m.Content, "\n"))
+	b.WriteString("\n")
+	if len(links) > 0 {
+		b.WriteString("\n## Related\n")
+		for _, l := range links {
+			other := l.TargetID
+			if other == m.ID {
+				other = l.SourceID
+			}
+			if f, ok := fileFor[other]; ok {
+				fmt.Fprintf(&b, "- [[%s]] — %s (%.2f)\n", strings.TrimSuffix(f, ".md"), l.Relation, l.Strength)
+			} else {
+				fmt.Fprintf(&b, "- %s — %s (%.2f)\n", id8(other), l.Relation, l.Strength)
+			}
+		}
+	}
+	return b.String()
+}
+```
+
+Note on `importance`: `%.2f` then trim trailing zeros → `0.8`, `0.75`, `1`. Adjust the test expectation only if you change the format — they must agree.
+
+- [ ] **Step 4: Run: `go test ./internal/obsidian/ -v` — expect PASS**
+- [ ] **Step 5: Commit: `git add internal/obsidian/ && git commit -m "feat(obsidian): note renderer — slug, frontmatter, memory notes"`**
+
+---
+
+### Task 3: Renderer — decision + task notes
+
+**Files:** Modify: `internal/obsidian/render.go`; Test: `internal/obsidian/render_test.go`
+
+- [ ] **Step 1: Failing tests**
+
+```go
+func TestRenderDecision(t *testing.T) {
+	d := memory.Decision{
+		ID: "dec0000011223344", ProjectID: "ghost", Title: "Use SQLite",
+		Decision: "SQLite over Postgres.", Rationale: "Zero infra.",
+		Alternatives: []string{"Postgres", "BoltDB"}, Status: "active",
+		Tags: []string{"storage"}, CreatedAt: "2026-07-01 08:00:00", UpdatedAt: "2026-07-01 08:00:00",
+	}
+	got := renderDecision(d)
+	for _, want := range []string{"ghost_id: dec0000011223344", "type: decision", "status: active",
+		"# Use SQLite", "SQLite over Postgres.", "## Rationale", "Zero infra.", "## Alternatives", "- Postgres"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("renderDecision missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderTask(t *testing.T) {
+	tk := memory.Task{
+		ID: "task000011223344", ProjectID: "ghost", Title: "Ship mirror",
+		Description: "Build it.", Status: "active", Priority: 2,
+		CreatedAt: "2026-07-10 10:00:00", UpdatedAt: "2026-07-10 10:00:00",
+	}
+	got := renderTask(tk)
+	for _, want := range []string{"ghost_id: task000011223344", "type: task", "status: active",
+		"priority: 2", "# Ship mirror", "Build it."} {
+		if !strings.Contains(got, want) {
+			t.Errorf("renderTask missing %q in:\n%s", want, got)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run: `go test ./internal/obsidian/ -v` — expect FAIL (undefined renderDecision/renderTask)**
+
+- [ ] **Step 3: Implement** (in `render.go`; decisions/tasks slug from Title: add `func fileNameFor(title, id string) string { return slug(title) + "-" + id8(id) + ".md" }`)
+
+```go
+func renderDecision(d memory.Decision) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	fm(&b, "ghost_id", d.ID)
+	fm(&b, "type", "decision")
+	fm(&b, "status", d.Status)
+	fm(&b, "project", d.ProjectID)
+	fm(&b, "tags", "["+strings.Join(d.Tags, ", ")+"]")
+	fm(&b, "created", date(d.CreatedAt))
+	fm(&b, "updated", date(d.UpdatedAt))
+	b.WriteString("---\n")
+	b.WriteString(banner)
+	fmt.Fprintf(&b, "\n# %s\n\n%s\n", d.Title, strings.TrimRight(d.Decision, "\n"))
+	if d.Rationale != "" {
+		fmt.Fprintf(&b, "\n## Rationale\n\n%s\n", strings.TrimRight(d.Rationale, "\n"))
+	}
+	if len(d.Alternatives) > 0 {
+		b.WriteString("\n## Alternatives\n\n")
+		for _, a := range d.Alternatives {
+			fmt.Fprintf(&b, "- %s\n", a)
+		}
+	}
+	return b.String()
+}
+
+func renderTask(t memory.Task) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	fm(&b, "ghost_id", t.ID)
+	fm(&b, "type", "task")
+	fm(&b, "status", t.Status)
+	fm(&b, "priority", fmt.Sprintf("%d", t.Priority))
+	fm(&b, "project", t.ProjectID)
+	fm(&b, "created", date(t.CreatedAt))
+	fm(&b, "updated", date(t.UpdatedAt))
+	b.WriteString("---\n")
+	b.WriteString(banner)
+	fmt.Fprintf(&b, "\n# %s\n", t.Title)
+	if t.Description != "" {
+		fmt.Fprintf(&b, "\n%s\n", strings.TrimRight(t.Description, "\n"))
+	}
+	if t.Notes != "" {
+		fmt.Fprintf(&b, "\n## Notes\n\n%s\n", strings.TrimRight(t.Notes, "\n"))
+	}
+	return b.String()
+}
+```
+
+- [ ] **Step 4: Run: `go test ./internal/obsidian/ -v` — expect PASS**
+- [ ] **Step 5: Commit: `git commit -am "feat(obsidian): decision and task note renderers"`**
+
+---
+
+### Task 4: Vault safety — marker, diff-write, prune guard
+
+**Files:** Create: `internal/obsidian/vault.go`, `internal/obsidian/vault_test.go`
+
+- [ ] **Step 1: Failing tests**
+
+```go
+package obsidian
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureVault(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "vault")
+	if err := ensureVault(dir); err != nil { // fresh dir: created + marker
+		t.Fatalf("fresh: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, markerName)); err != nil {
+		t.Fatalf("marker missing: %v", err)
+	}
+	if err := ensureVault(dir); err != nil { // idempotent
+		t.Fatalf("second run: %v", err)
+	}
+	// Existing non-empty dir WITHOUT marker → refuse.
+	dirty := t.TempDir()
+	os.WriteFile(filepath.Join(dirty, "keep.md"), []byte("user file"), 0o644)
+	if err := ensureVault(dirty); err == nil {
+		t.Fatal("expected refusal for unmarked non-empty dir")
+	}
+}
+
+func TestWriteIfChanged(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "a.md")
+	w1, err := writeIfChanged(p, "hello")
+	if err != nil || !w1 {
+		t.Fatalf("first write: wrote=%v err=%v", w1, err)
+	}
+	w2, _ := writeIfChanged(p, "hello")
+	if w2 {
+		t.Fatal("unchanged content must not rewrite")
+	}
+	w3, _ := writeIfChanged(p, "hello2")
+	if !w3 {
+		t.Fatal("changed content must rewrite")
+	}
+}
+
+func TestPrune(t *testing.T) {
+	root := t.TempDir()
+	os.WriteFile(filepath.Join(root, markerName), []byte(`{"schema_version":1}`), 0o644)
+	sub := filepath.Join(root, "proj", "Memories")
+	os.MkdirAll(sub, 0o755)
+	ghostNote := "---\nghost_id: dead0000\ntype: memory\n---\nbody\n"
+	os.WriteFile(filepath.Join(sub, "stale-dead0000.md"), []byte(ghostNote), 0o644)
+	os.WriteFile(filepath.Join(sub, "user-note.md"), []byte("no frontmatter"), 0o644)
+
+	if err := prune(root, []string{"proj"}, map[string]bool{}); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sub, "stale-dead0000.md")); !os.IsNotExist(err) {
+		t.Fatal("stale ghost note should be deleted")
+	}
+	if _, err := os.Stat(filepath.Join(sub, "user-note.md")); err != nil {
+		t.Fatal("user note must survive")
+	}
+	// No marker → prune must refuse to delete anything.
+	os.Remove(filepath.Join(root, markerName))
+	os.WriteFile(filepath.Join(sub, "stale2-beef0000.md"), []byte(ghostNote), 0o644)
+	if err := prune(root, []string{"proj"}, map[string]bool{}); err == nil {
+		t.Fatal("prune without marker must error")
+	}
+}
+```
+
+- [ ] **Step 2: Run: `go test ./internal/obsidian/ -run 'TestEnsureVault|TestWriteIfChanged|TestPrune' -v` — expect FAIL**
+
+- [ ] **Step 3: Implement `vault.go`**
+
+```go
+package obsidian
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const markerName = ".ghost-vault"
+
+// ensureVault prepares dir as a Ghost-managed mirror target. Fresh or empty
+// dirs are initialized with the marker; a non-empty dir without the marker is
+// refused — Ghost never adopts a folder it didn't create.
+func ensureVault(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create vault dir: %w", err)
+		}
+		entries = nil
+	} else if err != nil {
+		return fmt.Errorf("read vault dir: %w", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, markerName)); err == nil {
+		return nil
+	}
+	if len(entries) > 0 {
+		return fmt.Errorf("%s exists, is not empty, and has no %s marker — refusing to manage it (use a fresh directory)", dir, markerName)
+	}
+	return os.WriteFile(filepath.Join(dir, markerName), []byte(`{"schema_version":1}`+"\n"), 0o644)
+}
+
+// writeIfChanged writes content atomically (temp+rename), skipping the write
+// when the file already has identical content — no mtime churn.
+func writeIfChanged(path, content string) (bool, error) {
+	if existing, err := os.ReadFile(path); err == nil && string(existing) == content {
+		return false, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return false, err
+	}
+	tmp := path + ".ghost-tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		return false, err
+	}
+	return true, os.Rename(tmp, path)
+}
+
+// hasGhostID reports whether a file's frontmatter carries a ghost_id key —
+// the only files prune may touch. Only the frontmatter block (between the
+// opening and closing --- lines) is scanned, never the note body.
+func hasGhostID(path string) (string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) == 0 || lines[0] != "---" {
+		return "", false
+	}
+	for _, line := range lines[1:] {
+		if line == "---" { // end of frontmatter — stop before the body
+			break
+		}
+		if id, ok := strings.CutPrefix(line, "ghost_id: "); ok {
+			return strings.TrimSpace(id), true
+		}
+	}
+	return "", false
+}
+
+// prune deletes Ghost-managed .md files under the given vault subtrees whose
+// ghost_id is not in keep. All three guards from the spec are enforced.
+func prune(root string, subtrees []string, keep map[string]bool) error {
+	if _, err := os.Stat(filepath.Join(root, markerName)); err != nil {
+		return fmt.Errorf("refusing to prune: %s marker not found in %s", markerName, root)
+	}
+	for _, sub := range subtrees {
+		base := filepath.Join(root, sub)
+		err := filepath.WalkDir(base, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
+				return nil //nolint:nilerr // missing subtree is fine
+			}
+			if id, ok := hasGhostID(path); ok && !keep[id] {
+				return os.Remove(path)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run: `go test ./internal/obsidian/ -v` — expect PASS.** Check the `hasGhostID` frontmatter-end logic against the test with a body containing `ghost_id:`-like text if you harden it — v1 scans only until the closing `---` line after the first.
+- [ ] **Step 5: Commit: `git add internal/obsidian/ && git commit -m "feat(obsidian): vault marker, atomic diff-writes, guarded pruning"`**
+
+---
+
+### Task 5: Export walk
+
+**Files:** Create: `internal/obsidian/export.go`, `internal/obsidian/export_test.go`
+
+- [ ] **Step 1: Failing integration test**
+
+```go
+package obsidian
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+func seedStore(t *testing.T) *memory.Store {
+	t.Helper()
+	db, err := memory.OpenDB(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := memory.NewStore(db, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	t.Cleanup(func() { store.Close() })
+	ctx := context.Background()
+	if err := store.EnsureProject(ctx, "ghost", "/tmp/ghost", "ghost"); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func TestExport(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	id1, _ := store.Create(ctx, "ghost", memory.Memory{Category: "gotcha", Content: "First fact about embedding", Importance: 0.8, Source: "mcp"})
+	id2, _ := store.Create(ctx, "ghost", memory.Memory{Category: "fact", Content: "Second fact about linking", Importance: 0.7, Source: "mcp"})
+	if err := store.CreateLink(ctx, id1, id2, "related", 0.83, "auto"); err != nil {
+		t.Fatal(err)
+	}
+	store.RecordDecision(ctx, "ghost", "Use SQLite", "SQLite it is", "zero infra", []string{"Postgres"}, nil)
+	store.CreateTask(ctx, "ghost", "Ship mirror", "Build it", 2)
+
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	mems, _ := filepath.Glob(filepath.Join(vault, "ghost", "Memories", "*.md"))
+	if len(mems) != 2 {
+		t.Fatalf("want 2 memory notes, got %d", len(mems))
+	}
+	// Wikilink present between the two memories.
+	data, _ := os.ReadFile(mems[0])
+	other, _ := os.ReadFile(mems[1])
+	if !strings.Contains(string(data)+string(other), "[[") {
+		t.Error("expected a wikilink in Related section")
+	}
+	decs, _ := filepath.Glob(filepath.Join(vault, "ghost", "Decisions", "*.md"))
+	tasks, _ := filepath.Glob(filepath.Join(vault, "ghost", "Tasks", "*.md"))
+	if len(decs) != 1 || len(tasks) != 1 {
+		t.Fatalf("want 1 decision + 1 task, got %d + %d", len(decs), len(tasks))
+	}
+	// Note: RecordDecision also saves a companion memory — memory note count
+	// may include it; adjust the assertion above if so (verify against actual
+	// behavior, decisions.go RecordDecision doc says "also saves as a memory").
+
+	// Idempotence: second export rewrites nothing (mtimes unchanged).
+	before, _ := os.Stat(mems[0])
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.Stat(mems[0])
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Error("unchanged note was rewritten")
+	}
+
+	// Deletion prunes.
+	if err := store.Delete(ctx, id2); err != nil {
+		t.Fatal(err)
+	}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+	mems2, _ := filepath.Glob(filepath.Join(vault, "ghost", "Memories", "*.md"))
+	if len(mems2) >= len(mems) {
+		t.Errorf("deleted memory's note should be pruned: %d -> %d", len(mems), len(mems2))
+	}
+}
+```
+
+**Heads-up baked into the test:** `RecordDecision` also creates a companion memory (decisions.go doc comment) — the first memory-count assertion will likely see 3, not 2. Run once, read the actual count, and pin the assertion to reality. Do not weaken the wikilink/prune/mtime assertions.
+
+- [ ] **Step 2: Run: `go test ./internal/obsidian/ -run TestExport -v` — expect FAIL (undefined Exporter)**
+
+- [ ] **Step 3: Implement `export.go`**
+
+```go
+package obsidian
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+const globalProjectID = "_global"
+
+// Exporter mirrors the store into a vault directory.
+type Exporter struct {
+	Store  *memory.Store
+	Logger *slog.Logger
+}
+
+// Export performs one full deterministic mirror pass. projectFilter of ""
+// mirrors everything; otherwise that project (by ID or name) plus _global.
+func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) error {
+	if err := ensureVault(vaultDir); err != nil {
+		return err
+	}
+	projects, err := e.Store.ListProjects(ctx)
+	if err != nil {
+		return fmt.Errorf("list projects: %w", err)
+	}
+	selected := projects[:0:0]
+	matched := false
+	for _, p := range projects {
+		switch {
+		case projectFilter == "":
+			selected = append(selected, p)
+		case p.ID == projectFilter || p.Name == projectFilter:
+			selected = append(selected, p)
+			matched = true
+		case p.ID == globalProjectID:
+			selected = append(selected, p) // globals ride along with any filter
+		}
+	}
+	if projectFilter != "" && !matched {
+		return fmt.Errorf("no project matches %q", projectFilter)
+	}
+
+	// Pass 1: load all memories, build the global id → filename map for wikilinks.
+	type projData struct {
+		p        memory.Project
+		folder   string
+		memories []memory.Memory
+	}
+	var data []projData
+	fileFor := make(map[string]string)
+	for _, p := range selected {
+		mems, err := e.Store.GetAll(ctx, p.ID, 100000)
+		if err != nil {
+			return fmt.Errorf("load memories for %s: %w", p.ID, err)
+		}
+		folder := folderName(p)
+		for _, m := range mems {
+			fileFor[m.ID] = fileName(m)
+		}
+		data = append(data, projData{p: p, folder: folder, memories: mems})
+	}
+
+	// Pass 2: render + diff-write + collect keep-set, then prune.
+	keep := make(map[string]bool)
+	var subtrees []string
+	written, skipped := 0, 0
+	for _, d := range data {
+		subtrees = append(subtrees, d.folder)
+		for _, m := range d.memories {
+			links, err := e.Store.GetLinks(ctx, m.ID)
+			if err != nil {
+				return fmt.Errorf("links for %s: %w", m.ID, err)
+			}
+			keep[m.ID] = true
+			w, err := writeIfChanged(filepath.Join(vaultDir, d.folder, "Memories", fileFor[m.ID]), renderMemory(m, links, fileFor))
+			if err != nil {
+				return err
+			}
+			count(&written, &skipped, w)
+		}
+		decisions, err := e.Store.ListDecisions(ctx, d.p.ID, "", 100000)
+		if err != nil {
+			return fmt.Errorf("decisions for %s: %w", d.p.ID, err)
+		}
+		for _, dec := range decisions {
+			keep[dec.ID] = true
+			w, err := writeIfChanged(filepath.Join(vaultDir, d.folder, "Decisions", fileNameFor(dec.Title, dec.ID)), renderDecision(dec))
+			if err != nil {
+				return err
+			}
+			count(&written, &skipped, w)
+		}
+		tasks, err := e.Store.ListTasks(ctx, d.p.ID, "", 100000)
+		if err != nil {
+			return fmt.Errorf("tasks for %s: %w", d.p.ID, err)
+		}
+		for _, tk := range tasks {
+			keep[tk.ID] = true
+			w, err := writeIfChanged(filepath.Join(vaultDir, d.folder, "Tasks", fileNameFor(tk.Title, tk.ID)), renderTask(tk))
+			if err != nil {
+				return err
+			}
+			count(&written, &skipped, w)
+		}
+	}
+	if err := prune(vaultDir, subtrees, keep); err != nil {
+		return err
+	}
+	e.Logger.Info("obsidian export complete", "projects", len(data), "written", written, "unchanged", skipped)
+	return nil
+}
+
+func count(written, skipped *int, wrote bool) {
+	if wrote {
+		*written++
+	} else {
+		*skipped++
+	}
+}
+
+// folderName maps a project to its vault folder. _global gets "Global";
+// otherwise the sanitized project name (fallback: ID).
+func folderName(p memory.Project) string {
+	if p.ID == globalProjectID {
+		return "Global"
+	}
+	name := p.Name
+	if name == "" {
+		name = p.ID
+	}
+	var b []rune
+	for _, r := range name {
+		switch {
+		case r == '/' || r == '\\' || r == ':' || r == 0:
+			b = append(b, '-')
+		default:
+			b = append(b, r)
+		}
+	}
+	return string(b)
+}
+```
+
+- [ ] **Step 4: Run: `go test ./internal/obsidian/ -v` — fix the memory-count assertion to the real value (see heads-up), then expect PASS**
+- [ ] **Step 5: Run the full suite: `go test ./... && go vet ./...` — expect PASS**
+- [ ] **Step 6: Commit: `git add internal/obsidian/ && git commit -m "feat(obsidian): full export walk with wikilinks and pruning"`**
+
+---
+
+### Task 6: CLI wiring — `ghost obsidian export`
+
+**Files:** Modify: `cmd/ghost/main.go` (switch + new `runObsidian` + `printUsage`)
+
+- [ ] **Step 1: Add dispatch** — in the `main()` switch (after `case "upgrade":`):
+
+```go
+case "obsidian":
+	runObsidian()
+	return
+```
+
+- [ ] **Step 2: Implement `runObsidian`** (same file, mirrors `runReflect` style; read-only DB like hook.go:111):
+
+```go
+// runObsidian implements `ghost obsidian export|sync` — a one-way mirror of
+// the store into an Obsidian-readable Markdown vault.
+func runObsidian() {
+	if len(os.Args) < 3 || (os.Args[2] != "export" && os.Args[2] != "sync") {
+		fmt.Fprintln(os.Stderr, `Usage: ghost obsidian <export|sync> [flags]
+
+Flags:
+  --out string       Vault directory (default ~/Documents/GhostVault or obsidian.vault_dir)
+  --project string   Mirror a single project (plus Global)
+  --interval string  sync only: poll cadence (default 30s or obsidian.interval)`)
+		os.Exit(1)
+	}
+	mode := os.Args[2]
+	var out, project, interval string
+	for i := 3; i < len(os.Args); i++ {
+		switch {
+		case os.Args[i] == "--out" && i+1 < len(os.Args):
+			out = os.Args[i+1]
+			i++
+		case strings.HasPrefix(os.Args[i], "--out="):
+			out = strings.TrimPrefix(os.Args[i], "--out=")
+		case os.Args[i] == "--project" && i+1 < len(os.Args):
+			project = os.Args[i+1]
+			i++
+		case strings.HasPrefix(os.Args[i], "--project="):
+			project = strings.TrimPrefix(os.Args[i], "--project=")
+		case os.Args[i] == "--interval" && i+1 < len(os.Args):
+			interval = os.Args[i+1]
+			i++
+		case strings.HasPrefix(os.Args[i], "--interval="):
+			interval = strings.TrimPrefix(os.Args[i], "--interval=")
+		}
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if out == "" {
+		out = cfg.Obsidian.VaultDir
+	}
+	if out == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: cannot resolve home dir: %v\n", err)
+			os.Exit(1)
+		}
+		out = filepath.Join(home, "Documents", "GhostVault")
+	}
+	if interval == "" {
+		interval = cfg.Obsidian.Interval
+	}
+
+	dataDir, err := config.DataDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	dbPath := filepath.Join(dataDir, "ghost.db")
+	// Read-only: safe alongside a live MCP server (same pattern as the session hook).
+	db, err := sql.Open("sqlite", dbPath+"?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(1000)")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: open %s: %v\n", dbPath, err)
+		os.Exit(1)
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	store := memory.NewStore(db, logger)
+	defer store.Close() //nolint:errcheck
+
+	ex := &obsidian.Exporter{Store: store, Logger: logger}
+	ctx := context.Background()
+	if mode == "export" {
+		if err := ex.Export(ctx, out, project); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Mirrored to %s\n", out)
+		return
+	}
+	d, err := time.ParseDuration(interval)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: bad --interval %q: %v\n", interval, err)
+		os.Exit(1)
+	}
+	fmt.Printf("Syncing to %s every %s (Ctrl-C to stop)\n", out, d)
+	if err := obsidian.Sync(ctx, ex, db, out, project, d); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+```
+
+Imports to add in main.go: `"database/sql"`, `"time"`, `"github.com/wcatz/ghost/internal/obsidian"` (check `context`, `log/slog`, `path/filepath`, `strings` — most already imported).
+
+- [ ] **Step 3: Add to `printUsage()`** (find the existing usage block and append in style):
+
+```text
+  obsidian export      Mirror memories to an Obsidian vault (one-way)
+  obsidian sync        Keep the vault mirror fresh (polls for DB changes)
+```
+
+- [ ] **Step 4: `Sync` doesn't exist yet — stub it in `internal/obsidian/sync.go` so the build compiles** (full implementation is Task 7):
+
+```go
+package obsidian
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// Sync re-exports whenever the database changes, polling PRAGMA data_version.
+func Sync(ctx context.Context, ex *Exporter, db *sql.DB, vaultDir, projectFilter string, interval time.Duration) error {
+	return ex.Export(ctx, vaultDir, projectFilter) // poll loop lands in the next commit
+}
+```
+
+- [ ] **Step 5: Build + smoke test: `go build ./... && go vet ./...` then `go run ./cmd/ghost obsidian export --out /tmp/ghost-vault-smoke && ls /tmp/ghost-vault-smoke`** — expect real memories mirrored from the live local DB (read-only, harmless), folders per project.
+- [ ] **Step 6: Commit: `git add cmd/ghost/ internal/obsidian/ && git commit -m "feat(obsidian): ghost obsidian export CLI"`**
+
+---
+
+### Task 7: Sync poll loop + final verification
+
+**Files:** Modify: `internal/obsidian/sync.go`; Create: `internal/obsidian/sync_test.go`
+
+- [ ] **Step 1: Failing test** — `data_version` only moves for *other* connections, so the test writes via a second connection to a file-backed DB:
+
+```go
+package obsidian
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+func TestSyncDetectsChange(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "ghost.db")
+
+	writeDB, err := memory.OpenDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	writeStore := memory.NewStore(writeDB, logger)
+	defer writeStore.Close()
+	ctx := context.Background()
+	writeStore.EnsureProject(ctx, "p1", "/tmp/p1", "p1")
+	writeStore.Create(ctx, "p1", memory.Memory{Category: "fact", Content: "first memory", Importance: 0.7, Source: "test"})
+
+	readDB, err := memory.OpenDB(dbPath) // second connection: sees writeDB's commits as data_version bumps
+	if err != nil {
+		t.Fatal(err)
+	}
+	readStore := memory.NewStore(readDB, logger)
+	defer readStore.Close()
+
+	vault := filepath.Join(dir, "vault")
+	ex := &Exporter{Store: readStore, Logger: logger}
+
+	syncCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() { done <- Sync(syncCtx, ex, readDB, vault, "", 50*time.Millisecond) }()
+
+	// Initial export happens immediately.
+	waitFor(t, func() bool {
+		m, _ := filepath.Glob(filepath.Join(vault, "p1", "Memories", "*.md"))
+		return len(m) == 1
+	})
+	// A write from the other connection is picked up within a few ticks.
+	writeStore.Create(ctx, "p1", memory.Memory{Category: "fact", Content: "second memory", Importance: 0.7, Source: "test"})
+	waitFor(t, func() bool {
+		m, _ := filepath.Glob(filepath.Join(vault, "p1", "Memories", "*.md"))
+		return len(m) == 2
+	})
+	cancel()
+	if err := <-done; err != nil && err != context.Canceled {
+		t.Fatalf("sync returned: %v", err)
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("condition not met within 5s")
+}
+```
+
+- [ ] **Step 2: Run: `go test ./internal/obsidian/ -run TestSyncDetectsChange -v` — expect FAIL (stub exports once, never re-exports)**
+
+- [ ] **Step 3: Implement the real loop**
+
+```go
+package obsidian
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// Sync mirrors once immediately, then re-exports whenever PRAGMA data_version
+// reports a commit from another connection. Runs until ctx is cancelled.
+func Sync(ctx context.Context, ex *Exporter, db *sql.DB, vaultDir, projectFilter string, interval time.Duration) error {
+	if err := ex.Export(ctx, vaultDir, projectFilter); err != nil {
+		return err
+	}
+	last, err := dataVersion(ctx, db)
+	if err != nil {
+		return err
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			v, err := dataVersion(ctx, db)
+			if err != nil {
+				ex.Logger.Warn("obsidian sync: data_version poll failed", "error", err)
+				continue
+			}
+			if v == last {
+				continue
+			}
+			last = v
+			if err := ex.Export(ctx, vaultDir, projectFilter); err != nil {
+				ex.Logger.Warn("obsidian sync: export failed, will retry next change", "error", err)
+			}
+		}
+	}
+}
+
+func dataVersion(ctx context.Context, db *sql.DB) (int64, error) {
+	var v int64
+	err := db.QueryRowContext(ctx, "PRAGMA data_version").Scan(&v)
+	return v, err
+}
+```
+
+**Caveat to verify while running the test:** `data_version` is per-connection, and `database/sql` pools connections. The store sets `SetMaxOpenConns(1)` inside `OpenDB` (check schema.go:243-260 — if the pool limit is set there, the PRAGMA reads consistently from one connection; if not, add `db.SetMaxOpenConns(1)` for the read connection in `runObsidian` and the test). The test will catch it either way — if it flakes, this is why.
+
+- [ ] **Step 4: Run: `go test ./internal/obsidian/ -race -count=1 -v` — expect PASS (all package tests, race-clean)**
+- [ ] **Step 5: Full verification: `go test -race -count=1 ./... && go vet ./...` — expect PASS everywhere**
+- [ ] **Step 6: Commit: `git add internal/obsidian/ && git commit -m "feat(obsidian): sync loop via data_version polling"`**
+- [ ] **Step 7: README — add a short "Obsidian mirror" subsection under How it works** (3-4 sentences + the two commands; follow the README's existing tone; mention one-way + prune-guards + `.ghost-vault` marker), then `git add README.md && git commit -m "docs: obsidian vault mirror section"`
+- [ ] **Step 8: Push + PR: `git push -u origin feat/obsidian-mirror && gh pr create --title "feat: obsidian vault mirror (ghost obsidian export|sync)" --body "<summary + spec/plan links + test evidence>"`** — CI must pass; merge per repo convention (squash), delete branch.

--- a/docs/superpowers/specs/2026-07-10-obsidian-vault-mirror-design.md
+++ b/docs/superpowers/specs/2026-07-10-obsidian-vault-mirror-design.md
@@ -93,6 +93,7 @@ User-created files are never touched. First export into an existing non-empty di
 
 - Renamed or merged projects can leave orphaned folders in the vault: prune only walks the **current** run's managed subtrees by design, so a folder that no longer maps to any project is never revisited. Recovery is trivial — delete the vault directory and re-export; the mirror is fully regenerable from the store.
 - Per-project list queries are capped at 100,000 entries. A list that hits the cap may be silently truncated by the store, so the export logs a warning and skips pruning that project's folder for the run (stale extra notes beat silently deleted ones).
+- With `--project`, links into filtered-out projects render as plain short IDs rather than wikilinks, so alternating filtered and unfiltered runs rewrite those notes each time the link's rendering flips.
 
 ## Configuration
 
@@ -118,7 +119,7 @@ Two new keys in the compiled defaults (`internal/config/config.go`); CLI flags o
 - Missing/unreachable DB: same error path as `hook.go` (clear message, non-zero exit).
 - Unwritable `vault_dir`: fail the export with the path in the error; sync logs and retries next tick.
 - Partial-write safety: write to temp file + rename (atomic per note).
-- A project with unsanitizable/colliding names: sanitize with the existing `sanitizeName` approach from `mcpinit`; collisions get ID suffixes.
+- A project with unsanitizable/colliding names: as built, `folderName` sanitizes separators and enforces `filepath.IsLocal` containment (strictly stronger than reusing `sanitizeName` from `mcpinit`); case-insensitive collisions and non-local results get ID-suffixed `project-<id8>` folders.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-10-obsidian-vault-mirror-design.md
+++ b/docs/superpowers/specs/2026-07-10-obsidian-vault-mirror-design.md
@@ -77,7 +77,7 @@ source: mcp
 
 ## Filenames and idempotence
 
-`<slug>-<id8>.md` — slug from the first ~6 content words, 8-char ID suffix guarantees uniqueness and stability of identity. Export is a deterministic full regeneration (sorted by ID), but a file is only rewritten when rendered content differs — no mtime churn for Obsidian's indexer or file-sync tools. Content edits after consolidation may change the slug (a rename); all wikilinks are regenerated in the same pass, so the vault stays internally consistent.
+`<slug>-<id8>.md` — slug from the first ~6 content words, 8-char ID suffix guarantees uniqueness and stability of identity. Export is a deterministic full regeneration: each entity renders to its own file, the backing queries are explicitly ordered (importance/created_at), and the output bytes are independent of iteration order. A file is only rewritten when rendered content differs — no mtime churn for Obsidian's indexer or file-sync tools. Content edits after consolidation may change the slug (a rename); all wikilinks are regenerated in the same pass, so the vault stays internally consistent.
 
 ## Pruning safety (the load-bearing part)
 
@@ -88,6 +88,11 @@ A file is deleted only when **all** hold:
 3. The file's own frontmatter contains a `ghost_id` key (parsed before deletion).
 
 User-created files are never touched. First export into an existing non-empty directory **without** the marker is refused (no `--force` in v1 — create a fresh dir or add the marker manually). The banner callout in every note states the mirror is one-way.
+
+## Known limitations (v1)
+
+- Renamed or merged projects can leave orphaned folders in the vault: prune only walks the **current** run's managed subtrees by design, so a folder that no longer maps to any project is never revisited. Recovery is trivial — delete the vault directory and re-export; the mirror is fully regenerable from the store.
+- Per-project list queries are capped at 100,000 entries. A list that hits the cap may be silently truncated by the store, so the export logs a warning and skips pruning that project's folder for the run (stale extra notes beat silently deleted ones).
 
 ## Configuration
 

--- a/docs/superpowers/specs/2026-07-10-obsidian-vault-mirror-design.md
+++ b/docs/superpowers/specs/2026-07-10-obsidian-vault-mirror-design.md
@@ -1,0 +1,127 @@
+# Obsidian vault mirror — design
+
+**Date:** 2026-07-10
+**Status:** Approved (design review with owner)
+**Feature branch:** `feat/obsidian-mirror`
+
+## Goal
+
+Mirror Ghost's memory store into a plain-Markdown folder that Obsidian reads natively, giving users browsing, backlinks, graph view, Properties/Bases filtering, and mobile access (via any vault-sync mechanism) — without Ghost growing a UI. Strictly **one-way** (Ghost → vault) in v1.
+
+Obsidian auto-refreshes on external file changes, so a folder of generated Markdown is a live view. Ghost's schema maps 1:1 onto Obsidian primitives: memories → notes with YAML frontmatter, `memory_links` → wikilinks (graph view), decisions → ADR-style notes, tasks → notes with status properties, projects → folders.
+
+## Decisions locked in review
+
+| Decision | Choice |
+|---|---|
+| Vault home | Dedicated Ghost-managed folder (default `~/Documents/GhostVault`), configurable via `obsidian.vault_dir` / `--out`. Open as its own vault or symlink into an existing one. |
+| Freshness | `ghost obsidian export` (one-shot) + `ghost obsidian sync` (long-running, polls for DB changes). No background worker inside `ghost mcp` in v1. |
+| v1 scope | Memories + decisions + tasks. Bases `.base` views, JSON Canvas, vault ingestion, `obsidian://` deep links → v2. |
+| Direction | One-way, read-only mirror. Two-way sync explicitly out of scope. |
+
+## Command surface
+
+```text
+ghost obsidian export [--out DIR] [--project NAME]   # one-shot full mirror
+ghost obsidian sync   [--out DIR] [--interval 30s]   # poll PRAGMA data_version, re-export on change
+```
+
+`--project NAME` limits the mirror to that project's folder plus `Global/` (globals apply everywhere, mirroring the hook's behavior). Pruning is likewise scoped to the mirrored subtrees only.
+
+Added as `case "obsidian":` in the `cmd/ghost/main.go` string-switch, hand-parsed flags, matching the existing `reflect` pattern.
+
+## Change detection (sync)
+
+Poll SQLite `PRAGMA data_version` every `interval` (default 30s, config `obsidian.interval`). The counter changes whenever another connection commits — no fsnotify dependency, no WAL races. DB opened **read-only** (same pattern as `internal/mcpinit/hook.go`), safe alongside a live MCP server. Sync latency is bounded by the interval; that trade-off is documented.
+
+## Vault layout
+
+```text
+GhostVault/
+  .ghost-vault          # marker: JSON {schema_version: 1} — pruning guard
+  Global/               # the _global project — same shape as any project folder
+    Memories/  Decisions/  Tasks/     # subfolders created only when non-empty
+  <project-name>/       # one folder per project (sanitized name)
+    Memories/  Decisions/  Tasks/
+```
+
+## Note format
+
+One note per entity. Memory example:
+
+```markdown
+---
+ghost_id: 74A37CBA…
+type: memory
+category: gotcha
+importance: 0.8
+pinned: false
+project: ghost
+tags: [embedding, backfill]
+created: 2026-07-06
+updated: 2026-07-08
+source: mcp
+---
+> [!info] Mirrored from Ghost — edits here are not synced back.
+
+<memory content>
+
+## Related
+- [[<other-note>]] — related (0.83)
+```
+
+- Frontmatter keys are Obsidian Properties (filterable, Bases-ready in v2).
+- `## Related` renders non-invalidated `memory_links` as wikilinks with relation + strength → graph view shows Ghost's memory graph.
+- Decisions: frontmatter `status: active|superseded|revisit`, body sections Rationale / Alternatives.
+- Tasks: frontmatter `status: pending|active|done|blocked`, `priority`.
+
+## Filenames and idempotence
+
+`<slug>-<id8>.md` — slug from the first ~6 content words, 8-char ID suffix guarantees uniqueness and stability of identity. Export is a deterministic full regeneration (sorted by ID), but a file is only rewritten when rendered content differs — no mtime churn for Obsidian's indexer or file-sync tools. Content edits after consolidation may change the slug (a rename); all wikilinks are regenerated in the same pass, so the vault stays internally consistent.
+
+## Pruning safety (the load-bearing part)
+
+A file is deleted only when **all** hold:
+
+1. It is under `vault_dir`, inside a Ghost-managed subtree (`Global/` or `<project>/`).
+2. The `.ghost-vault` marker exists at the vault root.
+3. The file's own frontmatter contains a `ghost_id` key (parsed before deletion).
+
+User-created files are never touched. First export into an existing non-empty directory **without** the marker is refused (no `--force` in v1 — create a fresh dir or add the marker manually). The banner callout in every note states the mirror is one-way.
+
+## Configuration
+
+```yaml
+obsidian:
+  vault_dir: ~/Documents/GhostVault
+  interval: 30s
+```
+
+Two new keys in the compiled defaults (`internal/config/config.go`); CLI flags override config.
+
+## Implementation shape
+
+- New package `internal/obsidian/`:
+  - `render.go` — entity → Markdown (frontmatter marshal, slug, wikilinks)
+  - `export.go` — full-mirror walk: load projects/memories/links/decisions/tasks via `provider.MemoryStore` read methods, render, diff-write, prune
+  - `sync.go` — data_version poll loop wrapping export
+- `cmd/ghost/main.go` — `obsidian` subcommand dispatch.
+- No new dependencies: frontmatter is a fixed field set, emitted by a small hand-rolled writer (ordered keys, deterministic output, trivially golden-testable) — no yaml marshaling dep, **no fsnotify**.
+
+## Error handling
+
+- Missing/unreachable DB: same error path as `hook.go` (clear message, non-zero exit).
+- Unwritable `vault_dir`: fail the export with the path in the error; sync logs and retries next tick.
+- Partial-write safety: write to temp file + rename (atomic per note).
+- A project with unsanitizable/colliding names: sanitize with the existing `sanitizeName` approach from `mcpinit`; collisions get ID suffixes.
+
+## Testing
+
+- Golden-file tests for rendering (memory/decision/task notes, wikilink section).
+- Prune-guard unit tests: marker missing, foreign files, files without `ghost_id` — all must survive.
+- Integration test: seeded store (`OpenDB(":memory:")` pattern) → export to `t.TempDir()` → assert tree; mutate store → re-export → assert diff-writes and pruning.
+- Determinism: two exports of the same store are byte-identical.
+
+## Out of scope (v2 candidates)
+
+Bases `.base` dashboards; JSON Canvas relation edges; vault ingestion (`ghost obsidian ingest`); `obsidian://` deep links in MCP tool responses; two-way sync; background mirror worker inside `ghost mcp`.

--- a/internal/config/config.example.yaml
+++ b/internal/config/config.example.yaml
@@ -36,3 +36,10 @@
 # auto: tries haiku (if ANTHROPIC_API_KEY set) → sqlite (free, always available)
 # reflection:
 #   backend: "auto"                  # "auto", "haiku", "sqlite"
+
+# --- Obsidian Vault Mirror ---
+# One-way Markdown mirror of memories, decisions, and tasks
+# (ghost obsidian export|sync). Empty vault_dir means ~/Documents/GhostVault.
+# obsidian:
+#   vault_dir: ""                    # or set GHOST_OBSIDIAN_VAULT_DIR
+#   interval: "30s"                  # sync poll cadence (Go duration, e.g. "1m")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,7 +120,8 @@ func Load() (*Config, error) {
 	// koanf's _ → . transformer would map e.g. GHOST_SERVER_AUTH_TOKEN
 	// to server.auth.token instead of server.auth_token.
 	envOverrides := map[string]string{
-		"GHOST_SERVER_AUTH_TOKEN": "server.auth_token",
+		"GHOST_SERVER_AUTH_TOKEN":  "server.auth_token",
+		"GHOST_OBSIDIAN_VAULT_DIR": "obsidian.vault_dir",
 	}
 	for envKey, koanfKey := range envOverrides {
 		if val := os.Getenv(envKey); val != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Embedding  EmbeddingConfig  `koanf:"embedding"`
 	Reflection ReflectionConfig `koanf:"reflection"`
 	Linking    LinkingConfig    `koanf:"linking"`
+	Obsidian   ObsidianConfig   `koanf:"obsidian"`
 }
 
 // APIConfig holds Claude API settings (used by reflection only).
@@ -59,15 +60,23 @@ type LinkingConfig struct {
 	Threshold float64 `koanf:"threshold"`
 }
 
+// ObsidianConfig controls the Obsidian vault mirror (ghost obsidian export|sync).
+type ObsidianConfig struct {
+	VaultDir string `koanf:"vault_dir"` // empty = ~/Documents/GhostVault, resolved by the CLI
+	Interval string `koanf:"interval"`  // sync poll cadence, time.ParseDuration format
+}
+
 // defaults is the base layer — always loaded first.
 var defaults = map[string]interface{}{
-	"embedding.enabled":          true,
-	"embedding.ollama_url":       "http://localhost:11434",
-	"embedding.model":            "nomic-embed-text:v1.5",
-	"embedding.dimensions":       768,
-	"reflection.backend":         "auto",
-	"linking.enabled":            true,
-	"linking.threshold":          0.70,
+	"embedding.enabled":    true,
+	"embedding.ollama_url": "http://localhost:11434",
+	"embedding.model":      "nomic-embed-text:v1.5",
+	"embedding.dimensions": 768,
+	"reflection.backend":   "auto",
+	"linking.enabled":      true,
+	"linking.threshold":    0.70,
+	"obsidian.vault_dir":   "",
+	"obsidian.interval":    "30s",
 }
 
 // Load reads configuration with layered precedence.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -300,6 +300,20 @@ func TestLinkingDefaults(t *testing.T) {
 }
 
 func TestObsidianDefaults(t *testing.T) {
+	// Isolate from the host: a real ~/.config/ghost/config.yaml or a
+	// GHOST_OBSIDIAN_* var in the environment would otherwise skew defaults.
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	// t.Setenv can't unset, and the env provider has no empty-value guard, so
+	// clearing to "" would itself override the default. Save and restore.
+	for _, key := range []string{"GHOST_OBSIDIAN_VAULT_DIR", "GHOST_OBSIDIAN_INTERVAL"} {
+		if old, ok := os.LookupEnv(key); ok {
+			_ = os.Unsetenv(key)
+			t.Cleanup(func() { _ = os.Setenv(key, old) })
+		}
+	}
+
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -276,3 +276,16 @@ func TestLinkingDefaults(t *testing.T) {
 		t.Errorf("expected linking.threshold=0.70, got %f", cfg.Linking.Threshold)
 	}
 }
+
+func TestObsidianDefaults(t *testing.T) {
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Obsidian.VaultDir != "" {
+		t.Errorf("VaultDir default = %q, want empty (resolved at use time)", cfg.Obsidian.VaultDir)
+	}
+	if cfg.Obsidian.Interval != "30s" {
+		t.Errorf("Interval default = %q, want 30s", cfg.Obsidian.Interval)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -129,6 +129,28 @@ func TestLoad_ExplicitEnvOverrides(t *testing.T) {
 	}
 }
 
+func TestLoad_ObsidianVaultDirEnvOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Clear interfering env vars.
+	unsetEnvVars(t, []string{"GHOST_API_KEY", "ANTHROPIC_API_KEY"})
+
+	// The generic _ → . transformer would map this to obsidian.vault.dir,
+	// missing the obsidian.vault_dir key — the explicit override must catch it.
+	t.Setenv("GHOST_OBSIDIAN_VAULT_DIR", "/vaults/ghost")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Obsidian.VaultDir != "/vaults/ghost" {
+		t.Errorf("obsidian.vault_dir = %q, want %q (explicit env override)", cfg.Obsidian.VaultDir, "/vaults/ghost")
+	}
+}
+
 func TestLoad_YAMLFileOverride(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)

--- a/internal/obsidian/export.go
+++ b/internal/obsidian/export.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strings"
 
 	"github.com/wcatz/ghost/internal/memory"
 )
@@ -43,6 +44,7 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 	if projectFilter != "" && !matched {
 		return fmt.Errorf("no project matches %q", projectFilter)
 	}
+	folders := folderNames(selected)
 
 	// Pass 1: load all memories, build the global id → filename map for wikilinks.
 	type projData struct {
@@ -57,11 +59,10 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 		if err != nil {
 			return fmt.Errorf("load memories for %s: %w", p.ID, err)
 		}
-		folder := folderName(p)
 		for _, m := range mems {
 			fileFor[m.ID] = fileName(m)
 		}
-		data = append(data, projData{p: p, folder: folder, memories: mems})
+		data = append(data, projData{p: p, folder: folders[p.ID], memories: mems})
 	}
 
 	// Pass 2: render + diff-write + collect keep-set, then prune.
@@ -142,4 +143,23 @@ func folderName(p memory.Project) string {
 		}
 	}
 	return string(b)
+}
+
+// folderNames maps each project ID to a distinct vault folder. Folders that
+// collide case-insensitively (APFS/NTFS would silently merge "Foo" and
+// "foo") are disambiguated: the first keeps its plain name, later collisions
+// get "-" + the first 8 chars of the project ID appended. Input order is
+// deterministic (ListProjects sorts by name), so folder assignment is too.
+func folderNames(projects []memory.Project) map[string]string {
+	folders := make(map[string]string, len(projects))
+	seen := make(map[string]bool, len(projects))
+	for _, p := range projects {
+		f := folderName(p)
+		if seen[strings.ToLower(f)] {
+			f += "-" + id8(p.ID)
+		}
+		seen[strings.ToLower(f)] = true
+		folders[p.ID] = f
+	}
+	return folders
 }

--- a/internal/obsidian/export.go
+++ b/internal/obsidian/export.go
@@ -150,6 +150,11 @@ func folderName(p memory.Project) string {
 // "foo") are disambiguated: the first keeps its plain name, later collisions
 // get "-" + the first 8 chars of the project ID appended. Input order is
 // deterministic (ListProjects sorts by name), so folder assignment is too.
+//
+// Containment: a computed folder of ".", "..", "", or anything failing
+// filepath.IsLocal is replaced with "project-" + id8 — the write path must
+// stay under the vault root no matter what the projects table holds, just
+// like prune's subtree guard on the delete path.
 func folderNames(projects []memory.Project) map[string]string {
 	folders := make(map[string]string, len(projects))
 	seen := make(map[string]bool, len(projects))
@@ -157,6 +162,9 @@ func folderNames(projects []memory.Project) map[string]string {
 		f := folderName(p)
 		if seen[strings.ToLower(f)] {
 			f += "-" + id8(p.ID)
+		}
+		if f == "." || f == ".." || f == "" || !filepath.IsLocal(f) {
+			f = "project-" + id8(p.ID)
 		}
 		seen[strings.ToLower(f)] = true
 		folders[p.ID] = f

--- a/internal/obsidian/export.go
+++ b/internal/obsidian/export.go
@@ -173,8 +173,8 @@ func folderName(p memory.Project) string {
 	}
 	var b []rune
 	for _, r := range name {
-		switch {
-		case r == '/' || r == '\\' || r == ':' || r == 0:
+		switch r {
+		case '/', '\\', ':', 0:
 			b = append(b, '-')
 		default:
 			b = append(b, r)

--- a/internal/obsidian/export.go
+++ b/internal/obsidian/export.go
@@ -90,8 +90,11 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 		data = append(data, projData{p: p, folder: folders[p.ID], memories: mems, trunc: trunc})
 	}
 
-	// Pass 2: render + diff-write + collect keep-set, then prune.
-	keep := make(map[string]bool)
+	// Pass 2: render + diff-write + collect keep-set, then prune. keep maps
+	// each entity's ghost_id to its canonical basename this pass: content
+	// edits rewrite a memory in place (same ID, new slug), so prune must
+	// drop old-slug files even though their ghost_id is still live.
+	keep := make(map[string]string)
 	var subtrees []string
 	written, skipped := 0, 0
 	for _, d := range data {
@@ -100,7 +103,7 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 			if err != nil {
 				return fmt.Errorf("links for %s: %w", m.ID, err)
 			}
-			keep[m.ID] = true
+			keep[m.ID] = fileFor[m.ID]
 			w, err := writeIfChanged(filepath.Join(vaultDir, d.folder, "Memories", fileFor[m.ID]), renderMemory(m, links, fileFor))
 			if err != nil {
 				return err
@@ -116,8 +119,9 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 			d.trunc = true
 		}
 		for _, dec := range decisions {
-			keep[dec.ID] = true
-			w, err := writeIfChanged(filepath.Join(vaultDir, d.folder, "Decisions", fileNameFor(dec.Title, dec.ID)), renderDecision(dec))
+			name := fileNameFor(dec.Title, dec.ID)
+			keep[dec.ID] = name
+			w, err := writeIfChanged(filepath.Join(vaultDir, d.folder, "Decisions", name), renderDecision(dec))
 			if err != nil {
 				return err
 			}
@@ -132,8 +136,9 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 			d.trunc = true
 		}
 		for _, tk := range tasks {
-			keep[tk.ID] = true
-			w, err := writeIfChanged(filepath.Join(vaultDir, d.folder, "Tasks", fileNameFor(tk.Title, tk.ID)), renderTask(tk))
+			name := fileNameFor(tk.Title, tk.ID)
+			keep[tk.ID] = name
+			w, err := writeIfChanged(filepath.Join(vaultDir, d.folder, "Tasks", name), renderTask(tk))
 			if err != nil {
 				return err
 			}

--- a/internal/obsidian/export.go
+++ b/internal/obsidian/export.go
@@ -12,11 +12,24 @@ import (
 
 const globalProjectID = "_global"
 
+// exportListLimit caps each per-project list query. A list that comes back
+// exactly this long may have been truncated by the store — see truncated.
+const exportListLimit = 100000
+
 // Exporter mirrors the store into a vault directory.
 type Exporter struct {
 	Store  *memory.Store
 	Logger *slog.Logger
+
+	// listLimit overrides exportListLimit when > 0 (tests only).
+	listLimit int
 }
+
+// truncated reports whether a list of n rows fetched with the given limit
+// may have been silently cut off by the store. A truncated list would leave
+// entities out of the keep-set, and prune would then delete their notes —
+// so callers must treat the project as unsafe to prune.
+func truncated(n, limit int) bool { return n >= limit }
 
 // Export performs one full deterministic mirror pass. projectFilter of ""
 // mirrors everything; otherwise that project (by ID or name) plus _global.
@@ -24,10 +37,18 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 	if err := ensureVault(vaultDir); err != nil {
 		return err
 	}
+	limit := e.listLimit
+	if limit <= 0 {
+		limit = exportListLimit
+	}
 	projects, err := e.Store.ListProjects(ctx)
 	if err != nil {
 		return fmt.Errorf("list projects: %w", err)
 	}
+	// Folder assignment is computed over ALL projects before filtering so a
+	// --project run places notes in exactly the same folder as an unfiltered
+	// run, regardless of case-collision disambiguation.
+	folders := folderNames(projects)
 	selected := projects[:0:0]
 	matched := false
 	for _, p := range projects {
@@ -44,25 +65,29 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 	if projectFilter != "" && !matched {
 		return fmt.Errorf("no project matches %q", projectFilter)
 	}
-	folders := folderNames(selected)
 
 	// Pass 1: load all memories, build the global id → filename map for wikilinks.
 	type projData struct {
 		p        memory.Project
 		folder   string
 		memories []memory.Memory
+		trunc    bool // some list hit the limit — pruning this folder is unsafe
 	}
 	var data []projData
 	fileFor := make(map[string]string)
 	for _, p := range selected {
-		mems, err := e.Store.GetAll(ctx, p.ID, 100000)
+		mems, err := e.Store.GetAll(ctx, p.ID, limit)
 		if err != nil {
 			return fmt.Errorf("load memories for %s: %w", p.ID, err)
+		}
+		trunc := truncated(len(mems), limit)
+		if trunc {
+			e.Logger.Warn("obsidian export: list truncated at limit", "project", p.ID, "kind", "memories", "limit", limit)
 		}
 		for _, m := range mems {
 			fileFor[m.ID] = fileName(m)
 		}
-		data = append(data, projData{p: p, folder: folders[p.ID], memories: mems})
+		data = append(data, projData{p: p, folder: folders[p.ID], memories: mems, trunc: trunc})
 	}
 
 	// Pass 2: render + diff-write + collect keep-set, then prune.
@@ -70,7 +95,6 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 	var subtrees []string
 	written, skipped := 0, 0
 	for _, d := range data {
-		subtrees = append(subtrees, d.folder)
 		for _, m := range d.memories {
 			links, err := e.Store.GetLinks(ctx, m.ID)
 			if err != nil {
@@ -83,9 +107,13 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 			}
 			count(&written, &skipped, w)
 		}
-		decisions, err := e.Store.ListDecisions(ctx, d.p.ID, "", 100000)
+		decisions, err := e.Store.ListDecisions(ctx, d.p.ID, "", limit)
 		if err != nil {
 			return fmt.Errorf("decisions for %s: %w", d.p.ID, err)
+		}
+		if truncated(len(decisions), limit) {
+			e.Logger.Warn("obsidian export: list truncated at limit", "project", d.p.ID, "kind", "decisions", "limit", limit)
+			d.trunc = true
 		}
 		for _, dec := range decisions {
 			keep[dec.ID] = true
@@ -95,9 +123,13 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 			}
 			count(&written, &skipped, w)
 		}
-		tasks, err := e.Store.ListTasks(ctx, d.p.ID, "", 100000)
+		tasks, err := e.Store.ListTasks(ctx, d.p.ID, "", limit)
 		if err != nil {
 			return fmt.Errorf("tasks for %s: %w", d.p.ID, err)
+		}
+		if truncated(len(tasks), limit) {
+			e.Logger.Warn("obsidian export: list truncated at limit", "project", d.p.ID, "kind", "tasks", "limit", limit)
+			d.trunc = true
 		}
 		for _, tk := range tasks {
 			keep[tk.ID] = true
@@ -106,6 +138,12 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 				return err
 			}
 			count(&written, &skipped, w)
+		}
+		// A truncated list means the keep-set is incomplete for this project:
+		// pruning would delete notes for entities we simply didn't see. Skip
+		// the folder — stale extras beat silent deletions.
+		if !d.trunc {
+			subtrees = append(subtrees, d.folder)
 		}
 	}
 	if err := prune(vaultDir, subtrees, keep); err != nil {
@@ -155,6 +193,9 @@ func folderName(p memory.Project) string {
 // filepath.IsLocal is replaced with "project-" + id8 — the write path must
 // stay under the vault root no matter what the projects table holds, just
 // like prune's subtree guard on the delete path.
+//
+// id8 collisions are astronomically unlikely (hex UUIDs); a collision would
+// merge folders/files in the vault without any data loss in the store.
 func folderNames(projects []memory.Project) map[string]string {
 	folders := make(map[string]string, len(projects))
 	seen := make(map[string]bool, len(projects))

--- a/internal/obsidian/export.go
+++ b/internal/obsidian/export.go
@@ -1,0 +1,145 @@
+package obsidian
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+const globalProjectID = "_global"
+
+// Exporter mirrors the store into a vault directory.
+type Exporter struct {
+	Store  *memory.Store
+	Logger *slog.Logger
+}
+
+// Export performs one full deterministic mirror pass. projectFilter of ""
+// mirrors everything; otherwise that project (by ID or name) plus _global.
+func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) error {
+	if err := ensureVault(vaultDir); err != nil {
+		return err
+	}
+	projects, err := e.Store.ListProjects(ctx)
+	if err != nil {
+		return fmt.Errorf("list projects: %w", err)
+	}
+	selected := projects[:0:0]
+	matched := false
+	for _, p := range projects {
+		switch {
+		case projectFilter == "":
+			selected = append(selected, p)
+		case p.ID == projectFilter || p.Name == projectFilter:
+			selected = append(selected, p)
+			matched = true
+		case p.ID == globalProjectID:
+			selected = append(selected, p) // globals ride along with any filter
+		}
+	}
+	if projectFilter != "" && !matched {
+		return fmt.Errorf("no project matches %q", projectFilter)
+	}
+
+	// Pass 1: load all memories, build the global id → filename map for wikilinks.
+	type projData struct {
+		p        memory.Project
+		folder   string
+		memories []memory.Memory
+	}
+	var data []projData
+	fileFor := make(map[string]string)
+	for _, p := range selected {
+		mems, err := e.Store.GetAll(ctx, p.ID, 100000)
+		if err != nil {
+			return fmt.Errorf("load memories for %s: %w", p.ID, err)
+		}
+		folder := folderName(p)
+		for _, m := range mems {
+			fileFor[m.ID] = fileName(m)
+		}
+		data = append(data, projData{p: p, folder: folder, memories: mems})
+	}
+
+	// Pass 2: render + diff-write + collect keep-set, then prune.
+	keep := make(map[string]bool)
+	var subtrees []string
+	written, skipped := 0, 0
+	for _, d := range data {
+		subtrees = append(subtrees, d.folder)
+		for _, m := range d.memories {
+			links, err := e.Store.GetLinks(ctx, m.ID)
+			if err != nil {
+				return fmt.Errorf("links for %s: %w", m.ID, err)
+			}
+			keep[m.ID] = true
+			w, err := writeIfChanged(filepath.Join(vaultDir, d.folder, "Memories", fileFor[m.ID]), renderMemory(m, links, fileFor))
+			if err != nil {
+				return err
+			}
+			count(&written, &skipped, w)
+		}
+		decisions, err := e.Store.ListDecisions(ctx, d.p.ID, "", 100000)
+		if err != nil {
+			return fmt.Errorf("decisions for %s: %w", d.p.ID, err)
+		}
+		for _, dec := range decisions {
+			keep[dec.ID] = true
+			w, err := writeIfChanged(filepath.Join(vaultDir, d.folder, "Decisions", fileNameFor(dec.Title, dec.ID)), renderDecision(dec))
+			if err != nil {
+				return err
+			}
+			count(&written, &skipped, w)
+		}
+		tasks, err := e.Store.ListTasks(ctx, d.p.ID, "", 100000)
+		if err != nil {
+			return fmt.Errorf("tasks for %s: %w", d.p.ID, err)
+		}
+		for _, tk := range tasks {
+			keep[tk.ID] = true
+			w, err := writeIfChanged(filepath.Join(vaultDir, d.folder, "Tasks", fileNameFor(tk.Title, tk.ID)), renderTask(tk))
+			if err != nil {
+				return err
+			}
+			count(&written, &skipped, w)
+		}
+	}
+	if err := prune(vaultDir, subtrees, keep); err != nil {
+		return err
+	}
+	e.Logger.Info("obsidian export complete", "projects", len(data), "written", written, "unchanged", skipped)
+	return nil
+}
+
+func count(written, skipped *int, wrote bool) {
+	if wrote {
+		*written++
+	} else {
+		*skipped++
+	}
+}
+
+// folderName maps a project to its vault folder. _global gets "Global";
+// otherwise the sanitized project name (fallback: ID).
+func folderName(p memory.Project) string {
+	if p.ID == globalProjectID {
+		return "Global"
+	}
+	name := p.Name
+	if name == "" {
+		name = p.ID
+	}
+	var b []rune
+	for _, r := range name {
+		switch {
+		case r == '/' || r == '\\' || r == ':' || r == 0:
+			b = append(b, '-')
+		default:
+			b = append(b, r)
+		}
+	}
+	return string(b)
+}

--- a/internal/obsidian/export_test.go
+++ b/internal/obsidian/export_test.go
@@ -102,6 +102,59 @@ func TestExport(t *testing.T) {
 	}
 }
 
+// TestExportPrunesRenamedSlug: Upsert strengthens a memory by rewriting its
+// content in place (same ID) — when the leading words change, the next export
+// writes the note under a new slug. The old-slug file carries the same
+// ghost_id, so a keep-set of bare IDs would retain it forever; prune must
+// also match the canonical basename.
+func TestExportPrunesRenamedSlug(t *testing.T) {
+	db, err := memory.OpenDB(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := memory.NewStore(db, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := context.Background()
+	if err := store.EnsureProject(ctx, "ghost", "/tmp/ghost", "ghost"); err != nil {
+		t.Fatal(err)
+	}
+	id, err := store.Create(ctx, "ghost", memory.Memory{Category: "fact", Content: "original opening words drive the slug", Importance: 0.8, Source: "mcp"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	old := filepath.Join(vault, "ghost", "Memories", "original-opening-words-drive-the-slug-"+id[:8]+".md")
+	if _, err := os.Stat(old); err != nil {
+		t.Fatalf("expected note at old slug: %v", err)
+	}
+
+	// In-place content rewrite, same ID — the direct-SQL equivalent of
+	// Upsert's strengthen path (store.go: UPDATE memories SET content ...).
+	if _, err := db.ExecContext(ctx, `UPDATE memories SET content = ? WHERE id = ?`, "different phrasing appears here", id); err != nil {
+		t.Fatal(err)
+	}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatalf("second export: %v", err)
+	}
+
+	notes, _ := filepath.Glob(filepath.Join(vault, "ghost", "Memories", "*.md"))
+	if len(notes) != 1 {
+		t.Fatalf("renamed memory must leave exactly 1 note, got %d: %v", len(notes), notes)
+	}
+	want := "different-phrasing-appears-here-" + id[:8] + ".md"
+	if filepath.Base(notes[0]) != want {
+		t.Errorf("surviving note = %s, want %s", filepath.Base(notes[0]), want)
+	}
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Errorf("old-slug note must be pruned after rename: %v", err)
+	}
+}
+
 func TestExportProjectFilter(t *testing.T) {
 	store := seedStore(t)
 	ctx := context.Background()

--- a/internal/obsidian/export_test.go
+++ b/internal/obsidian/export_test.go
@@ -191,6 +191,56 @@ func TestExportReclaimsOrphanedTmpFiles(t *testing.T) {
 	}
 }
 
+func TestFolderNamesContainment(t *testing.T) {
+	ps := []memory.Project{
+		{ID: "aaaaaaaa-0000-0000-0000-000000000000", Name: ".."},
+		{ID: "bbbbbbbb-0000-0000-0000-000000000000", Name: "."},
+	}
+	got := folderNames(ps)
+	if got[ps[0].ID] != "project-aaaaaaaa" {
+		t.Errorf("'..' project must map to project-<id8>, got %q", got[ps[0].ID])
+	}
+	if got[ps[1].ID] != "project-bbbbbbbb" {
+		t.Errorf("'.' project must map to project-<id8>, got %q", got[ps[1].ID])
+	}
+}
+
+func TestExportContainsPathologicalProjectNames(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	if err := store.EnsureProject(ctx, "dotdot", "/tmp/dotdot", ".."); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(ctx, "dotdot", memory.Memory{Category: "fact", Content: "Escape attempt fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := t.TempDir()
+	vault := filepath.Join(parent, "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	// Nothing may land outside the vault root.
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "vault" {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("vault parent gained entries beyond the vault itself: %v", names)
+	}
+	// The pathological project lands in a contained project-<id8> folder.
+	notes, _ := filepath.Glob(filepath.Join(vault, "project-dotdot", "Memories", "*.md"))
+	if len(notes) != 1 {
+		t.Fatalf("want 1 note under project-dotdot/Memories, got %d", len(notes))
+	}
+}
+
 func TestFolderNamesCaseCollision(t *testing.T) {
 	ps := []memory.Project{
 		{ID: "aaaaaaaa-0000-0000-0000-000000000000", Name: "Foo"},

--- a/internal/obsidian/export_test.go
+++ b/internal/obsidian/export_test.go
@@ -1,0 +1,154 @@
+package obsidian
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+func seedStore(t *testing.T) *memory.Store {
+	t.Helper()
+	db, err := memory.OpenDB(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := memory.NewStore(db, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	t.Cleanup(func() { store.Close() })
+	ctx := context.Background()
+	if err := store.EnsureProject(ctx, "ghost", "/tmp/ghost", "ghost"); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func TestExport(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	id1, _ := store.Create(ctx, "ghost", memory.Memory{Category: "gotcha", Content: "First fact about embedding", Importance: 0.8, Source: "mcp"})
+	id2, _ := store.Create(ctx, "ghost", memory.Memory{Category: "fact", Content: "Second fact about linking", Importance: 0.7, Source: "mcp"})
+	if err := store.CreateLink(ctx, id1, id2, "related", 0.83, "auto"); err != nil {
+		t.Fatal(err)
+	}
+	store.RecordDecision(ctx, "ghost", "Use SQLite", "SQLite it is", "zero infra", []string{"Postgres"}, nil)
+	store.CreateTask(ctx, "ghost", "Ship mirror", "Build it", 2)
+	// A registered project with no entities must not produce a vault folder.
+	if err := store.EnsureProject(ctx, "empty", "/tmp/empty", "empty"); err != nil {
+		t.Fatal(err)
+	}
+
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	// RecordDecision also saves a companion memory (decisions.go: "creates a
+	// decision and also saves it as a memory"), so 2 explicit Creates + 1
+	// companion = 3 memory notes.
+	mems, _ := filepath.Glob(filepath.Join(vault, "ghost", "Memories", "*.md"))
+	if len(mems) != 3 {
+		t.Fatalf("want 3 memory notes (2 created + 1 decision companion), got %d", len(mems))
+	}
+	// Wikilink present between the two linked memories.
+	var all strings.Builder
+	for _, f := range mems {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		all.Write(data)
+	}
+	if !strings.Contains(all.String(), "[[") {
+		t.Error("expected a wikilink in Related section")
+	}
+	decs, _ := filepath.Glob(filepath.Join(vault, "ghost", "Decisions", "*.md"))
+	tasks, _ := filepath.Glob(filepath.Join(vault, "ghost", "Tasks", "*.md"))
+	if len(decs) != 1 || len(tasks) != 1 {
+		t.Fatalf("want 1 decision + 1 task, got %d + %d", len(decs), len(tasks))
+	}
+	if _, err := os.Stat(filepath.Join(vault, "empty")); !os.IsNotExist(err) {
+		t.Errorf("project with no entities should not get a folder: %v", err)
+	}
+
+	// Idempotence: second export rewrites nothing (mtimes unchanged).
+	before, _ := os.Stat(mems[0])
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.Stat(mems[0])
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Error("unchanged note was rewritten")
+	}
+
+	// Deletion prunes.
+	if err := store.Delete(ctx, id2); err != nil {
+		t.Fatal(err)
+	}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+	mems2, _ := filepath.Glob(filepath.Join(vault, "ghost", "Memories", "*.md"))
+	if len(mems2) >= len(mems) {
+		t.Errorf("deleted memory's note should be pruned: %d -> %d", len(mems), len(mems2))
+	}
+}
+
+func TestExportProjectFilter(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	if err := store.EnsureProject(ctx, "widget", "/tmp/widget", "widget"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.EnsureProject(ctx, "_global", "_global", "global"); err != nil {
+		t.Fatal(err)
+	}
+	ghostID, _ := store.Create(ctx, "ghost", memory.Memory{Category: "fact", Content: "Ghost project fact", Importance: 0.8, Source: "mcp"})
+	widgetID, _ := store.Create(ctx, "widget", memory.Memory{Category: "fact", Content: "Widget project fact", Importance: 0.8, Source: "mcp"})
+	if _, err := store.Create(ctx, "_global", memory.Memory{Category: "preference", Content: "Global preference fact", Importance: 0.9, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateLink(ctx, ghostID, widgetID, "related", 0.9, "auto"); err != nil {
+		t.Fatal(err)
+	}
+
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	if err := ex.Export(ctx, vault, "ghost"); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	// Filtered project exported; _global rides along under "Global".
+	ghostMems, _ := filepath.Glob(filepath.Join(vault, "ghost", "Memories", "*.md"))
+	if len(ghostMems) != 1 {
+		t.Fatalf("want 1 ghost memory note, got %d", len(ghostMems))
+	}
+	globalMems, _ := filepath.Glob(filepath.Join(vault, "Global", "Memories", "*.md"))
+	if len(globalMems) != 1 {
+		t.Fatalf("want 1 global memory note under Global/, got %d", len(globalMems))
+	}
+	// Filtered-out project gets no folder at all.
+	if _, err := os.Stat(filepath.Join(vault, "widget")); !os.IsNotExist(err) {
+		t.Errorf("filtered-out project should not get a folder: %v", err)
+	}
+	// Link to a filtered-out memory degrades to a plain short ID, not a wikilink.
+	data, err := os.ReadFile(ghostMems[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "[[") {
+		t.Error("link to filtered-out project should not be a wikilink")
+	}
+	if !strings.Contains(string(data), widgetID[:8]) {
+		t.Error("link to filtered-out project should degrade to its short ID")
+	}
+
+	// _global alone never satisfies a filter.
+	if err := ex.Export(ctx, vault, "no-such-project"); err == nil {
+		t.Error("expected error for unmatched project filter")
+	}
+}

--- a/internal/obsidian/export_test.go
+++ b/internal/obsidian/export_test.go
@@ -152,3 +152,58 @@ func TestExportProjectFilter(t *testing.T) {
 		t.Error("expected error for unmatched project filter")
 	}
 }
+
+func TestExportReclaimsOrphanedTmpFiles(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	if _, err := store.Create(ctx, "ghost", memory.Memory{Category: "fact", Content: "Some fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a crashed write: orphaned tmp inside a managed subtree.
+	stray := filepath.Join(vault, "ghost", "Memories", "foo.md.ghost-tmp")
+	if err := os.WriteFile(stray, []byte("orphan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A tmp file outside managed subtrees is none of our business.
+	outside := filepath.Join(vault, "user-notes", "bar.md.ghost-tmp")
+	if err := os.MkdirAll(filepath.Dir(outside), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outside, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stray); !os.IsNotExist(err) {
+		t.Errorf("orphaned tmp in managed subtree should be reclaimed: %v", err)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Errorf("tmp file outside managed subtrees must survive: %v", err)
+	}
+}
+
+func TestFolderNamesCaseCollision(t *testing.T) {
+	ps := []memory.Project{
+		{ID: "aaaaaaaa-0000-0000-0000-000000000000", Name: "Foo"},
+		{ID: "bbbbbbbb-0000-0000-0000-000000000000", Name: "foo"},
+	}
+	got := folderNames(ps)
+	if got[ps[0].ID] != "Foo" {
+		t.Errorf("first project keeps its plain folder, got %q", got[ps[0].ID])
+	}
+	if got[ps[1].ID] != "foo-bbbbbbbb" {
+		t.Errorf("later case-colliding project gets -id8 suffix, got %q", got[ps[1].ID])
+	}
+	if strings.EqualFold(got[ps[0].ID], got[ps[1].ID]) {
+		t.Errorf("folders still collide case-insensitively: %q vs %q", got[ps[0].ID], got[ps[1].ID])
+	}
+}

--- a/internal/obsidian/export_test.go
+++ b/internal/obsidian/export_test.go
@@ -18,7 +18,7 @@ func seedStore(t *testing.T) *memory.Store {
 		t.Fatal(err)
 	}
 	store := memory.NewStore(db, slog.New(slog.NewTextHandler(os.Stderr, nil)))
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 	ctx := context.Background()
 	if err := store.EnsureProject(ctx, "ghost", "/tmp/ghost", "ghost"); err != nil {
 		t.Fatal(err)
@@ -34,8 +34,12 @@ func TestExport(t *testing.T) {
 	if err := store.CreateLink(ctx, id1, id2, "related", 0.83, "auto"); err != nil {
 		t.Fatal(err)
 	}
-	store.RecordDecision(ctx, "ghost", "Use SQLite", "SQLite it is", "zero infra", []string{"Postgres"}, nil)
-	store.CreateTask(ctx, "ghost", "Ship mirror", "Build it", 2)
+	if _, err := store.RecordDecision(ctx, "ghost", "Use SQLite", "SQLite it is", "zero infra", []string{"Postgres"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateTask(ctx, "ghost", "Ship mirror", "Build it", 2); err != nil {
+		t.Fatal(err)
+	}
 	// A registered project with no entities must not produce a vault folder.
 	if err := store.EnsureProject(ctx, "empty", "/tmp/empty", "empty"); err != nil {
 		t.Fatal(err)

--- a/internal/obsidian/export_test.go
+++ b/internal/obsidian/export_test.go
@@ -153,6 +153,37 @@ func TestExportProjectFilter(t *testing.T) {
 	}
 }
 
+func TestExportFilterInvariantFolders(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	// Two projects whose names collide case-insensitively. ListProjects
+	// orders by name ("Foo" < "foo" in BINARY), so unfiltered folder
+	// assignment is Foo -> "Foo", foo -> "foo-bbbb-foo".
+	if err := store.EnsureProject(ctx, "aaaa-foo-upper", "/tmp/Foo", "Foo"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.EnsureProject(ctx, "bbbb-foo-lower", "/tmp/foo", "foo"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(ctx, "bbbb-foo-lower", memory.Memory{Category: "fact", Content: "Lowercase foo fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A filtered run must place notes in the SAME folder as an unfiltered
+	// run: folder assignment is computed over all projects, not the
+	// filtered subset, so case-collision suffixes do not flip with --project.
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	if err := ex.Export(ctx, vault, "foo"); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	notes, _ := filepath.Glob(filepath.Join(vault, "foo-bbbb-foo", "Memories", "*.md"))
+	if len(notes) != 1 {
+		got, _ := filepath.Glob(filepath.Join(vault, "*", "Memories", "*.md"))
+		t.Fatalf("filtered export must use the filter-invariant folder foo-bbbb-foo, notes found at %v", got)
+	}
+}
+
 func TestExportReclaimsOrphanedTmpFiles(t *testing.T) {
 	store := seedStore(t)
 	ctx := context.Background()
@@ -188,6 +219,58 @@ func TestExportReclaimsOrphanedTmpFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(outside); err != nil {
 		t.Errorf("tmp file outside managed subtrees must survive: %v", err)
+	}
+}
+
+func TestTruncated(t *testing.T) {
+	for _, tc := range []struct {
+		n, limit int
+		want     bool
+	}{
+		{0, 100000, false},
+		{99999, 100000, false},
+		{100000, 100000, true},
+	} {
+		if got := truncated(tc.n, tc.limit); got != tc.want {
+			t.Errorf("truncated(%d, %d) = %v, want %v", tc.n, tc.limit, got, tc.want)
+		}
+	}
+}
+
+func TestExportSkipsPruneOnTruncatedList(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	for _, m := range []memory.Memory{
+		{Category: "fact", Content: "Highest importance fact", Importance: 0.9, Source: "mcp"},
+		{Category: "fact", Content: "Middle importance fact", Importance: 0.8, Source: "mcp"},
+		{Category: "fact", Content: "Lowest importance fact", Importance: 0.7, Source: "mcp"},
+	} {
+		if _, err := store.Create(ctx, "ghost", m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	notes, _ := filepath.Glob(filepath.Join(vault, "ghost", "Memories", "*.md"))
+	if len(notes) != 3 {
+		t.Fatalf("want 3 notes after full export, got %d", len(notes))
+	}
+
+	// With the list limit squeezed below the row count, GetAll returns
+	// exactly limit rows — the export must treat the project as possibly
+	// truncated and skip pruning its folder: the third note survives even
+	// though it is absent from the keep-set (stale beats deleted).
+	limited := &Exporter{Store: store, Logger: slog.Default(), listLimit: 2}
+	if err := limited.Export(ctx, vault, ""); err != nil {
+		t.Fatalf("limited export: %v", err)
+	}
+	notes, _ = filepath.Glob(filepath.Join(vault, "ghost", "Memories", "*.md"))
+	if len(notes) != 3 {
+		t.Fatalf("truncated export must not prune: want 3 surviving notes, got %d", len(notes))
 	}
 }
 

--- a/internal/obsidian/render.go
+++ b/internal/obsidian/render.go
@@ -13,6 +13,8 @@ const banner = "> [!info] Mirrored from Ghost — edits here are not synced back
 
 // slug derives a stable-ish, readable filename prefix from the first ~6
 // content words: lowercase, alnum-only, dash-joined, max 40 chars.
+// Entirely non-ASCII content degrades to "note"; identity is preserved by
+// the id8 suffix in the filename.
 func slug(content string) string {
 	var words []string
 	for _, w := range strings.Fields(strings.ToLower(content)) {
@@ -58,6 +60,10 @@ func date(ts string) string {
 }
 
 // fm writes one frontmatter line.
+//
+// Invariant for every renderer: ghost_id must be the first frontmatter key;
+// values written before it must never contain newlines — prune's hasGhostID
+// scan depends on it.
 func fm(b *strings.Builder, key, val string) {
 	fmt.Fprintf(b, "%s: %s\n", key, val)
 }

--- a/internal/obsidian/render.go
+++ b/internal/obsidian/render.go
@@ -61,11 +61,35 @@ func date(ts string) string {
 
 // fm writes one frontmatter line.
 //
-// Invariant for every renderer: ghost_id must be the first frontmatter key;
-// values written before it must never contain newlines — prune's hasGhostID
-// scan depends on it.
+// Invariant for every renderer: ghost_id must be the first frontmatter key
+// and every value must occupy exactly one line — prune's hasGhostID scan
+// depends on it. Newlines are therefore flattened to spaces unconditionally,
+// and a value that could change its line's YAML shape (mapping separator,
+// flow/comment/quote characters) is double-quoted with escaping. Fixed-
+// vocabulary values — category, source, and task/decision status are all
+// CHECK-constrained in memory/schema.go — plus type, numerics, bools, and
+// dates never trip the quoting and are emitted plain, byte-identical to
+// before this hardening.
 func fm(b *strings.Builder, key, val string) {
+	val = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ").Replace(val)
+	if strings.Contains(val, ": ") || strings.Contains(val, `"`) || strings.Contains(val, "#") ||
+		strings.HasPrefix(val, "[") || strings.HasPrefix(val, "{") {
+		val = `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(val) + `"`
+	}
 	fmt.Fprintf(b, "%s: %s\n", key, val)
+}
+
+// fmTags writes the tags flow list. Each tag is sanitized — structural flow
+// characters and newlines stripped — so the composed [a, b] value is safe to
+// emit plain; routing it through fm would quote the leading '[' and Obsidian
+// would stop reading it as a list.
+func fmTags(b *strings.Builder, tags []string) {
+	clean := make([]string, 0, len(tags))
+	tagSanitizer := strings.NewReplacer("[", "", "]", "", ",", "", `"`, "", "\r", " ", "\n", " ")
+	for _, tag := range tags {
+		clean = append(clean, tagSanitizer.Replace(tag))
+	}
+	fmt.Fprintf(b, "tags: [%s]\n", strings.Join(clean, ", "))
 }
 
 func renderMemory(m memory.Memory, links []memory.Link, fileFor map[string]string) string {
@@ -77,7 +101,7 @@ func renderMemory(m memory.Memory, links []memory.Link, fileFor map[string]strin
 	fm(&b, "importance", strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.2f", m.Importance), "0"), "."))
 	fm(&b, "pinned", fmt.Sprintf("%v", m.Pinned))
 	fm(&b, "project", m.ProjectID)
-	fm(&b, "tags", "["+strings.Join(m.Tags, ", ")+"]")
+	fmTags(&b, m.Tags)
 	fm(&b, "created", date(m.CreatedAt))
 	fm(&b, "updated", date(m.UpdatedAt))
 	fm(&b, "source", m.Source)
@@ -113,7 +137,7 @@ func renderDecision(d memory.Decision) string {
 	fm(&b, "type", "decision")
 	fm(&b, "status", d.Status)
 	fm(&b, "project", d.ProjectID)
-	fm(&b, "tags", "["+strings.Join(d.Tags, ", ")+"]")
+	fmTags(&b, d.Tags)
 	fm(&b, "created", date(d.CreatedAt))
 	fm(&b, "updated", date(d.UpdatedAt))
 	b.WriteString("---\n")

--- a/internal/obsidian/render.go
+++ b/internal/obsidian/render.go
@@ -1,0 +1,98 @@
+// Package obsidian mirrors Ghost's store into a plain-Markdown folder that
+// Obsidian reads natively. Strictly one-way: Ghost → vault.
+package obsidian
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+const banner = "> [!info] Mirrored from Ghost — edits here are not synced back.\n"
+
+// slug derives a stable-ish, readable filename prefix from the first ~6
+// content words: lowercase, alnum-only, dash-joined, max 40 chars.
+func slug(content string) string {
+	var words []string
+	for _, w := range strings.Fields(strings.ToLower(content)) {
+		var b strings.Builder
+		for _, r := range w {
+			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+				b.WriteRune(r)
+			}
+		}
+		if b.Len() > 0 {
+			words = append(words, b.String())
+		}
+		if len(words) == 6 {
+			break
+		}
+	}
+	s := strings.Join(words, "-")
+	if len(s) > 40 {
+		s = strings.TrimRight(s[:40], "-")
+	}
+	if s == "" {
+		return "note"
+	}
+	return s
+}
+
+func id8(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
+func fileName(m memory.Memory) string {
+	return slug(m.Content) + "-" + id8(m.ID) + ".md"
+}
+
+func date(ts string) string {
+	if len(ts) >= 10 {
+		return ts[:10]
+	}
+	return ts
+}
+
+// fm writes one frontmatter line.
+func fm(b *strings.Builder, key, val string) {
+	fmt.Fprintf(b, "%s: %s\n", key, val)
+}
+
+func renderMemory(m memory.Memory, links []memory.Link, fileFor map[string]string) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	fm(&b, "ghost_id", m.ID)
+	fm(&b, "type", "memory")
+	fm(&b, "category", m.Category)
+	fm(&b, "importance", strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.2f", m.Importance), "0"), "."))
+	fm(&b, "pinned", fmt.Sprintf("%v", m.Pinned))
+	fm(&b, "project", m.ProjectID)
+	fm(&b, "tags", "["+strings.Join(m.Tags, ", ")+"]")
+	fm(&b, "created", date(m.CreatedAt))
+	fm(&b, "updated", date(m.UpdatedAt))
+	fm(&b, "source", m.Source)
+	b.WriteString("---\n")
+	b.WriteString(banner)
+	b.WriteString("\n")
+	b.WriteString(strings.TrimRight(m.Content, "\n"))
+	b.WriteString("\n")
+	if len(links) > 0 {
+		b.WriteString("\n## Related\n")
+		for _, l := range links {
+			other := l.TargetID
+			if other == m.ID {
+				other = l.SourceID
+			}
+			if f, ok := fileFor[other]; ok {
+				fmt.Fprintf(&b, "- [[%s]] — %s (%.2f)\n", strings.TrimSuffix(f, ".md"), l.Relation, l.Strength)
+			} else {
+				fmt.Fprintf(&b, "- %s — %s (%.2f)\n", id8(other), l.Relation, l.Strength)
+			}
+		}
+	}
+	return b.String()
+}

--- a/internal/obsidian/render.go
+++ b/internal/obsidian/render.go
@@ -96,3 +96,53 @@ func renderMemory(m memory.Memory, links []memory.Link, fileFor map[string]strin
 	}
 	return b.String()
 }
+
+// fileNameFor derives a filename for a decision or task from its title.
+func fileNameFor(title, id string) string { return slug(title) + "-" + id8(id) + ".md" }
+
+func renderDecision(d memory.Decision) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	fm(&b, "ghost_id", d.ID)
+	fm(&b, "type", "decision")
+	fm(&b, "status", d.Status)
+	fm(&b, "project", d.ProjectID)
+	fm(&b, "tags", "["+strings.Join(d.Tags, ", ")+"]")
+	fm(&b, "created", date(d.CreatedAt))
+	fm(&b, "updated", date(d.UpdatedAt))
+	b.WriteString("---\n")
+	b.WriteString(banner)
+	fmt.Fprintf(&b, "\n# %s\n\n%s\n", d.Title, strings.TrimRight(d.Decision, "\n"))
+	if d.Rationale != "" {
+		fmt.Fprintf(&b, "\n## Rationale\n\n%s\n", strings.TrimRight(d.Rationale, "\n"))
+	}
+	if len(d.Alternatives) > 0 {
+		b.WriteString("\n## Alternatives\n\n")
+		for _, a := range d.Alternatives {
+			fmt.Fprintf(&b, "- %s\n", a)
+		}
+	}
+	return b.String()
+}
+
+func renderTask(t memory.Task) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	fm(&b, "ghost_id", t.ID)
+	fm(&b, "type", "task")
+	fm(&b, "status", t.Status)
+	fm(&b, "priority", fmt.Sprintf("%d", t.Priority))
+	fm(&b, "project", t.ProjectID)
+	fm(&b, "created", date(t.CreatedAt))
+	fm(&b, "updated", date(t.UpdatedAt))
+	b.WriteString("---\n")
+	b.WriteString(banner)
+	fmt.Fprintf(&b, "\n# %s\n", t.Title)
+	if t.Description != "" {
+		fmt.Fprintf(&b, "\n%s\n", strings.TrimRight(t.Description, "\n"))
+	}
+	if t.Notes != "" {
+		fmt.Fprintf(&b, "\n## Notes\n\n%s\n", strings.TrimRight(t.Notes, "\n"))
+	}
+	return b.String()
+}

--- a/internal/obsidian/render_test.go
+++ b/internal/obsidian/render_test.go
@@ -70,6 +70,53 @@ Embedding backfill bug: ticker only swept seen projects.
 	}
 }
 
+// TestRenderHostileFrontmatter: frontmatter values must occupy exactly one
+// line per key (the ghost_id-first invariant prune depends on) and must not
+// change the YAML shape of their line, whatever the store holds. The note
+// body is not frontmatter and stays verbatim.
+func TestRenderHostileFrontmatter(t *testing.T) {
+	m := memory.Memory{
+		ID: "bad0000011223344", ProjectID: "evil: proj\nect", Category: "fact",
+		Content:    "Body content: stays verbatim, even with colons\nand newlines.",
+		Importance: 0.7, Source: "mcp",
+		Tags:      []string{"a,b", "x[0]", `quo"te`},
+		CreatedAt: "2026-07-10 10:00:00", UpdatedAt: "2026-07-10 10:00:00",
+	}
+	got := renderMemory(m, nil, nil)
+
+	if !strings.HasPrefix(got, "---\nghost_id: bad0000011223344\n") {
+		t.Errorf("ghost_id must stay the first frontmatter line:\n%s", got)
+	}
+	// Newline flattened to a space, then quoted because of ": ".
+	if !strings.Contains(got, "project: \"evil: proj ect\"\n") {
+		t.Errorf("hostile project value must be flattened and quoted:\n%s", got)
+	}
+	// Tags: structural flow characters stripped before the join.
+	if !strings.Contains(got, "tags: [ab, x0, quote]\n") {
+		t.Errorf("hostile tags must be sanitized:\n%s", got)
+	}
+	// Body is untouched.
+	if !strings.Contains(got, "Body content: stays verbatim, even with colons\nand newlines.") {
+		t.Errorf("note body must stay verbatim:\n%s", got)
+	}
+	// Block integrity: exactly the 10 emitted keys between the fences, one
+	// line each — nothing injected a stray line.
+	rest := strings.TrimPrefix(got, "---\n")
+	end := strings.Index(rest, "\n---\n")
+	if end < 0 {
+		t.Fatalf("no closing frontmatter fence:\n%s", got)
+	}
+	lines := strings.Split(rest[:end], "\n")
+	if len(lines) != 10 {
+		t.Errorf("frontmatter must hold exactly 10 single-line keys, got %d:\n%s", len(lines), rest[:end])
+	}
+	for _, line := range lines {
+		if !strings.Contains(line, ": ") {
+			t.Errorf("frontmatter line lost its key-value shape: %q", line)
+		}
+	}
+}
+
 func TestRenderDecision(t *testing.T) {
 	d := memory.Decision{
 		ID: "dec0000011223344", ProjectID: "ghost", Title: "Use SQLite",

--- a/internal/obsidian/render_test.go
+++ b/internal/obsidian/render_test.go
@@ -66,3 +66,34 @@ Embedding backfill bug: ticker only swept seen projects.
 		t.Errorf("missing target should render short ID without wikilink:\n%s", got2)
 	}
 }
+
+func TestRenderDecision(t *testing.T) {
+	d := memory.Decision{
+		ID: "dec0000011223344", ProjectID: "ghost", Title: "Use SQLite",
+		Decision: "SQLite over Postgres.", Rationale: "Zero infra.",
+		Alternatives: []string{"Postgres", "BoltDB"}, Status: "active",
+		Tags: []string{"storage"}, CreatedAt: "2026-07-01 08:00:00", UpdatedAt: "2026-07-01 08:00:00",
+	}
+	got := renderDecision(d)
+	for _, want := range []string{"ghost_id: dec0000011223344", "type: decision", "status: active",
+		"# Use SQLite", "SQLite over Postgres.", "## Rationale", "Zero infra.", "## Alternatives", "- Postgres"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("renderDecision missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderTask(t *testing.T) {
+	tk := memory.Task{
+		ID: "task000011223344", ProjectID: "ghost", Title: "Ship mirror",
+		Description: "Build it.", Status: "active", Priority: 2,
+		CreatedAt: "2026-07-10 10:00:00", UpdatedAt: "2026-07-10 10:00:00",
+	}
+	got := renderTask(tk)
+	for _, want := range []string{"ghost_id: task000011223344", "type: task", "status: active",
+		"priority: 2", "# Ship mirror", "Build it."} {
+		if !strings.Contains(got, want) {
+			t.Errorf("renderTask missing %q in:\n%s", want, got)
+		}
+	}
+}

--- a/internal/obsidian/render_test.go
+++ b/internal/obsidian/render_test.go
@@ -13,6 +13,9 @@ func TestSlug(t *testing.T) {
 		{"???", "note"},
 		{"", "note"},
 		{"UPPER case Words here now okay more words ignored", "upper-case-words-here-now-okay"},
+		// Join exceeds 40 chars and the cut lands on a dash: truncate, then
+		// trim the trailing dash (result is 39 chars).
+		{"abcdefghi abcdefghi abcdefghi abcdefghi abcdefghi", "abcdefghi-abcdefghi-abcdefghi-abcdefghi"},
 	}
 	for _, c := range cases {
 		if got := slug(c.in); got != c.want {
@@ -75,6 +78,10 @@ func TestRenderDecision(t *testing.T) {
 		Tags: []string{"storage"}, CreatedAt: "2026-07-01 08:00:00", UpdatedAt: "2026-07-01 08:00:00",
 	}
 	got := renderDecision(d)
+	// ghost_id must be the first frontmatter key — prune's hasGhostID depends on it.
+	if !strings.HasPrefix(got, "---\nghost_id: dec0000011223344\n") {
+		t.Errorf("renderDecision must open with ghost_id-first frontmatter:\n%s", got)
+	}
 	for _, want := range []string{"ghost_id: dec0000011223344", "type: decision", "status: active",
 		"# Use SQLite", "SQLite over Postgres.", "## Rationale", "Zero infra.", "## Alternatives", "- Postgres"} {
 		if !strings.Contains(got, want) {
@@ -90,6 +97,10 @@ func TestRenderTask(t *testing.T) {
 		CreatedAt: "2026-07-10 10:00:00", UpdatedAt: "2026-07-10 10:00:00",
 	}
 	got := renderTask(tk)
+	// ghost_id must be the first frontmatter key — prune's hasGhostID depends on it.
+	if !strings.HasPrefix(got, "---\nghost_id: task000011223344\n") {
+		t.Errorf("renderTask must open with ghost_id-first frontmatter:\n%s", got)
+	}
 	for _, want := range []string{"ghost_id: task000011223344", "type: task", "status: active",
 		"priority: 2", "# Ship mirror", "Build it."} {
 		if !strings.Contains(got, want) {

--- a/internal/obsidian/render_test.go
+++ b/internal/obsidian/render_test.go
@@ -1,0 +1,68 @@
+package obsidian
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+func TestSlug(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Embedding backfill bug (fixed in v0.9.3): the worker's ticker", "embedding-backfill-bug-fixed-in-v093"},
+		{"???", "note"},
+		{"", "note"},
+		{"UPPER case Words here now okay more words ignored", "upper-case-words-here-now-okay"},
+	}
+	for _, c := range cases {
+		if got := slug(c.in); got != c.want {
+			t.Errorf("slug(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFileName(t *testing.T) {
+	m := memory.Memory{ID: "74a37cba00112233", Content: "Embedding backfill bug"}
+	if got := fileName(m); got != "embedding-backfill-bug-74a37cba.md" {
+		t.Errorf("fileName = %q", got)
+	}
+}
+
+func TestRenderMemory(t *testing.T) {
+	m := memory.Memory{
+		ID: "74a37cba00112233", ProjectID: "ghost", Category: "gotcha",
+		Content:    "Embedding backfill bug: ticker only swept seen projects.",
+		Importance: 0.8, Source: "mcp", Tags: []string{"embedding", "backfill"},
+		Pinned: false, CreatedAt: "2026-07-06 12:00:00", UpdatedAt: "2026-07-08 09:30:00",
+	}
+	links := []memory.Link{{SourceID: m.ID, TargetID: "beef000011223344", Relation: "related", Strength: 0.83}}
+	fileFor := map[string]string{"beef000011223344": "other-note-beef0000.md"}
+	got := renderMemory(m, links, fileFor)
+	want := `---
+ghost_id: 74a37cba00112233
+type: memory
+category: gotcha
+importance: 0.8
+pinned: false
+project: ghost
+tags: [embedding, backfill]
+created: 2026-07-06
+updated: 2026-07-08
+source: mcp
+---
+> [!info] Mirrored from Ghost — edits here are not synced back.
+
+Embedding backfill bug: ticker only swept seen projects.
+
+## Related
+- [[other-note-beef0000]] — related (0.83)
+`
+	if got != want {
+		t.Errorf("renderMemory mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	// Link target absent from fileFor → plain ID, no broken wikilink.
+	got2 := renderMemory(m, links, map[string]string{})
+	if strings.Contains(got2, "[[") || !strings.Contains(got2, "beef0000") {
+		t.Errorf("missing target should render short ID without wikilink:\n%s", got2)
+	}
+}

--- a/internal/obsidian/sync.go
+++ b/internal/obsidian/sync.go
@@ -1,0 +1,12 @@
+package obsidian
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// Sync re-exports whenever the database changes, polling PRAGMA data_version.
+func Sync(ctx context.Context, ex *Exporter, db *sql.DB, vaultDir, projectFilter string, interval time.Duration) error {
+	return ex.Export(ctx, vaultDir, projectFilter) // poll loop lands in the next commit
+}

--- a/internal/obsidian/sync.go
+++ b/internal/obsidian/sync.go
@@ -35,10 +35,13 @@ func Sync(ctx context.Context, ex *Exporter, db *sql.DB, vaultDir, projectFilter
 			if v == last {
 				continue
 			}
-			last = v
 			if err := ex.Export(ctx, vaultDir, projectFilter); err != nil {
-				ex.Logger.Warn("obsidian sync: export failed, will retry next change", "error", err)
+				// Baseline stays put: the version delta persists, so the
+				// next tick retries without needing another commit.
+				ex.Logger.Warn("obsidian sync: export failed, will retry next tick", "error", err)
+				continue
 			}
+			last = v
 		}
 	}
 }

--- a/internal/obsidian/sync.go
+++ b/internal/obsidian/sync.go
@@ -6,7 +6,47 @@ import (
 	"time"
 )
 
-// Sync re-exports whenever the database changes, polling PRAGMA data_version.
+// Sync mirrors once immediately, then re-exports whenever PRAGMA data_version
+// reports a commit from another connection. Runs until ctx is cancelled.
+//
+// data_version is per-connection, so db must be pinned to a single pooled
+// connection (SetMaxOpenConns(1) — memory.OpenDB does this) for polls to
+// compare against a stable baseline.
 func Sync(ctx context.Context, ex *Exporter, db *sql.DB, vaultDir, projectFilter string, interval time.Duration) error {
-	return ex.Export(ctx, vaultDir, projectFilter) // poll loop lands in the next commit
+	if err := ex.Export(ctx, vaultDir, projectFilter); err != nil {
+		return err
+	}
+	last, err := dataVersion(ctx, db)
+	if err != nil {
+		return err
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			v, err := dataVersion(ctx, db)
+			if err != nil {
+				ex.Logger.Warn("obsidian sync: data_version poll failed", "error", err)
+				continue
+			}
+			if v == last {
+				continue
+			}
+			last = v
+			if err := ex.Export(ctx, vaultDir, projectFilter); err != nil {
+				ex.Logger.Warn("obsidian sync: export failed, will retry next change", "error", err)
+			}
+		}
+	}
+}
+
+// dataVersion reads SQLite's per-connection change counter; it increments
+// whenever another connection commits to the database.
+func dataVersion(ctx context.Context, db *sql.DB) (int64, error) {
+	var v int64
+	err := db.QueryRowContext(ctx, "PRAGMA data_version").Scan(&v)
+	return v, err
 }

--- a/internal/obsidian/sync_test.go
+++ b/internal/obsidian/sync_test.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -62,6 +64,93 @@ func TestSyncDetectsChange(t *testing.T) {
 	if err := <-done; err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("sync returned: %v", err)
 	}
+}
+
+// TestSyncRetriesFailedExport: a failed export must not advance the
+// data_version baseline — the loop retries on the next tick without
+// requiring another DB commit.
+func TestSyncRetriesFailedExport(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "ghost.db")
+
+	writeDB, err := memory.OpenDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	writeStore := memory.NewStore(writeDB, logger)
+	defer writeStore.Close() //nolint:errcheck
+	ctx := context.Background()
+	if err := writeStore.EnsureProject(ctx, "p1", "/tmp/p1", "p1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeStore.Create(ctx, "p1", memory.Memory{Category: "fact", Content: "first memory", Importance: 0.7, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+
+	readDB, err := memory.OpenDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readStore := memory.NewStore(readDB, logger)
+	defer readStore.Close() //nolint:errcheck
+
+	var buf logBuffer
+	vault := filepath.Join(dir, "vault")
+	ex := &Exporter{Store: readStore, Logger: slog.New(slog.NewTextHandler(&buf, nil))}
+
+	syncCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() { done <- Sync(syncCtx, ex, readDB, vault, "", 50*time.Millisecond) }()
+
+	waitFor(t, func() bool {
+		m, _ := filepath.Glob(filepath.Join(vault, "p1", "Memories", "*.md"))
+		return len(m) == 1
+	})
+
+	// Break the vault: ensureVault's ReadDir fails on an unreadable root.
+	if err := os.Chmod(vault, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(vault, 0o755) }) // let TempDir removal succeed on failure paths
+
+	// A commit from the other connection triggers an export that fails.
+	if _, err := writeStore.Create(ctx, "p1", memory.Memory{Category: "fact", Content: "second memory", Importance: 0.7, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, func() bool { return strings.Contains(buf.String(), "export failed") })
+
+	// Fix the vault. NO further commits: only a retained baseline retries.
+	if err := os.Chmod(vault, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, func() bool {
+		m, _ := filepath.Glob(filepath.Join(vault, "p1", "Memories", "*.md"))
+		return len(m) == 2
+	})
+	cancel()
+	if err := <-done; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("sync returned: %v", err)
+	}
+}
+
+// logBuffer is a goroutine-safe io.Writer for capturing slog output from the
+// Sync goroutine while the test polls it.
+type logBuffer struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (l *logBuffer) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.b.Write(p)
+}
+
+func (l *logBuffer) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.b.String()
 }
 
 func waitFor(t *testing.T, cond func() bool) {

--- a/internal/obsidian/sync_test.go
+++ b/internal/obsidian/sync_test.go
@@ -1,0 +1,77 @@
+package obsidian
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+func TestSyncDetectsChange(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "ghost.db")
+
+	writeDB, err := memory.OpenDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	writeStore := memory.NewStore(writeDB, logger)
+	defer writeStore.Close() //nolint:errcheck
+	ctx := context.Background()
+	if err := writeStore.EnsureProject(ctx, "p1", "/tmp/p1", "p1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeStore.Create(ctx, "p1", memory.Memory{Category: "fact", Content: "first memory", Importance: 0.7, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+
+	readDB, err := memory.OpenDB(dbPath) // second connection: sees writeDB's commits as data_version bumps
+	if err != nil {
+		t.Fatal(err)
+	}
+	readStore := memory.NewStore(readDB, logger)
+	defer readStore.Close() //nolint:errcheck
+
+	vault := filepath.Join(dir, "vault")
+	ex := &Exporter{Store: readStore, Logger: logger}
+
+	syncCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() { done <- Sync(syncCtx, ex, readDB, vault, "", 50*time.Millisecond) }()
+
+	// Initial export happens immediately.
+	waitFor(t, func() bool {
+		m, _ := filepath.Glob(filepath.Join(vault, "p1", "Memories", "*.md"))
+		return len(m) == 1
+	})
+	// A write from the other connection is picked up within a few ticks.
+	if _, err := writeStore.Create(ctx, "p1", memory.Memory{Category: "fact", Content: "second memory", Importance: 0.7, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, func() bool {
+		m, _ := filepath.Glob(filepath.Join(vault, "p1", "Memories", "*.md"))
+		return len(m) == 2
+	})
+	cancel()
+	if err := <-done; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("sync returned: %v", err)
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("condition not met within 5s")
+}

--- a/internal/obsidian/vault.go
+++ b/internal/obsidian/vault.go
@@ -1,0 +1,95 @@
+package obsidian
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const markerName = ".ghost-vault"
+
+// ensureVault prepares dir as a Ghost-managed mirror target. Fresh or empty
+// dirs are initialized with the marker; a non-empty dir without the marker is
+// refused — Ghost never adopts a folder it didn't create.
+func ensureVault(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create vault dir: %w", err)
+		}
+		entries = nil
+	} else if err != nil {
+		return fmt.Errorf("read vault dir: %w", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, markerName)); err == nil {
+		return nil
+	}
+	if len(entries) > 0 {
+		return fmt.Errorf("%s exists, is not empty, and has no %s marker — refusing to manage it (use a fresh directory)", dir, markerName)
+	}
+	return os.WriteFile(filepath.Join(dir, markerName), []byte(`{"schema_version":1}`+"\n"), 0o644)
+}
+
+// writeIfChanged writes content atomically (temp+rename), skipping the write
+// when the file already has identical content — no mtime churn.
+func writeIfChanged(path, content string) (bool, error) {
+	if existing, err := os.ReadFile(path); err == nil && string(existing) == content {
+		return false, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return false, err
+	}
+	tmp := path + ".ghost-tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		return false, err
+	}
+	return true, os.Rename(tmp, path)
+}
+
+// hasGhostID reports whether a file's frontmatter carries a ghost_id key —
+// the only files prune may touch. Only the frontmatter block (between the
+// opening and closing --- lines) is scanned, never the note body.
+func hasGhostID(path string) (string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) == 0 || lines[0] != "---" {
+		return "", false
+	}
+	for _, line := range lines[1:] {
+		if line == "---" { // end of frontmatter — stop before the body
+			break
+		}
+		if id, ok := strings.CutPrefix(line, "ghost_id: "); ok {
+			return strings.TrimSpace(id), true
+		}
+	}
+	return "", false
+}
+
+// prune deletes Ghost-managed .md files under the given vault subtrees whose
+// ghost_id is not in keep. All three guards from the spec are enforced.
+func prune(root string, subtrees []string, keep map[string]bool) error {
+	if _, err := os.Stat(filepath.Join(root, markerName)); err != nil {
+		return fmt.Errorf("refusing to prune: %s marker not found in %s", markerName, root)
+	}
+	for _, sub := range subtrees {
+		base := filepath.Join(root, sub)
+		err := filepath.WalkDir(base, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
+				return nil //nolint:nilerr // missing subtree is fine
+			}
+			if id, ok := hasGhostID(path); ok && !keep[id] {
+				return os.Remove(path)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/obsidian/vault.go
+++ b/internal/obsidian/vault.go
@@ -72,6 +72,8 @@ func hasGhostID(path string) (string, bool) {
 
 // prune deletes Ghost-managed .md files under the given vault subtrees whose
 // ghost_id is not in keep. All three guards from the spec are enforced.
+// Orphaned *.ghost-tmp files (left by a crashed writeIfChanged) are also
+// reclaimed — but only inside the managed subtrees, behind the marker guard.
 func prune(root string, subtrees []string, keep map[string]bool) error {
 	if _, err := os.Stat(filepath.Join(root, markerName)); err != nil {
 		return fmt.Errorf("refusing to prune: %s marker not found in %s", markerName, root)
@@ -88,7 +90,13 @@ func prune(root string, subtrees []string, keep map[string]bool) error {
 				}
 				return err
 			}
-			if d.IsDir() || !strings.HasSuffix(path, ".md") {
+			if d.IsDir() {
+				return nil
+			}
+			if strings.HasSuffix(path, ".ghost-tmp") {
+				return os.Remove(path) // orphan from a crashed write
+			}
+			if !strings.HasSuffix(path, ".md") {
 				return nil
 			}
 			if id, ok := hasGhostID(path); ok && !keep[id] {

--- a/internal/obsidian/vault.go
+++ b/internal/obsidian/vault.go
@@ -77,10 +77,19 @@ func prune(root string, subtrees []string, keep map[string]bool) error {
 		return fmt.Errorf("refusing to prune: %s marker not found in %s", markerName, root)
 	}
 	for _, sub := range subtrees {
+		if !filepath.IsLocal(sub) {
+			return fmt.Errorf("refusing to prune: subtree %q escapes vault root", sub)
+		}
 		base := filepath.Join(root, sub)
 		err := filepath.WalkDir(base, func(path string, d os.DirEntry, err error) error {
-			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
-				return nil //nolint:nilerr // missing subtree is fine
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil // missing subtree is fine
+				}
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".md") {
+				return nil
 			}
 			if id, ok := hasGhostID(path); ok && !keep[id] {
 				return os.Remove(path)

--- a/internal/obsidian/vault.go
+++ b/internal/obsidian/vault.go
@@ -71,10 +71,13 @@ func hasGhostID(path string) (string, bool) {
 }
 
 // prune deletes Ghost-managed .md files under the given vault subtrees whose
-// ghost_id is not in keep. All three guards from the spec are enforced.
-// Orphaned *.ghost-tmp files (left by a crashed writeIfChanged) are also
-// reclaimed — but only inside the managed subtrees, behind the marker guard.
-func prune(root string, subtrees []string, keep map[string]bool) error {
+// ghost_id is not in keep, or whose basename is not the canonical one for
+// that ghost_id (a content edit renamed the slug — the old-slug file is
+// stale even though its ID is still live). All three guards from the spec
+// are enforced. Orphaned *.ghost-tmp files (left by a crashed writeIfChanged)
+// are also reclaimed — but only inside the managed subtrees, behind the
+// marker guard.
+func prune(root string, subtrees []string, keep map[string]string) error {
 	if _, err := os.Stat(filepath.Join(root, markerName)); err != nil {
 		return fmt.Errorf("refusing to prune: %s marker not found in %s", markerName, root)
 	}
@@ -99,8 +102,10 @@ func prune(root string, subtrees []string, keep map[string]bool) error {
 			if !strings.HasSuffix(path, ".md") {
 				return nil
 			}
-			if id, ok := hasGhostID(path); ok && !keep[id] {
-				return os.Remove(path)
+			if id, ok := hasGhostID(path); ok {
+				if canonical, kept := keep[id]; !kept || canonical != filepath.Base(path) {
+					return os.Remove(path)
+				}
 			}
 			return nil
 		})

--- a/internal/obsidian/vault_test.go
+++ b/internal/obsidian/vault_test.go
@@ -1,0 +1,68 @@
+package obsidian
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureVault(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "vault")
+	if err := ensureVault(dir); err != nil { // fresh dir: created + marker
+		t.Fatalf("fresh: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, markerName)); err != nil {
+		t.Fatalf("marker missing: %v", err)
+	}
+	if err := ensureVault(dir); err != nil { // idempotent
+		t.Fatalf("second run: %v", err)
+	}
+	// Existing non-empty dir WITHOUT marker → refuse.
+	dirty := t.TempDir()
+	os.WriteFile(filepath.Join(dirty, "keep.md"), []byte("user file"), 0o644)
+	if err := ensureVault(dirty); err == nil {
+		t.Fatal("expected refusal for unmarked non-empty dir")
+	}
+}
+
+func TestWriteIfChanged(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "a.md")
+	w1, err := writeIfChanged(p, "hello")
+	if err != nil || !w1 {
+		t.Fatalf("first write: wrote=%v err=%v", w1, err)
+	}
+	w2, _ := writeIfChanged(p, "hello")
+	if w2 {
+		t.Fatal("unchanged content must not rewrite")
+	}
+	w3, _ := writeIfChanged(p, "hello2")
+	if !w3 {
+		t.Fatal("changed content must rewrite")
+	}
+}
+
+func TestPrune(t *testing.T) {
+	root := t.TempDir()
+	os.WriteFile(filepath.Join(root, markerName), []byte(`{"schema_version":1}`), 0o644)
+	sub := filepath.Join(root, "proj", "Memories")
+	os.MkdirAll(sub, 0o755)
+	ghostNote := "---\nghost_id: dead0000\ntype: memory\n---\nbody\n"
+	os.WriteFile(filepath.Join(sub, "stale-dead0000.md"), []byte(ghostNote), 0o644)
+	os.WriteFile(filepath.Join(sub, "user-note.md"), []byte("no frontmatter"), 0o644)
+
+	if err := prune(root, []string{"proj"}, map[string]bool{}); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sub, "stale-dead0000.md")); !os.IsNotExist(err) {
+		t.Fatal("stale ghost note should be deleted")
+	}
+	if _, err := os.Stat(filepath.Join(sub, "user-note.md")); err != nil {
+		t.Fatal("user note must survive")
+	}
+	// No marker → prune must refuse to delete anything.
+	os.Remove(filepath.Join(root, markerName))
+	os.WriteFile(filepath.Join(sub, "stale2-beef0000.md"), []byte(ghostNote), 0o644)
+	if err := prune(root, []string{"proj"}, map[string]bool{}); err == nil {
+		t.Fatal("prune without marker must error")
+	}
+}

--- a/internal/obsidian/vault_test.go
+++ b/internal/obsidian/vault_test.go
@@ -66,7 +66,7 @@ func TestPrune(t *testing.T) {
 	mustWrite(t, filepath.Join(sub, "stale-dead0000.md"), ghostNote)
 	mustWrite(t, filepath.Join(sub, "user-note.md"), "no frontmatter")
 
-	if err := prune(root, []string{"proj"}, map[string]bool{}); err != nil {
+	if err := prune(root, []string{"proj"}, map[string]string{}); err != nil {
 		t.Fatalf("prune: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(sub, "stale-dead0000.md")); !os.IsNotExist(err) {
@@ -80,7 +80,7 @@ func TestPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 	mustWrite(t, filepath.Join(sub, "stale2-beef0000.md"), ghostNote)
-	if err := prune(root, []string{"proj"}, map[string]bool{}); err == nil {
+	if err := prune(root, []string{"proj"}, map[string]string{}); err == nil {
 		t.Fatal("prune without marker must error")
 	}
 }
@@ -102,12 +102,18 @@ func TestPruneGuards(t *testing.T) {
 	// (c) body-only ghost_id: no frontmatter, ghost_id appears after a --- in the body.
 	bodyOnly := "just a user note\n\n---\nghost_id: feed0000\n"
 	mustWrite(t, filepath.Join(sub, "body-only.md"), bodyOnly)
+	// (d) slug rename: same live ghost_id under a non-canonical basename is stale.
+	renamed := "---\nghost_id: cafe0000\ntype: memory\n---\nbody\n"
+	mustWrite(t, filepath.Join(sub, "old-slug-cafe0000.md"), renamed)
 
-	if err := prune(root, []string{"proj"}, map[string]bool{"cafe0000": true}); err != nil {
+	if err := prune(root, []string{"proj"}, map[string]string{"cafe0000": "kept-cafe0000.md"}); err != nil {
 		t.Fatalf("prune: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(sub, "kept-cafe0000.md")); err != nil {
 		t.Fatal("note with ghost_id in keep must survive")
+	}
+	if _, err := os.Stat(filepath.Join(sub, "old-slug-cafe0000.md")); !os.IsNotExist(err) {
+		t.Fatal("live ghost_id under a stale (renamed) basename must be pruned")
 	}
 	if _, err := os.Stat(filepath.Join(other, "stale-dead0000.md")); err != nil {
 		t.Fatal("ghost note outside the pruned subtrees must survive")
@@ -128,14 +134,14 @@ func TestPruneRefusesEscapingSubtree(t *testing.T) {
 	victim := filepath.Join(escape, "victim-dead0000.md")
 	mustWrite(t, victim, "---\nghost_id: dead0000\ntype: memory\n---\nbody\n")
 
-	if err := prune(root, []string{"../escape"}, map[string]bool{}); err == nil {
+	if err := prune(root, []string{"../escape"}, map[string]string{}); err == nil {
 		t.Fatal("prune with escaping subtree must error")
 	}
 	if _, err := os.Stat(victim); err != nil {
 		t.Fatal("file outside the vault root must survive an escaping-subtree prune attempt")
 	}
 	// Absolute paths must be refused too.
-	if err := prune(root, []string{escape}, map[string]bool{}); err == nil {
+	if err := prune(root, []string{escape}, map[string]string{}); err == nil {
 		t.Fatal("prune with absolute subtree must error")
 	}
 	if _, err := os.Stat(victim); err != nil {

--- a/internal/obsidian/vault_test.go
+++ b/internal/obsidian/vault_test.go
@@ -66,3 +66,61 @@ func TestPrune(t *testing.T) {
 		t.Fatal("prune without marker must error")
 	}
 }
+
+func TestPruneGuards(t *testing.T) {
+	root := t.TempDir()
+	os.WriteFile(filepath.Join(root, markerName), []byte(`{"schema_version":1}`), 0o644)
+	sub := filepath.Join(root, "proj", "Memories")
+	os.MkdirAll(sub, 0o755)
+
+	// (a) keep-set retention: ghost_id in keep must survive.
+	keptNote := "---\nghost_id: cafe0000\ntype: memory\n---\nbody\n"
+	os.WriteFile(filepath.Join(sub, "kept-cafe0000.md"), []byte(keptNote), 0o644)
+	// (b) subtree scoping: ghost note outside the pruned subtrees must survive.
+	other := filepath.Join(root, "otherproj", "Memories")
+	os.MkdirAll(other, 0o755)
+	staleNote := "---\nghost_id: dead0000\ntype: memory\n---\nbody\n"
+	os.WriteFile(filepath.Join(other, "stale-dead0000.md"), []byte(staleNote), 0o644)
+	// (c) body-only ghost_id: no frontmatter, ghost_id appears after a --- in the body.
+	bodyOnly := "just a user note\n\n---\nghost_id: feed0000\n"
+	os.WriteFile(filepath.Join(sub, "body-only.md"), []byte(bodyOnly), 0o644)
+
+	if err := prune(root, []string{"proj"}, map[string]bool{"cafe0000": true}); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sub, "kept-cafe0000.md")); err != nil {
+		t.Fatal("note with ghost_id in keep must survive")
+	}
+	if _, err := os.Stat(filepath.Join(other, "stale-dead0000.md")); err != nil {
+		t.Fatal("ghost note outside the pruned subtrees must survive")
+	}
+	if _, err := os.Stat(filepath.Join(sub, "body-only.md")); err != nil {
+		t.Fatal("file with ghost_id only in the body must survive")
+	}
+}
+
+func TestPruneRefusesEscapingSubtree(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "vault")
+	os.MkdirAll(root, 0o755)
+	os.WriteFile(filepath.Join(root, markerName), []byte(`{"schema_version":1}`), 0o644)
+	// Sibling dir outside the vault holding a ghost-looking note.
+	escape := filepath.Join(parent, "escape")
+	os.MkdirAll(escape, 0o755)
+	victim := filepath.Join(escape, "victim-dead0000.md")
+	os.WriteFile(victim, []byte("---\nghost_id: dead0000\ntype: memory\n---\nbody\n"), 0o644)
+
+	if err := prune(root, []string{"../escape"}, map[string]bool{}); err == nil {
+		t.Fatal("prune with escaping subtree must error")
+	}
+	if _, err := os.Stat(victim); err != nil {
+		t.Fatal("file outside the vault root must survive an escaping-subtree prune attempt")
+	}
+	// Absolute paths must be refused too.
+	if err := prune(root, []string{escape}, map[string]bool{}); err == nil {
+		t.Fatal("prune with absolute subtree must error")
+	}
+	if _, err := os.Stat(victim); err != nil {
+		t.Fatal("file outside the vault root must survive an absolute-subtree prune attempt")
+	}
+}

--- a/internal/obsidian/vault_test.go
+++ b/internal/obsidian/vault_test.go
@@ -6,6 +6,22 @@ import (
 	"testing"
 )
 
+// mustWrite / mustMkdirAll fail the test on setup errors instead of
+// silently proceeding against a half-built fixture.
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustMkdirAll(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestEnsureVault(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "vault")
 	if err := ensureVault(dir); err != nil { // fresh dir: created + marker
@@ -19,7 +35,7 @@ func TestEnsureVault(t *testing.T) {
 	}
 	// Existing non-empty dir WITHOUT marker → refuse.
 	dirty := t.TempDir()
-	os.WriteFile(filepath.Join(dirty, "keep.md"), []byte("user file"), 0o644)
+	mustWrite(t, filepath.Join(dirty, "keep.md"), "user file")
 	if err := ensureVault(dirty); err == nil {
 		t.Fatal("expected refusal for unmarked non-empty dir")
 	}
@@ -43,12 +59,12 @@ func TestWriteIfChanged(t *testing.T) {
 
 func TestPrune(t *testing.T) {
 	root := t.TempDir()
-	os.WriteFile(filepath.Join(root, markerName), []byte(`{"schema_version":1}`), 0o644)
+	mustWrite(t, filepath.Join(root, markerName), `{"schema_version":1}`)
 	sub := filepath.Join(root, "proj", "Memories")
-	os.MkdirAll(sub, 0o755)
+	mustMkdirAll(t, sub)
 	ghostNote := "---\nghost_id: dead0000\ntype: memory\n---\nbody\n"
-	os.WriteFile(filepath.Join(sub, "stale-dead0000.md"), []byte(ghostNote), 0o644)
-	os.WriteFile(filepath.Join(sub, "user-note.md"), []byte("no frontmatter"), 0o644)
+	mustWrite(t, filepath.Join(sub, "stale-dead0000.md"), ghostNote)
+	mustWrite(t, filepath.Join(sub, "user-note.md"), "no frontmatter")
 
 	if err := prune(root, []string{"proj"}, map[string]bool{}); err != nil {
 		t.Fatalf("prune: %v", err)
@@ -60,8 +76,10 @@ func TestPrune(t *testing.T) {
 		t.Fatal("user note must survive")
 	}
 	// No marker → prune must refuse to delete anything.
-	os.Remove(filepath.Join(root, markerName))
-	os.WriteFile(filepath.Join(sub, "stale2-beef0000.md"), []byte(ghostNote), 0o644)
+	if err := os.Remove(filepath.Join(root, markerName)); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(sub, "stale2-beef0000.md"), ghostNote)
 	if err := prune(root, []string{"proj"}, map[string]bool{}); err == nil {
 		t.Fatal("prune without marker must error")
 	}
@@ -69,21 +87,21 @@ func TestPrune(t *testing.T) {
 
 func TestPruneGuards(t *testing.T) {
 	root := t.TempDir()
-	os.WriteFile(filepath.Join(root, markerName), []byte(`{"schema_version":1}`), 0o644)
+	mustWrite(t, filepath.Join(root, markerName), `{"schema_version":1}`)
 	sub := filepath.Join(root, "proj", "Memories")
-	os.MkdirAll(sub, 0o755)
+	mustMkdirAll(t, sub)
 
 	// (a) keep-set retention: ghost_id in keep must survive.
 	keptNote := "---\nghost_id: cafe0000\ntype: memory\n---\nbody\n"
-	os.WriteFile(filepath.Join(sub, "kept-cafe0000.md"), []byte(keptNote), 0o644)
+	mustWrite(t, filepath.Join(sub, "kept-cafe0000.md"), keptNote)
 	// (b) subtree scoping: ghost note outside the pruned subtrees must survive.
 	other := filepath.Join(root, "otherproj", "Memories")
-	os.MkdirAll(other, 0o755)
+	mustMkdirAll(t, other)
 	staleNote := "---\nghost_id: dead0000\ntype: memory\n---\nbody\n"
-	os.WriteFile(filepath.Join(other, "stale-dead0000.md"), []byte(staleNote), 0o644)
+	mustWrite(t, filepath.Join(other, "stale-dead0000.md"), staleNote)
 	// (c) body-only ghost_id: no frontmatter, ghost_id appears after a --- in the body.
 	bodyOnly := "just a user note\n\n---\nghost_id: feed0000\n"
-	os.WriteFile(filepath.Join(sub, "body-only.md"), []byte(bodyOnly), 0o644)
+	mustWrite(t, filepath.Join(sub, "body-only.md"), bodyOnly)
 
 	if err := prune(root, []string{"proj"}, map[string]bool{"cafe0000": true}); err != nil {
 		t.Fatalf("prune: %v", err)
@@ -102,13 +120,13 @@ func TestPruneGuards(t *testing.T) {
 func TestPruneRefusesEscapingSubtree(t *testing.T) {
 	parent := t.TempDir()
 	root := filepath.Join(parent, "vault")
-	os.MkdirAll(root, 0o755)
-	os.WriteFile(filepath.Join(root, markerName), []byte(`{"schema_version":1}`), 0o644)
+	mustMkdirAll(t, root)
+	mustWrite(t, filepath.Join(root, markerName), `{"schema_version":1}`)
 	// Sibling dir outside the vault holding a ghost-looking note.
 	escape := filepath.Join(parent, "escape")
-	os.MkdirAll(escape, 0o755)
+	mustMkdirAll(t, escape)
 	victim := filepath.Join(escape, "victim-dead0000.md")
-	os.WriteFile(victim, []byte("---\nghost_id: dead0000\ntype: memory\n---\nbody\n"), 0o644)
+	mustWrite(t, victim, "---\nghost_id: dead0000\ntype: memory\n---\nbody\n")
 
 	if err := prune(root, []string{"../escape"}, map[string]bool{}); err == nil {
 		t.Fatal("prune with escaping subtree must error")


### PR DESCRIPTION
## What

New `ghost obsidian` subcommand: a strictly one-way mirror of Ghost's store into a plain-Markdown folder Obsidian reads natively.

```
ghost obsidian export [--out DIR] [--project NAME]   # one-shot full mirror
ghost obsidian sync   [--out DIR] [--interval 30s]   # re-export when the DB changes
```

- One note per memory/decision/task, YAML frontmatter as Obsidian Properties; `memory_links` render as wikilinks → graph view shows the memory graph
- Change detection via `PRAGMA data_version` polling over a read-only connection (hook.go pattern) — safe alongside a live MCP server, zero new dependencies
- Design spec: `docs/superpowers/specs/2026-07-10-obsidian-vault-mirror-design.md`; implementation plan: `docs/superpowers/plans/2026-07-10-obsidian-vault-mirror.md`

## Safety (the load-bearing part)

Deletes require **all** guards: `.ghost-vault` marker at the vault root, `filepath.IsLocal` subtree containment, and a frontmatter `ghost_id` (basename must also match the canonical name for that id, so slug renames prune their stale twin). Writes are contained the same way (pathological project names map to `project-<id8>`). Fail-safe directions throughout: truncated list queries warn and skip pruning that project (stale extras beat silent deletions); failed sync exports retry next tick.

## Review loop evidence

Each task passed spec-compliance + adversarial quality review; findings fixed with failing-first regression tests:
- prune path-traversal via crafted project names (containment guard)
- writes escaping the vault before prune's guard fires
- truncation-at-limit deleting low-importance notes
- filter-dependent folder assignment duplicating project folders
- slug renames leaking permanent stale duplicates

## Verification

- `go test -race -count=1 ./...` green (23 obsidian-package tests); `go vet` clean; exact CI lint invocation (`golangci-lint run --new-from-rev=origin/main`) → 0 issues
- Live smoke test against the real local DB (read-only): 147 notes across 14 project folders, correct frontmatter, marker present; `sync --project ghost` scoped correctly

## Known limitations (v1, documented in spec)

Renamed/merged projects can leave orphaned folders (recovery: delete vault dir + re-export — the mirror is fully regenerable); with `--project`, cross-project links render as plain short IDs. Bases views, JSON Canvas, vault ingestion, and two-way sync are explicitly v2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ghost obsidian export` to mirror memories, decisions, and tasks into an Obsidian vault as Markdown notes.
  * Added `ghost obsidian sync` to keep the mirror updated via periodic polling.
  * Supports project filtering, configurable vault location and polling interval, deterministic note naming, and one-way (read-only) behavior.

* **Documentation**
  * Updated CLI and “How it works” docs with vault behavior, wikilinks, pruning rules, and examples.
  * Extended the example config with Obsidian mirror settings.

* **Tests**
  * Added coverage for export/sync, rendering, vault safety, pruning, and read-only database mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->