### PR TITLE
feat: fusion parameter sweep (ghost bench --sweep); disable graph ranking bonus by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@
 - Project lookup: path-prefix match (longest wins) OR basename name fallback
 - Global memories: `_global` project, included in every project's context
 - Hybrid search: 70% vector (cosine, Ollama) + 30% FTS5, RRF fusion — falls back to FTS5-only
-- Memory links: `memory_links` edge table auto-populated by cosine similarity (internal/linking worker); links cascade-delete with memories and self-heal after reflection; hybrid search adds an additive graph-expansion bonus from top seeds
+- Memory links: `memory_links` edge table auto-populated by cosine similarity (internal/linking worker); links cascade-delete with memories and self-heal after reflection. The graph-expansion ranking bonus ships disabled (`DefaultSearchParams().GraphWeight = 0`) — the bench sweep measured it degrading ranking; opt in via `SearchHybridParams`
 
 ## Critical Rules
 - Always `go vet ./...` before committing

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Claude Code's built-in memory is a markdown file with a limited load window ([~2
 | Consolidation | None | Haiku LLM or local Jaccard tier |
 | Time decay | None (stale facts persist equally) | Category-aware: conventions never decay, gotchas fade |
 | Cross-project | None (siloed per repository) | `ghost_search_all` + `_global` project |
-| Memory graph | None | Auto-linked related memories, graph-aware search |
+| Memory graph | None | Auto-linked related memories, graph view in Obsidian |
 | Clients | Claude Code only | Any MCP client |
 
 Switching migrates your existing Claude Code memories into Ghost — at init or on first contact. Nothing is lost.
@@ -128,7 +128,7 @@ Ghost is a memory pipeline: **Save → Embed → Link → Search → Consolidate
 
 ### Hybrid search
 
-Full-text (FTS5) and vector results are fused with Reciprocal Rank Fusion (k=60), weighted 70% vector / 30% FTS. A background worker links similar memories (cosine ≥ 0.70) into a graph; search adds an additive graph-expansion bonus (weight 0.15, up to 3 seeds, 2 hops) so related memories surface together. Links self-heal after consolidation rewrites memories.
+Full-text (FTS5) and vector results are fused with Reciprocal Rank Fusion (k=60), weighted 70% vector / 30% FTS. A background worker links similar memories (cosine ≥ 0.70) into a graph, which powers the Obsidian mirror's graph view and future link-aware features; links self-heal after consolidation rewrites memories. An experimental graph-expansion ranking bonus exists but ships disabled — our own benchmark sweep (`ghost bench --sweep`) showed it demoting exact matches, so it stays off until a redesign beats that measurement ([methodology](docs/benchmarks.md)).
 
 Vectors come from a local Ollama instance (`nomic-embed-text:v1.5`, 768 dims) if one is running. **No Ollama? No error, no setup step** — Ghost is fully functional with FTS5-only search and quietly upgrades to hybrid the moment Ollama appears:
 

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -587,7 +587,8 @@ Commands:
   reflect <project> [flags]   Memory consolidation (dry-run by default, --apply to save)
   obsidian export [flags]     Mirror memories to an Obsidian vault (one-way)
   obsidian sync [flags]       Keep the vault mirror fresh (polls for DB changes)
-  bench                       Run the retrieval-quality benchmark (built-in dataset)
+  bench [--sweep]             Run the retrieval-quality benchmark (built-in dataset);
+                              --sweep grid-searches the fusion parameters
   upgrade                     Update ghost to the latest release
   version                     Print version
 
@@ -602,11 +603,23 @@ Environment:
 `, version)
 }
 
-// bootstrap loads config, sets up logging, and opens the database.
 // runBench implements `ghost bench` — runs the built-in retrieval-quality
 // benchmark (four ablations over the embedded dataset) and prints the metric
-// table. Judge-free, deterministic, no network. See docs/benchmarks.md.
+// table. With --sweep it instead grid-searches the fusion parameters and
+// prints the ranked table. Judge-free, deterministic, no network. See
+// docs/benchmarks.md.
 func runBench() {
+	sweep := false
+	for _, arg := range os.Args[2:] {
+		switch arg {
+		case "--sweep":
+			sweep = true
+		default:
+			fmt.Fprintf(os.Stderr, "error: unknown flag %q\n\nUsage: ghost bench [--sweep]\n", arg)
+			os.Exit(1)
+		}
+	}
+
 	ds, vecs, err := bench.BuiltinDataset()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -635,6 +648,20 @@ func runBench() {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
+
+	if sweep {
+		// The sweep varies query-time fusion parameters over one prepared
+		// store, so the link graph is built once up front.
+		linking.NewWorker(store, logger, time.Hour, threshold).SweepOnce(ctx)
+		points, err := bench.Sweep(ctx, store, queries, bench.SweepGrid())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Print(bench.FormatSweep(points))
+		return
+	}
+
 	results, err := bench.Run(ctx, store, queries, threshold)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -19,7 +19,7 @@ The first published numbers. A Go harness that, per question, ingests the haysta
   1. FTS5-only (no embeddings)
   2. vector-only
   3. hybrid RRF (the shipped 70/30 fusion, k=60)
-  4. hybrid + graph-expansion bonus (weight 0.15, after the linking worker runs)
+  4. hybrid + graph-expansion bonus (candidate weight 0.15 — disabled in production defaults; the ablation opts in to keep measuring it)
 - **Cost:** $0 API. Wall-clock is dominated by locally embedding the haystack through Ollama (`nomic-embed-text:v1.5`); the FTS5-only ablation runs in minutes.
 - **Published anchors for context:** the LongMemEval paper's flat-index baseline (session-level Recall@5 ≈ 0.64 on the -M variant) and reported ~95% Recall@5 hybrid results on -S.
 
@@ -40,7 +40,7 @@ hybrid+graph     0.500   0.964   1.000    0.780    0.824
 Two findings, both honest:
 
 - **Hybrid fusion earns its keep.** Hybrid NDCG@10 (0.989) beats both single legs (FTS 0.965, vector 0.946) — the 70/30 RRF weighting is a net win on this dataset. `TestBenchRegressionFloors` asserts this relationship so a regression trips CI.
-- **The graph-expansion bonus currently hurts.** `hybrid+graph` is *worse* than plain hybrid (NDCG 0.824, R@1 0.500) — the additive bonus (weight 0.15) lifts semantically-adjacent neighbors above exact matches. The regression test documents this rather than flooring it; the 0.15 weight has no empirical basis and needs retuning.
+- **The graph-expansion bonus hurts, so it now ships disabled.** `hybrid+graph` is *worse* than plain hybrid (NDCG 0.824, R@1 0.500) — the additive bonus at its former 0.15 default lifts semantically-adjacent neighbors above exact matches. Following the parameter sweep below, production defaults ship with `GraphWeight 0`; the ablation opts into the candidate 0.15 weight so the signal stays under measurement.
 
 The dataset is deliberately a v1 starter (all 8 categories represented); growing it toward ~150 memories / ~40 graded queries is planned. Regression tests assert **metric floors** (a little below observed), not exact rankings, since RRF scores can tie.
 
@@ -48,9 +48,9 @@ The dataset is deliberately a v1 starter (all 8 categories represented); growing
 
 The RRF fusion is parameterized (`memory.SearchParams`), and `ghost bench --sweep` grid-searches the vector-leg weight (FTS = complement) × the graph-bonus weight — 36 combinations over the same dataset, one prepared store, link graph built once. Findings from the first sweep (full table: run `ghost bench --sweep`):
 
-- **The graph bonus degrades retrieval monotonically.** `graph=0` and `graph=0.02` tie for best at every leg weighting (0.02 is too small to reorder anything — effectively off); `0.05` costs ~2.5 NDCG points; `0.10` costs ~9; the shipped default `0.15` puts the production configuration (NDCG 0.824) in the **bottom third of all 36 combinations**. The additive strength-scaled bonus, at any effective magnitude, lifts semantically-adjacent neighbors above exact matches on this dataset.
+- **The graph bonus degrades retrieval monotonically.** `graph=0` and `graph=0.02` tie for best at every leg weighting (0.02 is too small to reorder anything — effectively off); at vec 0.3–0.7, `0.05` costs ~2.5 NDCG points and `0.10` costs ~9 (worse still at vec ≥ 0.8); the former `0.15` default put the production configuration (NDCG 0.824, rank 24 of 36, in a display tie spilling into the bottom third) far below every graph-off point. The additive strength-scaled bonus, at any effective magnitude, lifts semantically-adjacent neighbors above exact matches on this dataset.
 - **Leg weights are robust.** With the graph off, vec 0.3–0.7 all land within 0.989–0.992 NDCG; only vec ≥ 0.8 degrades. The shipped 70/30 weighting is fine; there is no evidence for changing it from a 14-query dataset.
-- **Implication:** the graph bonus as designed is not a precision signal. Either its default weight should be 0 (off until a better design — e.g. relation-aware or seed-confidence-gated expansion — proves itself here), or it should be reframed as a recall/context feature and kept out of top-k ranking. Tracked as a follow-up decision; the sweep is the gate any redesign must pass.
+- **Outcome: production defaults now ship with `GraphWeight 0`.** The link graph is still built (it powers the Obsidian mirror's graph view and future link-aware features), and the bonus mechanism remains behind `SearchHybridParams`. A redesign — e.g. relation-aware or seed-confidence-gated expansion — ships only when it beats `graph=0` in this sweep.
 
 ## Phase 3 — staleness suite (the flagship)
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -42,7 +42,15 @@ Two findings, both honest:
 - **Hybrid fusion earns its keep.** Hybrid NDCG@10 (0.989) beats both single legs (FTS 0.965, vector 0.946) — the 70/30 RRF weighting is a net win on this dataset. `TestBenchRegressionFloors` asserts this relationship so a regression trips CI.
 - **The graph-expansion bonus currently hurts.** `hybrid+graph` is *worse* than plain hybrid (NDCG 0.824, R@1 0.500) — the additive bonus (weight 0.15) lifts semantically-adjacent neighbors above exact matches. The regression test documents this rather than flooring it; the 0.15 weight has no empirical basis and needs retuning.
 
-The dataset is deliberately a v1 starter (all 8 categories represented); growing it toward ~150 memories / ~40 graded queries is planned. Regression tests assert **metric floors** (a little below observed), not exact rankings, since RRF scores can tie. A follow-up refactor extracts the RRF fusion into a parameterized function, enabling `ghost bench --sweep` to find empirically-grounded values for the currently hand-tuned knobs (70/30 weights, graph bonus 0.15, cosine link threshold 0.70) — with the graph-bonus regression above as the first thing to fix.
+The dataset is deliberately a v1 starter (all 8 categories represented); growing it toward ~150 memories / ~40 graded queries is planned. Regression tests assert **metric floors** (a little below observed), not exact rankings, since RRF scores can tie.
+
+### Parameter sweep (`ghost bench --sweep`)
+
+The RRF fusion is parameterized (`memory.SearchParams`), and `ghost bench --sweep` grid-searches the vector-leg weight (FTS = complement) × the graph-bonus weight — 36 combinations over the same dataset, one prepared store, link graph built once. Findings from the first sweep (full table: run `ghost bench --sweep`):
+
+- **The graph bonus degrades retrieval monotonically.** `graph=0` and `graph=0.02` tie for best at every leg weighting (0.02 is too small to reorder anything — effectively off); `0.05` costs ~2.5 NDCG points; `0.10` costs ~9; the shipped default `0.15` puts the production configuration (NDCG 0.824) in the **bottom third of all 36 combinations**. The additive strength-scaled bonus, at any effective magnitude, lifts semantically-adjacent neighbors above exact matches on this dataset.
+- **Leg weights are robust.** With the graph off, vec 0.3–0.7 all land within 0.989–0.992 NDCG; only vec ≥ 0.8 degrades. The shipped 70/30 weighting is fine; there is no evidence for changing it from a 14-query dataset.
+- **Implication:** the graph bonus as designed is not a precision signal. Either its default weight should be 0 (off until a better design — e.g. relation-aware or seed-confidence-gated expansion — proves itself here), or it should be reframed as a recall/context feature and kept out of top-k ranking. Tracked as a follow-up decision; the sweep is the gate any redesign must pass.
 
 ## Phase 3 — staleness suite (the flagship)
 

--- a/internal/bench/regression_test.go
+++ b/internal/bench/regression_test.go
@@ -52,11 +52,13 @@ func TestBenchRegressionFloors(t *testing.T) {
 		t.Errorf("hybrid NDCG@10 %.3f must be >= vector-only %.3f", r[CondHybrid].NDCG10, r[CondVector].NDCG10)
 	}
 
-	// Known regression, documented not asserted: the graph-expansion bonus
-	// currently HURTS precision (its 0.15 weight has no empirical basis), so
-	// hybrid+graph underperforms plain hybrid. We log the gap rather than
-	// floor it; when the weight is retuned this should shrink or invert.
+	// Tracked, not asserted: the hybrid+graph ablation opts into the candidate
+	// graph weight (the former default — production now ships GraphWeight 0
+	// after the sweep measured the bonus degrading ranking monotonically).
+	// The gap is logged so redesign progress is visible; a graph redesign
+	// ships when this inverts, i.e. it beats plain hybrid here and in the
+	// sweep (see docs/benchmarks.md).
 	if g, h := r[CondHybridGraph].NDCG10, r[CondHybrid].NDCG10; g < h {
-		t.Logf("note: hybrid+graph NDCG@10 %.3f < hybrid %.3f — graph bonus needs tuning (see docs/benchmarks.md)", g, h)
+		t.Logf("note: hybrid+graph (candidate weight %.2f) NDCG@10 %.3f < hybrid %.3f — graph bonus disabled in production defaults (see docs/benchmarks.md)", candidateGraphWeight, g, h)
 	}
 }

--- a/internal/bench/runner.go
+++ b/internal/bench/runner.go
@@ -44,6 +44,12 @@ const (
 	CondHybridGraph = "hybrid+graph"
 )
 
+// candidateGraphWeight is the graph-bonus weight the hybrid+graph ablation
+// opts into. It is the former production default, kept under measurement
+// after the sweep showed it degrades ranking; production defaults now ship
+// with GraphWeight 0.
+const candidateGraphWeight = 0.15
+
 // Run evaluates all four ablations over the seeded store and query set. The
 // graph condition is run last: it first builds the memory-link graph (the same
 // linking worker production uses, at the given cosine threshold), which
@@ -69,11 +75,17 @@ func Run(ctx context.Context, store *memory.Store, queries []Query, linkThreshol
 		return nil, err
 	}
 
-	// Build the link graph, then re-run hybrid so the graph-expansion bonus
-	// participates. SweepOnce does a single pass; the interval is irrelevant.
+	// Build the link graph, then re-run hybrid with the CANDIDATE graph weight
+	// so the graph-expansion bonus participates. Production defaults ship with
+	// GraphWeight 0 (the sweep showed the bonus degrades ranking — see
+	// docs/benchmarks.md), so this ablation deliberately opts in: it keeps
+	// measuring the signal a redesign must improve. SweepOnce does a single
+	// pass; the interval is irrelevant.
 	linking.NewWorker(store, slog.New(slog.NewTextHandler(discard{}, nil)), time.Hour, linkThreshold).SweepOnce(ctx)
+	pGraph := memory.DefaultSearchParams()
+	pGraph.GraphWeight = candidateGraphWeight
 	hybridGraph, err := runCondition(ctx, CondHybridGraph, queries, func(q Query) ([]string, error) {
-		return idsFromMemories(store.SearchHybrid(ctx, q.ProjectID, q.Text, q.Vector, scoreK))
+		return idsFromMemories(store.SearchHybridParams(ctx, q.ProjectID, q.Text, q.Vector, scoreK, pGraph))
 	})
 	if err != nil {
 		return nil, err

--- a/internal/bench/sweep.go
+++ b/internal/bench/sweep.go
@@ -47,7 +47,6 @@ func SweepGrid() []memory.SearchParams {
 func Sweep(ctx context.Context, store *memory.Store, queries []Query, grid []memory.SearchParams) ([]SweepPoint, error) {
 	points := make([]SweepPoint, 0, len(grid))
 	for _, p := range grid {
-		p := p
 		cond := fmt.Sprintf("vec=%.2f graph=%.2f", p.VecWeight, p.GraphWeight)
 		res, err := runCondition(ctx, cond, queries, func(q Query) ([]string, error) {
 			return idsFromMemories(store.SearchHybridParams(ctx, q.ProjectID, q.Text, q.Vector, scoreK, p))

--- a/internal/bench/sweep.go
+++ b/internal/bench/sweep.go
@@ -1,0 +1,91 @@
+package bench
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+// SweepPoint is the outcome of evaluating one parameter combination over the
+// query set with the hybrid searcher.
+type SweepPoint struct {
+	Params memory.SearchParams
+	Result Result
+}
+
+// SweepGrid returns the default parameter grid: vector-leg weight (FTS weight
+// is its complement, keeping the legs normalized to 1) crossed with the graph
+// bonus weight, including 0 (graph off). RRF k and graph seeds/hops stay at
+// production defaults — sweep one axis at a time.
+func SweepGrid() []memory.SearchParams {
+	vecWeights := []float64{0.3, 0.5, 0.6, 0.7, 0.8, 0.9}
+	graphWeights := []float64{0, 0.02, 0.05, 0.10, 0.15, 0.30}
+	grid := make([]memory.SearchParams, 0, len(vecWeights)*len(graphWeights))
+	for _, vw := range vecWeights {
+		for _, gw := range graphWeights {
+			p := memory.DefaultSearchParams()
+			p.VecWeight = vw
+			// Round the complement so e.g. 1-0.7 is exactly 0.3 and the grid
+			// contains a point == DefaultSearchParams (float identity matters
+			// for the "current default" marker).
+			p.FTSWeight = math.Round((1-vw)*100) / 100
+			p.GraphWeight = gw
+			grid = append(grid, p)
+		}
+	}
+	return grid
+}
+
+// Sweep evaluates every parameter combination with the hybrid searcher over an
+// already-seeded store whose link graph is already built (the graph pass reads
+// links at query time, so one store serves every point). Results are sorted by
+// NDCG@10 descending, ties broken by MRR@10 then recall@1.
+func Sweep(ctx context.Context, store *memory.Store, queries []Query, grid []memory.SearchParams) ([]SweepPoint, error) {
+	points := make([]SweepPoint, 0, len(grid))
+	for _, p := range grid {
+		p := p
+		cond := fmt.Sprintf("vec=%.2f graph=%.2f", p.VecWeight, p.GraphWeight)
+		res, err := runCondition(ctx, cond, queries, func(q Query) ([]string, error) {
+			return idsFromMemories(store.SearchHybridParams(ctx, q.ProjectID, q.Text, q.Vector, scoreK, p))
+		})
+		if err != nil {
+			return nil, err
+		}
+		points = append(points, SweepPoint{Params: p, Result: res})
+	}
+	sort.SliceStable(points, func(i, j int) bool {
+		a, b := points[i].Result, points[j].Result
+		if a.NDCG10 != b.NDCG10 {
+			return a.NDCG10 > b.NDCG10
+		}
+		if a.MRR10 != b.MRR10 {
+			return a.MRR10 > b.MRR10
+		}
+		return a.Recall1 > b.Recall1
+	})
+	return points, nil
+}
+
+// FormatSweep renders the sweep as an aligned table, best first, and marks the
+// production-default row.
+func FormatSweep(points []SweepPoint) string {
+	var b bytes.Buffer
+	def := memory.DefaultSearchParams()
+	fmt.Fprintf(&b, "%-22s %7s %7s %8s %8s\n", "params", "R@1", "R@10", "MRR@10", "NDCG@10")
+	for _, pt := range points {
+		mark := ""
+		if pt.Params == def {
+			mark = "  <- current default"
+		}
+		fmt.Fprintf(&b, "%-22s %7.3f %7.3f %8.3f %8.3f%s\n",
+			pt.Result.Condition, pt.Result.Recall1, pt.Result.Recall10, pt.Result.MRR10, pt.Result.NDCG10, mark)
+	}
+	if n := len(points); n > 0 {
+		fmt.Fprintf(&b, "\n%d parameter combinations, sorted by NDCG@10; %d graded queries each.\n", n, points[0].Result.Queries)
+	}
+	return b.String()
+}

--- a/internal/bench/sweep_test.go
+++ b/internal/bench/sweep_test.go
@@ -30,11 +30,12 @@ func TestSweep(t *testing.T) {
 	store, queries := sweepFixture(t)
 	ctx := context.Background()
 
-	// A tiny grid containing the production default and graph-off.
+	// A tiny grid containing the production default (graph off) and the
+	// candidate graph weight the ablation runner tracks.
 	def := memory.DefaultSearchParams()
-	off := def
-	off.GraphWeight = 0
-	points, err := Sweep(ctx, store, queries, []memory.SearchParams{def, off})
+	graph := def
+	graph.GraphWeight = candidateGraphWeight
+	points, err := Sweep(ctx, store, queries, []memory.SearchParams{def, graph})
 	if err != nil {
 		t.Fatalf("Sweep: %v", err)
 	}
@@ -47,11 +48,12 @@ func TestSweep(t *testing.T) {
 		t.Errorf("points not sorted by NDCG: %.3f then %.3f", points[0].Result.NDCG10, points[1].Result.NDCG10)
 	}
 
-	// Cross-check both points against the ablation runner: default params ==
-	// hybrid+graph, graph-off == hybrid. The ablation runner MUST start from a
+	// Cross-check both points against the ablation runner: default params
+	// (graph off) == the hybrid ablation, and the candidate graph weight ==
+	// the hybrid+graph ablation. The ablation runner MUST start from a
 	// link-free store (it builds the graph itself between conditions — a
-	// pre-linked store would contaminate its plain-hybrid condition with the
-	// graph bonus), so use runTestdata, not sweepFixture.
+	// pre-linked store would contaminate its plain-hybrid condition if a
+	// caller opted into a graph weight), so use runTestdata, not sweepFixture.
 	byCond := byCondition(runTestdata(t))
 	find := func(p memory.SearchParams) Result {
 		for _, pt := range points {
@@ -62,11 +64,11 @@ func TestSweep(t *testing.T) {
 		t.Fatalf("sweep point not found for %+v", p)
 		return Result{}
 	}
-	if got, want := find(def).NDCG10, byCond[CondHybridGraph].NDCG10; got != want {
-		t.Errorf("default sweep point NDCG %.6f != hybrid+graph ablation %.6f", got, want)
+	if got, want := find(def).NDCG10, byCond[CondHybrid].NDCG10; got != want {
+		t.Errorf("default (graph-off) sweep point NDCG %.6f != hybrid ablation %.6f", got, want)
 	}
-	if got, want := find(off).NDCG10, byCond[CondHybrid].NDCG10; got != want {
-		t.Errorf("graph-off sweep point NDCG %.6f != hybrid ablation %.6f", got, want)
+	if got, want := find(graph).NDCG10, byCond[CondHybridGraph].NDCG10; got != want {
+		t.Errorf("candidate-graph sweep point NDCG %.6f != hybrid+graph ablation %.6f", got, want)
 	}
 }
 

--- a/internal/bench/sweep_test.go
+++ b/internal/bench/sweep_test.go
@@ -1,0 +1,100 @@
+package bench
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/wcatz/ghost/internal/linking"
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+// sweepFixture seeds the committed dataset into a fresh store and builds the
+// link graph, mirroring what runBench does before a sweep.
+func sweepFixture(t *testing.T) (*memory.Store, []Query) {
+	t.Helper()
+	ds, vecs := loadTestdataDataset(t)
+	store := newBenchStore(t)
+	ctx := context.Background()
+	queries, err := Seed(ctx, store, ds, vecs)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	linking.NewWorker(store, slog.New(slog.NewTextHandler(io.Discard, nil)), time.Hour, 0.70).SweepOnce(ctx)
+	return store, queries
+}
+
+func TestSweep(t *testing.T) {
+	store, queries := sweepFixture(t)
+	ctx := context.Background()
+
+	// A tiny grid containing the production default and graph-off.
+	def := memory.DefaultSearchParams()
+	off := def
+	off.GraphWeight = 0
+	points, err := Sweep(ctx, store, queries, []memory.SearchParams{def, off})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(points) != 2 {
+		t.Fatalf("got %d points, want 2", len(points))
+	}
+
+	// Sorted by NDCG@10 descending.
+	if points[0].Result.NDCG10 < points[1].Result.NDCG10 {
+		t.Errorf("points not sorted by NDCG: %.3f then %.3f", points[0].Result.NDCG10, points[1].Result.NDCG10)
+	}
+
+	// Cross-check both points against the ablation runner: default params ==
+	// hybrid+graph, graph-off == hybrid. The ablation runner MUST start from a
+	// link-free store (it builds the graph itself between conditions — a
+	// pre-linked store would contaminate its plain-hybrid condition with the
+	// graph bonus), so use runTestdata, not sweepFixture.
+	byCond := byCondition(runTestdata(t))
+	find := func(p memory.SearchParams) Result {
+		for _, pt := range points {
+			if pt.Params == p {
+				return pt.Result
+			}
+		}
+		t.Fatalf("sweep point not found for %+v", p)
+		return Result{}
+	}
+	if got, want := find(def).NDCG10, byCond[CondHybridGraph].NDCG10; got != want {
+		t.Errorf("default sweep point NDCG %.6f != hybrid+graph ablation %.6f", got, want)
+	}
+	if got, want := find(off).NDCG10, byCond[CondHybrid].NDCG10; got != want {
+		t.Errorf("graph-off sweep point NDCG %.6f != hybrid ablation %.6f", got, want)
+	}
+}
+
+func TestSweepGrid(t *testing.T) {
+	grid := SweepGrid()
+	if len(grid) != 36 {
+		t.Fatalf("grid size %d, want 36 (6 vec weights x 6 graph weights)", len(grid))
+	}
+	def := memory.DefaultSearchParams()
+	foundDefault, foundGraphOff := false, false
+	for _, p := range grid {
+		if got := p.FTSWeight + p.VecWeight; got < 0.999 || got > 1.001 {
+			t.Errorf("leg weights not normalized: fts=%.2f vec=%.2f", p.FTSWeight, p.VecWeight)
+		}
+		if p.RRFK != def.RRFK || p.GraphSeeds != def.GraphSeeds || p.GraphHops != def.GraphHops {
+			t.Errorf("non-swept knobs must stay at defaults: %+v", p)
+		}
+		if p == def {
+			foundDefault = true
+		}
+		if p.GraphWeight == 0 && p.VecWeight == def.VecWeight {
+			foundGraphOff = true
+		}
+	}
+	if !foundDefault {
+		t.Error("grid must include the production default point")
+	}
+	if !foundGraphOff {
+		t.Error("grid must include a graph-off point at the default leg weighting")
+	}
+}

--- a/internal/memory/vector.go
+++ b/internal/memory/vector.go
@@ -203,13 +203,27 @@ func (s *Store) fuseAndRank(ctx context.Context, projectID string, ftsResults []
 		idSet[sm.MemoryID] = true
 	}
 
+	// Ranking sorts break score ties by ID so identical searches return
+	// identical orderings (and pick identical graph seeds) — the candidate
+	// sets come from map iteration, which would otherwise make tie order
+	// random per call.
+	byScoreThenID := func(ids []string) {
+		sort.Slice(ids, func(i, j int) bool {
+			si, sj := scores[ids[i]], scores[ids[j]]
+			if si != sj {
+				return si > sj
+			}
+			return ids[i] < ids[j]
+		})
+	}
+
 	if p.GraphWeight > 0 && p.GraphSeeds > 0 {
 		// Preliminary ranking to pick graph seeds.
 		prelim := make([]string, 0, len(idSet))
 		for id := range idSet {
 			prelim = append(prelim, id)
 		}
-		sort.Slice(prelim, func(i, j int) bool { return scores[prelim[i]] > scores[prelim[j]] })
+		byScoreThenID(prelim)
 
 		// Third signal: link-graph expansion from top seeds (additive-only).
 		s.applyGraphBonus(ctx, projectID, scores, idSet, prelim, limit, p)
@@ -220,7 +234,7 @@ func (s *Store) fuseAndRank(ctx context.Context, projectID string, ftsResults []
 	for id := range idSet {
 		ranked = append(ranked, id)
 	}
-	sort.Slice(ranked, func(i, j int) bool { return scores[ranked[i]] > scores[ranked[j]] })
+	byScoreThenID(ranked)
 	if len(ranked) > limit {
 		ranked = ranked[:limit]
 	}
@@ -229,9 +243,14 @@ func (s *Store) fuseAndRank(ctx context.Context, projectID string, ftsResults []
 	if err != nil {
 		return nil, err
 	}
-	// Re-sort by fused score (GetByIDs doesn't preserve order).
+	// Re-sort by fused score (GetByIDs doesn't preserve order), same
+	// tie-breaking as the ID ranking above.
 	sort.Slice(memories, func(i, j int) bool {
-		return scores[memories[i].ID] > scores[memories[j].ID]
+		si, sj := scores[memories[i].ID], scores[memories[j].ID]
+		if si != sj {
+			return si > sj
+		}
+		return memories[i].ID < memories[j].ID
 	})
 	return memories, nil
 }

--- a/internal/memory/vector.go
+++ b/internal/memory/vector.go
@@ -128,44 +128,116 @@ type ScoredMemory struct {
 	Score    float32
 }
 
+// SearchParams parameterizes hybrid-search fusion. The zero value disables
+// every signal — use DefaultSearchParams for production behavior. The bench
+// harness (ghost bench --sweep) grid-searches these knobs against the graded
+// dataset; defaults should only change on the strength of those numbers.
+type SearchParams struct {
+	FTSWeight   float64 // RRF weight of the full-text leg
+	VecWeight   float64 // RRF weight of the vector leg
+	RRFK        int     // RRF smoothing constant (Cormack & Clarke use 60)
+	GraphWeight float64 // additive link-graph bonus weight; 0 skips the graph pass
+	GraphSeeds  int     // top-ranked results used as graph-expansion seeds
+	GraphHops   int     // link-traversal depth from each seed
+}
+
+// DefaultSearchParams returns the production fusion parameters.
+func DefaultSearchParams() SearchParams {
+	return SearchParams{
+		FTSWeight:   0.3,
+		VecWeight:   0.7,
+		RRFK:        60,
+		GraphWeight: 0.15,
+		GraphSeeds:  3,
+		GraphHops:   2,
+	}
+}
+
 // applyGraphBonus adds an additive RRF-style bonus to scores for memories
 // reachable via links from the top-ranked seed IDs. Additive-only: when no
 // links exist, scores are unchanged. Errors are non-fatal (the graph signal
 // is best-effort, like the FTS and vector legs). Pass projectID "" to span
 // all projects.
-func (s *Store) applyGraphBonus(ctx context.Context, projectID string, scores map[string]float64, idSet map[string]bool, ranked []string, limit int) {
-	const k = 60
-	const graphWeight = 0.15
-	const maxSeeds = 3
-	const maxHops = 2
-
+func (s *Store) applyGraphBonus(ctx context.Context, projectID string, scores map[string]float64, idSet map[string]bool, ranked []string, limit int, p SearchParams) {
 	seeds := ranked
-	if len(seeds) > maxSeeds {
-		seeds = seeds[:maxSeeds]
+	if len(seeds) > p.GraphSeeds {
+		seeds = seeds[:p.GraphSeeds]
 	}
 
 	// Walk from each seed separately so a seed is only excluded from its own
 	// expansion — a lower-ranked candidate linked to the top hit still gets
 	// the bonus. The bonus decays with seed rank.
 	for seedRank, seed := range seeds {
-		neighbors, err := s.GraphNeighbors(ctx, projectID, []string{seed}, maxHops, limit)
+		neighbors, err := s.GraphNeighbors(ctx, projectID, []string{seed}, p.GraphHops, limit)
 		if err != nil {
 			s.logger.Debug("graph bonus: traversal failed", "error", err, "seed", seed)
 			return
 		}
 		for _, n := range neighbors {
-			scores[n.MemoryID] += graphWeight * float64(n.Strength) / float64(k+seedRank+1)
+			scores[n.MemoryID] += p.GraphWeight * float64(n.Strength) / float64(p.RRFK+seedRank+1)
 			idSet[n.MemoryID] = true
 		}
 	}
+}
+
+// fuseAndRank runs the shared hybrid pipeline: RRF-fuse the two result legs,
+// optionally apply the link-graph bonus, then rank, truncate, and hydrate.
+// projectID scopes the graph traversal; "" spans all projects.
+func (s *Store) fuseAndRank(ctx context.Context, projectID string, ftsResults []Memory, vecResults []ScoredMemory, limit int, p SearchParams) ([]Memory, error) {
+	scores := make(map[string]float64)
+	idSet := make(map[string]bool)
+	for rank, m := range ftsResults {
+		scores[m.ID] += p.FTSWeight / float64(p.RRFK+rank+1)
+		idSet[m.ID] = true
+	}
+	for rank, sm := range vecResults {
+		scores[sm.MemoryID] += p.VecWeight / float64(p.RRFK+rank+1)
+		idSet[sm.MemoryID] = true
+	}
+
+	if p.GraphWeight > 0 && p.GraphSeeds > 0 {
+		// Preliminary ranking to pick graph seeds.
+		prelim := make([]string, 0, len(idSet))
+		for id := range idSet {
+			prelim = append(prelim, id)
+		}
+		sort.Slice(prelim, func(i, j int) bool { return scores[prelim[i]] > scores[prelim[j]] })
+
+		// Third signal: link-graph expansion from top seeds (additive-only).
+		s.applyGraphBonus(ctx, projectID, scores, idSet, prelim, limit, p)
+	}
+
+	// Sort by fused score, truncate, and hydrate.
+	ranked := make([]string, 0, len(idSet))
+	for id := range idSet {
+		ranked = append(ranked, id)
+	}
+	sort.Slice(ranked, func(i, j int) bool { return scores[ranked[i]] > scores[ranked[j]] })
+	if len(ranked) > limit {
+		ranked = ranked[:limit]
+	}
+
+	memories, err := s.GetByIDs(ctx, ranked)
+	if err != nil {
+		return nil, err
+	}
+	// Re-sort by fused score (GetByIDs doesn't preserve order).
+	sort.Slice(memories, func(i, j int) bool {
+		return scores[memories[i].ID] > scores[memories[j].ID]
+	})
+	return memories, nil
 }
 
 // SearchHybrid combines FTS5 keyword search with vector similarity using
 // Reciprocal Rank Fusion (RRF), plus an additive link-graph expansion bonus.
 // Falls back to FTS-only if queryVec is nil.
 func (s *Store) SearchHybrid(ctx context.Context, projectID, query string, queryVec []float32, limit int) ([]Memory, error) {
-	const k = 60 // RRF smoothing constant
+	return s.SearchHybridParams(ctx, projectID, query, queryVec, limit, DefaultSearchParams())
+}
 
+// SearchHybridParams is SearchHybrid with explicit fusion parameters. It
+// exists for the benchmark harness; production callers use SearchHybrid.
+func (s *Store) SearchHybridParams(ctx context.Context, projectID, query string, queryVec []float32, limit int, p SearchParams) ([]Memory, error) {
 	// FTS results.
 	ftsResults, err := s.SearchFTS(ctx, projectID, query, limit*2)
 	if err != nil {
@@ -194,64 +266,7 @@ func (s *Store) SearchHybrid(ctx context.Context, projectID, query string, query
 		return ftsResults, nil
 	}
 
-	// RRF fusion: score = 0.3/(k+fts_rank) + 0.7/(k+vec_rank)
-	scores := make(map[string]float64)
-	idSet := make(map[string]bool)
-
-	for rank, m := range ftsResults {
-		scores[m.ID] += 0.3 / float64(k+rank+1)
-		idSet[m.ID] = true
-	}
-	for rank, sm := range vecResults {
-		scores[sm.MemoryID] += 0.7 / float64(k+rank+1)
-		idSet[sm.MemoryID] = true
-	}
-
-	// Preliminary ranking to pick graph seeds.
-	prelim := make([]string, 0, len(idSet))
-	for id := range idSet {
-		prelim = append(prelim, id)
-	}
-	sort.Slice(prelim, func(i, j int) bool { return scores[prelim[i]] > scores[prelim[j]] })
-
-	// Third signal: link-graph expansion from top seeds (additive-only).
-	s.applyGraphBonus(ctx, projectID, scores, idSet, prelim, limit)
-
-	// Sort by fused score.
-	type idScore struct {
-		id    string
-		score float64
-	}
-	ranked := make([]idScore, 0, len(idSet))
-	for id := range idSet {
-		ranked = append(ranked, idScore{id: id, score: scores[id]})
-	}
-	sort.Slice(ranked, func(i, j int) bool {
-		return ranked[i].score > ranked[j].score
-	})
-
-	if len(ranked) > limit {
-		ranked = ranked[:limit]
-	}
-
-	// Build ID list for batch fetch.
-	ids := make([]string, len(ranked))
-	for i, r := range ranked {
-		ids[i] = r.id
-	}
-
-	memories, err := s.GetByIDs(ctx, ids)
-	if err != nil {
-		return nil, err
-	}
-
-	// Re-sort by fused score (GetByIDs doesn't preserve order).
-	scoreMap := scores
-	sort.Slice(memories, func(i, j int) bool {
-		return scoreMap[memories[i].ID] > scoreMap[memories[j].ID]
-	})
-
-	return memories, nil
+	return s.fuseAndRank(ctx, projectID, ftsResults, vecResults, limit, p)
 }
 
 // GetByIDs fetches memories by a list of IDs.
@@ -327,8 +342,6 @@ func (s *Store) SearchVectorAll(ctx context.Context, queryVec []float32, limit i
 // SearchHybridAll combines FTS5 and vector search across ALL projects using RRF.
 // Falls back to FTS-only when queryVec is nil.
 func (s *Store) SearchHybridAll(ctx context.Context, query string, queryVec []float32, limit int) ([]Memory, error) {
-	const k = 60
-
 	ftsResults, err := s.SearchFTSAll(ctx, query, limit*2)
 	if err != nil {
 		ftsResults = nil
@@ -353,53 +366,7 @@ func (s *Store) SearchHybridAll(ctx context.Context, query string, queryVec []fl
 		return ftsResults, nil
 	}
 
-	scores := make(map[string]float64)
-	idSet := make(map[string]bool)
-	for rank, m := range ftsResults {
-		scores[m.ID] += 0.3 / float64(k+rank+1)
-		idSet[m.ID] = true
-	}
-	for rank, sm := range vecResults {
-		scores[sm.MemoryID] += 0.7 / float64(k+rank+1)
-		idSet[sm.MemoryID] = true
-	}
-
-	// Preliminary ranking to pick graph seeds.
-	prelim := make([]string, 0, len(idSet))
-	for id := range idSet {
-		prelim = append(prelim, id)
-	}
-	sort.Slice(prelim, func(i, j int) bool { return scores[prelim[i]] > scores[prelim[j]] })
-
-	// Third signal: link-graph expansion from top seeds (additive-only).
-	s.applyGraphBonus(ctx, "", scores, idSet, prelim, limit)
-
-	type idScore struct {
-		id    string
-		score float64
-	}
-	ranked := make([]idScore, 0, len(idSet))
-	for id := range idSet {
-		ranked = append(ranked, idScore{id: id, score: scores[id]})
-	}
-	sort.Slice(ranked, func(i, j int) bool { return ranked[i].score > ranked[j].score })
-	if len(ranked) > limit {
-		ranked = ranked[:limit]
-	}
-
-	ids := make([]string, len(ranked))
-	for i, r := range ranked {
-		ids[i] = r.id
-	}
-	memories, err := s.GetByIDs(ctx, ids)
-	if err != nil {
-		return nil, err
-	}
-	scoreMap := scores
-	sort.Slice(memories, func(i, j int) bool {
-		return scoreMap[memories[i].ID] > scoreMap[memories[j].ID]
-	})
-	return memories, nil
+	return s.fuseAndRank(ctx, "", ftsResults, vecResults, limit, DefaultSearchParams())
 }
 
 func float32sToBytes(fs []float32) []byte {

--- a/internal/memory/vector.go
+++ b/internal/memory/vector.go
@@ -142,12 +142,20 @@ type SearchParams struct {
 }
 
 // DefaultSearchParams returns the production fusion parameters.
+//
+// GraphWeight ships at 0: the ghost bench --sweep grid showed the additive
+// graph bonus degrades ranking monotonically at every effective weight on the
+// graded dataset (the former 0.15 default demoted exact matches below
+// semantically-adjacent neighbors — see docs/benchmarks.md). The link graph
+// itself is still built and traversable; a redesigned bonus must beat
+// GraphWeight 0 in the sweep before it ships. GraphSeeds/GraphHops keep their
+// tuned values so an explicit non-zero GraphWeight behaves as before.
 func DefaultSearchParams() SearchParams {
 	return SearchParams{
 		FTSWeight:   0.3,
 		VecWeight:   0.7,
 		RRFK:        60,
-		GraphWeight: 0.15,
+		GraphWeight: 0,
 		GraphSeeds:  3,
 		GraphHops:   2,
 	}

--- a/internal/memory/vector_test.go
+++ b/internal/memory/vector_test.go
@@ -696,3 +696,62 @@ func TestSearchHybridGraphBonus(t *testing.T) {
 		t.Fatalf("linked c (rank %d) should outrank unlinked d (rank %d): %v", rc, rd, after)
 	}
 }
+
+// TestSearchHybridParams: the parameterized entrypoint must (a) reproduce
+// SearchHybrid exactly under DefaultSearchParams, (b) honor leg weights — an
+// all-vector weighting ranks the vector match first and an all-FTS weighting
+// ranks the keyword match first on the same store, (c) skip the graph pass
+// entirely when GraphWeight is 0.
+func TestSearchHybridParams(t *testing.T) {
+	store, ctx := setupTestStore(t)
+
+	// kw matches the FTS query; vec matches the query vector. Cross-wired
+	// embeddings so the two legs disagree about the winner.
+	kw := createTestMemory(t, store, ctx, "goroutines scheduler internals")
+	vec := createTestMemory(t, store, ctx, "python event loop design")
+	if err := store.StoreEmbedding(ctx, kw, []float32{0, 1}, "test-model"); err != nil {
+		t.Fatalf("StoreEmbedding: %v", err)
+	}
+	if err := store.StoreEmbedding(ctx, vec, []float32{1, 0}, "test-model"); err != nil {
+		t.Fatalf("StoreEmbedding: %v", err)
+	}
+	queryVec := []float32{1, 0}
+
+	// (a) Defaults reproduce SearchHybrid ranking exactly.
+	want, err := store.SearchHybrid(ctx, "test-proj", "goroutines", queryVec, 10)
+	if err != nil {
+		t.Fatalf("SearchHybrid: %v", err)
+	}
+	got, err := store.SearchHybridParams(ctx, "test-proj", "goroutines", queryVec, 10, DefaultSearchParams())
+	if err != nil {
+		t.Fatalf("SearchHybridParams: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("defaults mismatch: got %d results, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].ID != want[i].ID {
+			t.Errorf("defaults mismatch at rank %d: got %s, want %s", i, got[i].ID, want[i].ID)
+		}
+	}
+
+	// (b) All-vector weighting: vec first. All-FTS weighting: kw first.
+	p := DefaultSearchParams()
+	p.FTSWeight, p.VecWeight = 0, 1
+	if rs, err := store.SearchHybridParams(ctx, "test-proj", "goroutines", queryVec, 10, p); err != nil || len(rs) == 0 || rs[0].ID != vec {
+		t.Errorf("all-vector weighting should rank vector match first (err=%v, results=%v)", err, ids(rs))
+	}
+	p.FTSWeight, p.VecWeight = 1, 0
+	if rs, err := store.SearchHybridParams(ctx, "test-proj", "goroutines", queryVec, 10, p); err != nil || len(rs) == 0 || rs[0].ID != kw {
+		t.Errorf("all-FTS weighting should rank keyword match first (err=%v, results=%v)", err, ids(rs))
+	}
+}
+
+// ids extracts memory IDs for readable test failure output.
+func ids(ms []Memory) []string {
+	out := make([]string, len(ms))
+	for i, m := range ms {
+		out[i] = m.ID
+	}
+	return out
+}

--- a/internal/memory/vector_test.go
+++ b/internal/memory/vector_test.go
@@ -668,10 +668,16 @@ func TestSearchHybridGraphBonus(t *testing.T) {
 		return -1
 	}
 
+	// The graph MECHANISM is tested with an explicit non-zero weight —
+	// production defaults ship with GraphWeight 0 (see DefaultSearchParams),
+	// so the bonus only participates when a caller opts in.
+	pGraph := DefaultSearchParams()
+	pGraph.GraphWeight = 0.15
+
 	// Without links: a ranks first, and d strictly outranks c.
-	before, err := s.SearchHybrid(ctx, testProject, "kubernetes ingress", queryVec, 10)
+	before, err := s.SearchHybridParams(ctx, testProject, "kubernetes ingress", queryVec, 10, pGraph)
 	if err != nil {
-		t.Fatalf("SearchHybrid before: %v", err)
+		t.Fatalf("SearchHybridParams before: %v", err)
 	}
 	if rank(before, a) != 0 {
 		t.Fatalf("a should rank first, got order %v", before)
@@ -684,9 +690,9 @@ func TestSearchHybridGraphBonus(t *testing.T) {
 	if err := s.CreateLink(ctx, a, c, "related", 0.9, "auto"); err != nil {
 		t.Fatalf("CreateLink: %v", err)
 	}
-	after, err := s.SearchHybrid(ctx, testProject, "kubernetes ingress", queryVec, 10)
+	after, err := s.SearchHybridParams(ctx, testProject, "kubernetes ingress", queryVec, 10, pGraph)
 	if err != nil {
-		t.Fatalf("SearchHybrid after: %v", err)
+		t.Fatalf("SearchHybridParams after: %v", err)
 	}
 	if rank(after, a) != 0 {
 		t.Fatalf("a should still rank first, got order %v", after)
@@ -694,6 +700,16 @@ func TestSearchHybridGraphBonus(t *testing.T) {
 	rc, rd := rank(after, c), rank(after, d)
 	if rc == -1 || rd == -1 || rc >= rd {
 		t.Fatalf("linked c (rank %d) should outrank unlinked d (rank %d): %v", rc, rd, after)
+	}
+
+	// And with production defaults (GraphWeight 0), the link must NOT reorder:
+	// d keeps its strictly-better vector rank over linked c.
+	defAfter, err := s.SearchHybrid(ctx, testProject, "kubernetes ingress", queryVec, 10)
+	if err != nil {
+		t.Fatalf("SearchHybrid default after link: %v", err)
+	}
+	if rc, rd := rank(defAfter, c), rank(defAfter, d); rd == -1 || rc == -1 || rd >= rc {
+		t.Fatalf("default params must ignore links: d (rank %d) should outrank c (rank %d): %v", rd, rc, defAfter)
 	}
 }
 


### PR DESCRIPTION
## What

Three commits that turn the benchmark harness into a tuning instrument — and act on its first finding.

1. **refactor(memory):** the duplicated RRF pipeline in `SearchHybrid`/`SearchHybridAll` is extracted into a shared `fuseAndRank`, with every fusion knob (leg weights, RRF k, graph weight/seeds/hops) lifted into `memory.SearchParams`. `DefaultSearchParams` preserved behavior exactly — the bench regression floors, which pin default rankings, passed unchanged before the default change below.
2. **feat(bench):** `ghost bench --sweep` grid-searches vector-leg weight × graph-bonus weight (36 combinations) over the committed dataset, ranked by NDCG@10, with the production default marked. Sweep points are cross-checked in tests against the independent ablation runner.
3. **fix(memory):** `DefaultSearchParams` ships `GraphWeight 0`.

## The data behind the default change

The sweep showed the additive graph bonus degrades ranking **monotonically at every effective weight**: `graph=0` ties for best at every leg weighting; 0.05 costs ~2.5 NDCG points; 0.10 costs ~9; the former 0.15 default put production at NDCG 0.824 vs 0.989 with it off (R@1 0.500 vs 0.857) — it lifts semantically-adjacent neighbors above exact matches. Leg weights are robust (vec 0.3–0.7 all ≈0.99), so 70/30 stays.

What does NOT change: the linking worker, the `memory_links` graph, traversal, and the Obsidian mirror's graph view. The bonus mechanism stays available via `SearchHybridParams`; the `hybrid+graph` bench ablation opts into the candidate 0.15 weight so the signal remains under measurement. A redesigned bonus (relation-aware / seed-gated) ships only when it beats `graph=0` in this sweep.

Reproduce: `ghost bench --sweep` — deterministic, judge-free, no network. Methodology + full findings in `docs/benchmarks.md`.

## Verification

`go test -race -count=1 ./...` green; exact CI lint invocation → 0 issues; ablation table byte-identical to the documented numbers; independently code-reviewed pre-PR (behavioral identity of the refactor verified by line-diff, test oracles, and unchanged bench output).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable hybrid-search parameters, including FTS/vector weighting and optional graph-expansion ranking.
  * Added `ghost bench --sweep` to compare search configurations and display ranked benchmark results.

* **Improvements**
  * Graph-expansion ranking is now disabled by default to preserve exact-match performance.
  * Updated benchmark and search documentation with current behavior and findings.
  * Added coverage for configurable search ranking and parameter sweeps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->