### PR TITLE
fix: un-freeze the session counter, URI-safe OpenDB path handling

### DIFF
--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -29,6 +29,41 @@ func roDSN(dbPath string) string {
 	return u.String()
 }
 
+// bumpSessionCount increments the project's session counter and returns the
+// new count, or 0 on any failure. It is the session hook's single deliberate
+// write: its own short-lived read-write connection (URI-escaped like roDSN,
+// busy_timeout so a live MCP server never blocks it for long), guarded by an
+// existence check so a missing database is never created.
+func bumpSessionCount(dbPath, projectID string) int {
+	if _, err := os.Stat(dbPath); err != nil {
+		return 0
+	}
+	u := url.URL{
+		Scheme:   "file",
+		Opaque:   (&url.URL{Path: dbPath}).EscapedPath(),
+		RawQuery: "_pragma=busy_timeout(1000)",
+	}
+	db, err := sql.Open("sqlite", u.String())
+	if err != nil {
+		return 0
+	}
+	defer db.Close() //nolint:errcheck
+
+	var n int
+	err = db.QueryRow(`
+		INSERT INTO ghost_state (project_id, interaction_count)
+		VALUES (?, 1)
+		ON CONFLICT(project_id) DO UPDATE SET
+			interaction_count = interaction_count + 1,
+			updated_at = datetime('now')
+		RETURNING interaction_count
+	`, projectID).Scan(&n)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
 type sessionStartInput struct {
 	CWD    string `json:"cwd"`
 	Source string `json:"source"`
@@ -55,7 +90,19 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 		cwd = resolved
 	}
 
-	project, memories, learned, tasks, decisions, interactionCount := loadSessionContext(cwd)
+	projectID, project, memories, learned, tasks, decisions, interactionCount := loadSessionContext(cwd)
+
+	// Count this session. Context loading above is strictly read-only; the
+	// counter bump is the one deliberate write, scoped to its own short-lived
+	// connection and best-effort — on any failure (busy store, permissions)
+	// the stale stored count is shown instead. Never creates a database.
+	if projectID != "" {
+		if dataDir, err := config.DataDir(); err == nil {
+			if n := bumpSessionCount(filepath.Join(dataDir, "ghost.db"), projectID); n > 0 {
+				interactionCount = n
+			}
+		}
+	}
 
 	// Load globals unconditionally — they apply to every session regardless of project match.
 	var globalSection string
@@ -155,7 +202,7 @@ func loadGlobalMemories(dbPath string) [][2]string {
 	return out
 }
 
-func loadSessionContext(cwd string) (project string, memories [][3]string, learned string, tasks [][4]string, decisions [][2]string, interactionCount int) {
+func loadSessionContext(cwd string) (projectID, project string, memories [][3]string, learned string, tasks [][4]string, decisions [][2]string, interactionCount int) {
 	dataDir, err := config.DataDir()
 	if err != nil {
 		return
@@ -171,7 +218,6 @@ func loadSessionContext(cwd string) (project string, memories [][3]string, learn
 	defer db.Close() //nolint:errcheck
 
 	// Find matching project: try full path prefix first, then cwd basename name match
-	var projectID string
 	projectID, project = lookupProject(db, cwd)
 	if projectID == "" {
 		return

--- a/internal/mcpinit/hook_test.go
+++ b/internal/mcpinit/hook_test.go
@@ -191,3 +191,61 @@ func TestHandleSessionStartHook_GlobalsOnNoMatch(t *testing.T) {
 		t.Errorf("global memory content missing from no-match output; got:\n%s", result)
 	}
 }
+
+// TestSessionCounterIncrements: each hook invocation bumps the project's
+// session counter — the one deliberate write the hook makes — and the emitted
+// "Session #N" reflects the post-increment count.
+func TestSessionCounterIncrements(t *testing.T) {
+	xdgHome := t.TempDir()
+	ghostDir := filepath.Join(xdgHome, "ghost")
+	if err := os.MkdirAll(ghostDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	dbPath := filepath.Join(ghostDir, "ghost.db")
+
+	projDir := filepath.Join(t.TempDir(), "myproj")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("mkdir proj: %v", err)
+	}
+	// EvalSymlinks in the hook canonicalizes cwd; store the canonical path.
+	canonical, err := filepath.EvalSymlinks(projDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+
+	db, err := memory.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO projects (id, path, name) VALUES ('p1', ?, 'myproj')`, canonical); err != nil {
+		t.Fatalf("insert project: %v", err)
+	}
+	_ = db.Close()
+
+	t.Setenv("XDG_DATA_HOME", xdgHome)
+
+	run := func() string {
+		input, _ := json.Marshal(map[string]string{"cwd": projDir})
+		var out strings.Builder
+		HandleSessionStartHook(strings.NewReader(string(input)), &out)
+		return out.String()
+	}
+	if got := run(); !strings.Contains(got, "Session #1") {
+		t.Errorf("first run should show Session #1; got:\n%s", got)
+	}
+	if got := run(); !strings.Contains(got, "Session #2") {
+		t.Errorf("second run should show Session #2; got:\n%s", got)
+	}
+}
+
+// TestBumpSessionCountNoPhantomDB: the counter write path must never create a
+// database that isn't there.
+func TestBumpSessionCountNoPhantomDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "ghost.db")
+	if n := bumpSessionCount(dbPath, "p1"); n != 0 {
+		t.Errorf("bump on missing DB returned %d, want 0", n)
+	}
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Errorf("bumpSessionCount must not create %s", dbPath)
+	}
+}

--- a/internal/memory/schema.go
+++ b/internal/memory/schema.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"database/sql"
 	"fmt"
+	"net/url"
 
 	_ "modernc.org/sqlite"
 )
@@ -212,7 +213,17 @@ CREATE TABLE IF NOT EXISTS link_scans (
 
 // OpenDB opens or creates the SQLite database and runs migrations.
 func OpenDB(dbPath string) (*sql.DB, error) {
-	db, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)&_pragma=busy_timeout(5000)")
+	// File paths go through the file: URI form with the path percent-encoded —
+	// a '?' or '#' in the data-dir path (legal in $XDG_DATA_HOME/$HOME) would
+	// otherwise be parsed as the query/fragment separator, silently opening a
+	// truncated path. ":memory:" stays bare: the file::memory: URI form has
+	// different sharing semantics.
+	dsn := dbPath
+	if dbPath != ":memory:" {
+		u := url.URL{Scheme: "file", Opaque: (&url.URL{Path: dbPath}).EscapedPath()}
+		dsn = u.String()
+	}
+	db, err := sql.Open("sqlite", dsn+"?_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)&_pragma=busy_timeout(5000)")
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}

--- a/internal/memory/schema_test.go
+++ b/internal/memory/schema_test.go
@@ -1,0 +1,64 @@
+package memory
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOpenDBHostilePath: OpenDB must open the database at exactly the path it
+// was given even when the path contains URI-special characters ('?' or '#',
+// legal in $XDG_DATA_HOME/$HOME). A naive DSN concatenation parses those as
+// query/fragment separators and silently opens a truncated path instead.
+func TestOpenDBHostilePath(t *testing.T) {
+	for _, dirName := range []string{"we?rd", "we#rd", "with space"} {
+		t.Run(dirName, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), dirName)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			dbPath := filepath.Join(dir, "ghost.db")
+
+			db, err := OpenDB(dbPath)
+			if err != nil {
+				t.Fatalf("OpenDB(%q): %v", dbPath, err)
+			}
+			store := NewStore(db, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+			defer func() { _ = store.Close() }()
+
+			ctx := context.Background()
+			if err := store.EnsureProject(ctx, "p", "/tmp/p", "p"); err != nil {
+				t.Fatalf("EnsureProject: %v", err)
+			}
+			id, err := store.Create(ctx, "p", Memory{Category: "fact", Content: "roundtrip", Importance: 0.5, Source: "mcp"})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			got, err := store.GetByIDs(ctx, []string{id})
+			if err != nil || len(got) != 1 || got[0].Content != "roundtrip" {
+				t.Fatalf("roundtrip failed: %v %v", got, err)
+			}
+
+			// The database landed at the intended path — not a truncated one.
+			if _, err := os.Stat(dbPath); err != nil {
+				t.Errorf("database not at intended path %q: %v", dbPath, err)
+			}
+		})
+	}
+}
+
+// TestOpenDBInMemory: the ":memory:" special path must keep its bare form —
+// wrapping it in a file: URI would change its per-connection semantics.
+func TestOpenDBInMemory(t *testing.T) {
+	db, err := OpenDB(":memory:")
+	if err != nil {
+		t.Fatalf("OpenDB(:memory:): %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	var n int
+	if err := db.QueryRow(`SELECT count(*) FROM projects`).Scan(&n); err != nil {
+		t.Fatalf("schema not initialized on :memory:: %v", err)
+	}
+}


### PR DESCRIPTION
The two behavior-changing fixes deferred from the dead-code sweep (#180), each with regression tests:

1. **The session counter actually counts now.** `IncrementInteraction` had zero production callers, so the hook's "Session #N" was frozen forever at whatever an old version last wrote. The hook now bumps the counter as its single deliberate write — scoped to its own short-lived connection with a URI-escaped DSN and busy timeout, guarded so a missing database is never created (the read-only context-loading path is unchanged), and best-effort so a busy store degrades to showing the stored count. Verified live: the counter moved for the first time in months.

2. **`memory.OpenDB` is URI-safe.** The last bare-path DSN call site — a `?` or `#` in `$XDG_DATA_HOME`/`$HOME` silently opened a truncated path. Now percent-encoded `file:` URI, with `:memory:` deliberately left bare (the URI form changes sharing semantics). `TestOpenDBHostilePath` covers `?`, `#`, and spaces end-to-end.

`go test -race ./...` green, vet clean, full-run lint 0 issues.