### PR TITLE
fix(memory): gate Upsert dedup behind Jaccard 0.5 — stop silent merge of unrelated memories

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"strings"
+	"unicode"
 	"sync"
 	"time"
 
@@ -339,9 +340,13 @@ func (s *Store) Upsert(ctx context.Context, projectID, category, content, source
 	var existingImportance float32
 	var existingContent string
 
-	// Extract keywords for FTS match (strip FTS5 operators to prevent injection).
+	// Two-stage duplicate detection. Stage 1 (recall): the FTS OR-probe over
+	// the first 10 words retrieves merge candidates cheaply. Stage 2
+	// (precision): Jaccard >= upsertMergeThreshold over the full token sets
+	// confirms a true duplicate — the OR-probe alone treats a single shared
+	// word as a match, which silently swallowed unrelated saves.
 	ftsQuery := sanitizeFTS(content)
-	err = s.db.QueryRowContext(ctx, `
+	rows, err := s.db.QueryContext(ctx, `
 		SELECT m.id, m.importance, m.content
 		FROM memories m
 		JOIN memories_fts f ON f.rowid = m.rowid
@@ -349,10 +354,32 @@ func (s *Store) Upsert(ctx context.Context, projectID, category, content, source
 		  AND m.category = ?
 		  AND memories_fts MATCH ?
 		ORDER BY rank, m.importance DESC
-		LIMIT 1
-	`, projectID, category, ftsQuery).Scan(&existingID, &existingImportance, &existingContent)
+		LIMIT 5
+	`, projectID, category, ftsQuery)
+	if err == nil {
+		newTokens := tokenizeContent(content)
+		var bestSim float64
+		for rows.Next() {
+			var candID, candContent string
+			var candImportance float32
+			if scanErr := rows.Scan(&candID, &candImportance, &candContent); scanErr != nil {
+				continue
+			}
+			sim := jaccard(newTokens, tokenizeContent(candContent))
+			if sim >= upsertMergeThreshold && sim > bestSim {
+				bestSim = sim
+				existingID = candID
+				existingImportance = candImportance
+				existingContent = candContent
+			}
+		}
+		if rowsErr := rows.Err(); rowsErr != nil {
+			existingID = "" // treat a broken candidate scan as no match
+		}
+		_ = rows.Close()
+	}
 
-	if err == nil && existingID != "" {
+	if existingID != "" {
 		// Found a match — strengthen it.
 		newImportance := existingImportance + (importance * 0.2)
 		if newImportance > 1.0 {
@@ -1041,6 +1068,45 @@ func scanMemories(rows *sql.Rows) ([]Memory, error) {
 
 // sanitizeFTS strips FTS5 special operators from text to prevent query injection.
 // Extracts plain words and quotes each one so they're treated as literals.
+// upsertMergeThreshold is the minimum Jaccard similarity between full token
+// sets for Upsert to treat two memories as duplicates. Matches the 0.5 gate
+// reflection's SQLite tier uses, so save-time and reflection-time dedup agree
+// on what "duplicate" means.
+const upsertMergeThreshold = 0.5
+
+// tokenizeContent lowercases s and splits it into a set of alphanumeric
+// tokens longer than one rune. Mirrors reflection's tokenize so both dedup
+// layers score similarity identically.
+func tokenizeContent(s string) map[string]bool {
+	tokens := make(map[string]bool)
+	for _, word := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		if len(word) > 1 {
+			tokens[word] = true
+		}
+	}
+	return tokens
+}
+
+// jaccard computes the Jaccard similarity coefficient between two token sets.
+func jaccard(a, b map[string]bool) float64 {
+	if len(a) == 0 && len(b) == 0 {
+		return 1.0
+	}
+	intersection := 0
+	for token := range a {
+		if b[token] {
+			intersection++
+		}
+	}
+	union := len(a) + len(b) - intersection
+	if union == 0 {
+		return 0
+	}
+	return float64(intersection) / float64(union)
+}
+
 func sanitizeFTS(text string) string {
 	// Remove FTS5 operators and punctuation, keep only words.
 	var words []string

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -357,9 +357,12 @@ func (s *Store) Upsert(ctx context.Context, projectID, category, content, source
 		LIMIT 5
 	`, projectID, category, ftsQuery)
 	if err == nil {
+		// Token-free content (punctuation/single-char words only) can still
+		// FTS-match — sanitizeFTS keeps single-char words that tokenizeContent
+		// drops — and jaccard(∅,∅) scores 1.0. Never merge on empty tokens.
 		newTokens := tokenizeContent(content)
 		var bestSim float64
-		for rows.Next() {
+		for len(newTokens) > 0 && rows.Next() {
 			var candID, candContent string
 			var candImportance float32
 			if scanErr := rows.Scan(&candID, &candImportance, &candContent); scanErr != nil {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -117,6 +117,112 @@ func TestStoreUpsert(t *testing.T) {
 	}
 }
 
+func TestStoreUpsertNoMergeOnSharedWord(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Two unrelated same-category memories sharing a single common word
+	// ("Phase"). Reproduces the 2026-07-19 live bug: the FTS OR-probe alone
+	// treated any one-word overlap as a duplicate and silently swallowed
+	// the second save.
+	id1, merged, err := s.Upsert(ctx, testProject, "decision",
+		"Benchmark strategy decided: Phase one is LongMemEval retrieval eval with ablations",
+		"mcp", 0.8, nil)
+	if err != nil {
+		t.Fatalf("Upsert (first): %v", err)
+	}
+	if merged {
+		t.Error("first Upsert should not merge")
+	}
+
+	id2, merged, err := s.Upsert(ctx, testProject, "decision",
+		"MCP Phase two design approved: memory update tool, stop hook, promote to global",
+		"mcp", 0.8, nil)
+	if err != nil {
+		t.Fatalf("Upsert (second): %v", err)
+	}
+	if merged {
+		t.Error("unrelated content sharing one word must not merge")
+	}
+	if id2 == id1 {
+		t.Error("second Upsert should have created a distinct memory")
+	}
+
+	all, err := s.GetAll(ctx, testProject, 100)
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 memories, got %d", len(all))
+	}
+}
+
+func TestStoreUpsertNoMergeBelowThreshold(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Same topic vocabulary but genuinely different facts: token overlap is
+	// real yet below the 0.5 Jaccard gate, so both must survive.
+	_, _, err := s.Upsert(ctx, testProject, "gotcha",
+		"SQLite busy timeout must be set on the read-only hook connection",
+		"mcp", 0.7, nil)
+	if err != nil {
+		t.Fatalf("Upsert (first): %v", err)
+	}
+
+	_, merged, err := s.Upsert(ctx, testProject, "gotcha",
+		"SQLite FTS5 rank ordering is unstable across identical RRF scores in hybrid search",
+		"mcp", 0.7, nil)
+	if err != nil {
+		t.Fatalf("Upsert (second): %v", err)
+	}
+	if merged {
+		t.Error("below-threshold overlap must not merge")
+	}
+
+	all, err := s.GetAll(ctx, testProject, 100)
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 memories, got %d", len(all))
+	}
+}
+
+func TestStoreUpsertMergesBestCandidate(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Two existing memories; the new content shares one word with A but is a
+	// near-duplicate of B. It must merge into B, not the first FTS hit.
+	_, _, err := s.Upsert(ctx, testProject, "fact",
+		"Deployment pipeline uses GitHub Actions runners on the cluster",
+		"mcp", 0.7, nil)
+	if err != nil {
+		t.Fatalf("Upsert (A): %v", err)
+	}
+
+	idB, _, err := s.Upsert(ctx, testProject, "fact",
+		"Ollama embedding worker sweeps unembedded memories every two minutes",
+		"mcp", 0.7, nil)
+	if err != nil {
+		t.Fatalf("Upsert (B): %v", err)
+	}
+
+	idNew, merged, err := s.Upsert(ctx, testProject, "fact",
+		"Ollama embedding worker sweeps the unembedded memories every two minutes for cluster projects",
+		"mcp", 0.7, nil)
+	if err != nil {
+		t.Fatalf("Upsert (near-dup of B): %v", err)
+	}
+	if !merged {
+		t.Fatal("near-duplicate of B should merge")
+	}
+	if idNew != idB {
+		t.Errorf("should merge into B (%s), merged into %s", idB, idNew)
+	}
+}
+
 func TestStoreUpsertImportanceCap(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -189,6 +189,36 @@ func TestStoreUpsertNoMergeBelowThreshold(t *testing.T) {
 	}
 }
 
+func TestStoreUpsertNoMergeOnTokenFreeContent(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Contents whose tokens are all single characters produce EMPTY token
+	// sets (tokenizeContent keeps len>1 only) while still FTS-matching each
+	// other (sanitizeFTS keeps single-char words). jaccard(∅,∅) = 1.0, so
+	// without a guard these unrelated saves would spuriously merge.
+	_, _, err := s.Upsert(ctx, testProject, "fact", "a b c", "mcp", 0.5, nil)
+	if err != nil {
+		t.Fatalf("Upsert (first): %v", err)
+	}
+
+	_, merged, err := s.Upsert(ctx, testProject, "fact", "a x y", "mcp", 0.5, nil)
+	if err != nil {
+		t.Fatalf("Upsert (second): %v", err)
+	}
+	if merged {
+		t.Error("token-free contents must never merge")
+	}
+
+	all, err := s.GetAll(ctx, testProject, 100)
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 memories, got %d", len(all))
+	}
+}
+
 func TestStoreUpsertMergesBestCandidate(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Bug

`store.Upsert`'s duplicate probe reuses `sanitizeFTS`, which OR-joins the **first 10 words** of new content. Built for search recall, catastrophic for dedup precision: any new memory sharing **one word** (within its first 10) with any same-category memory FTS-matches, wins on rank, and the save silently "merges" into that unrelated memory — the new content is discarded (the longer-content CASE keeps the old text).

Reproduced live 4 consecutive times on 2026-07-19: saves swallowed by unrelated memories via the shared words "Phase", "design", "bug", and "duplicate". In a mature project this breaks the core *over-saving is free* promise — over-saving silently discards. Tracked as ghost task `97312D06`.

## Fix

Two-stage detection in `Upsert` only:

- **Stage 1 (recall, unchanged mechanism):** the FTS OR-probe retrieves the top 5 same-category candidates.
- **Stage 2 (precision, new):** Jaccard similarity ≥ 0.5 over full token sets confirms a true duplicate; the best-scoring candidate above the gate is strengthened. No candidate passes → normal insert.

The 0.5 threshold and tokenization mirror reflection's SQLite tier (`internal/reflection/tier_sqlite.go`), so save-time and reflection-time dedup agree on what "duplicate" means. `sanitizeFTS` itself is untouched — search callers depend on its OR recall. Missed dupes (< 0.5 overlap) remain reflection's job, as designed.

## Tests

- `TestStoreUpsertNoMergeOnSharedWord` — live-bug reproduction; failed before the fix, passes after.
- `TestStoreUpsertNoMergeBelowThreshold` — real-but-subthreshold overlap must not merge; failed before, passes after.
- `TestStoreUpsertMergesBestCandidate` — near-duplicate merges into the right candidate, not the first FTS hit.
- Existing merge tests (`TestStoreUpsert` at J=0.556, `TestStoreUpsertImportanceCap` at J=0.75) pass unchanged — no test weakening.

Verified end-to-end against the real MCP stdio server on an isolated DB: the one-shared-word save now returns "Memory saved" with a distinct ID; an exact re-save still merges into the original; `go vet` + full suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory deduplication to avoid merging entries that share only minimal content.
  * Ensured updates merge with the most closely matching existing memory instead of the first search result.
  * Added safer handling when candidate matching cannot be completed.

* **Tests**
  * Added coverage for similarity thresholds, weak matches, and selecting the best duplicate candidate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->