### PR TITLE
ci: LongMemEval-S regression floors in GitHub Actions

### DIFF
--- a/.github/workflows/longmemeval.yml
+++ b/.github/workflows/longmemeval.yml
@@ -1,0 +1,160 @@
+name: longmemeval
+
+# LongMemEval-S retrieval-only regression benchmark (see docs/benchmarks.md,
+# "Phase 1"). Judge-free, deterministic given a fixed embedding cache — this
+# workflow gates on metric FLOORS (bench/longmemeval -floors), not exact
+# rankings, since RRF scores can tie.
+#
+# - pull_request: fts only (no Ollama) — fast enough for PR latency.
+# - schedule / workflow_dispatch: fts + hybrid (Ollama + nomic-embed-text).
+#   Hybrid is skipped on pull_request because the first-ever embedding pass
+#   over the dataset is CPU-bound and slow (see the hybrid job below); a warm
+#   embed-cache (restored via actions/cache) makes subsequent runs fast.
+on:
+  workflow_dispatch:
+    inputs:
+      condition:
+        description: "Which condition(s) to run"
+        required: false
+        default: both
+        type: choice
+        options:
+          - both
+          - fts
+          - hybrid
+  schedule:
+    # Weekly, Monday 06:00 UTC.
+    - cron: "0 6 * * 1"
+  pull_request:
+    paths:
+      - "internal/memory/**"
+      - "bench/longmemeval/**"
+      - ".github/workflows/longmemeval.yml"
+
+permissions:
+  contents: read
+
+env:
+  # xiaowu0162/longmemeval-cleaned — the canonical cleaned -S variant (the
+  # original HF longmemeval dataset is deprecated; see docs/benchmarks.md).
+  # Verified 2026-07-19: resolve URL 302s to a signed CDN URL then 200s,
+  # content-length 277383467 bytes (~277MB), so a plain `curl -fL` download
+  # (following the redirect) works with no auth.
+  DATASET_URL: https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/resolve/main/longmemeval_s_cleaned.json
+
+jobs:
+  fts:
+    name: fts (retrieval-only, no Ollama)
+    runs-on: ubuntu-latest
+    # Skip only when a manual dispatch explicitly asked for hybrid alone.
+    if: github.event_name != 'workflow_dispatch' || inputs.condition != 'hybrid'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Set cache paths
+        run: echo "DATASET_PATH=$HOME/.cache/ghost-bench/longmemeval_s_cleaned.json" >> "$GITHUB_ENV"
+
+      - name: Restore LongMemEval-S dataset cache
+        id: cache-dataset
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.DATASET_PATH }}
+          key: longmemeval-s-cleaned-v1
+
+      - name: Download dataset (cache miss)
+        if: steps.cache-dataset.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$(dirname "$DATASET_PATH")"
+          curl -fL --retry 3 --retry-delay 5 -o "$DATASET_PATH" "$DATASET_URL"
+
+      - name: Run fts condition with regression floors
+        run: |
+          go run ./bench/longmemeval \
+            -data "$DATASET_PATH" \
+            -condition fts \
+            -floors "r5=0.74,ndcg10=0.72"
+        # Floors derived from published fts OVERALL numbers
+        # (docs/benchmarks.md, 2026-07-15 run, n=470): R@5 0.751 -> floor
+        # 0.74, NDCG@10 0.738 -> floor 0.72. ~0.01-0.02 safety margin below
+        # the observed score: enough to catch a real regression, loose
+        # enough to tolerate RRF tie jitter.
+
+  hybrid:
+    name: hybrid (Ollama embeddings)
+    runs-on: ubuntu-latest
+    # Never on pull_request — cold-cache embedding is too slow for PR
+    # latency. Runs on schedule always, and on manual dispatch unless the
+    # input explicitly asked for fts alone.
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.condition != 'fts')
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Set cache paths
+        run: |
+          echo "DATASET_PATH=$HOME/.cache/ghost-bench/longmemeval_s_cleaned.json" >> "$GITHUB_ENV"
+          echo "EMBED_CACHE_PATH=$HOME/.cache/ghost-bench/embed-cache.jsonl" >> "$GITHUB_ENV"
+
+      - name: Restore LongMemEval-S dataset cache
+        id: cache-dataset
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.DATASET_PATH }}
+          key: longmemeval-s-cleaned-v1
+
+      - name: Download dataset (cache miss)
+        if: steps.cache-dataset.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$(dirname "$DATASET_PATH")"
+          curl -fL --retry 3 --retry-delay 5 -o "$DATASET_PATH" "$DATASET_URL"
+
+      - name: Restore embedding cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.EMBED_CACHE_PATH }}
+          key: longmemeval-embed-cache-v1
+
+      - name: Install Ollama
+        run: curl -fsSL https://ollama.com/install.sh | sh
+
+      - name: Start Ollama
+        run: |
+          ollama serve > /tmp/ollama.log 2>&1 &
+          for i in $(seq 1 60); do
+            curl -sf http://localhost:11434/api/tags >/dev/null 2>&1 && exit 0
+            sleep 1
+          done
+          echo "ollama serve did not become ready in time"; cat /tmp/ollama.log; exit 1
+
+      - name: Pull embedding model
+        # Must match embedModel in bench/longmemeval/embed.go exactly —
+        # /api/embed does not auto-pull, and an untagged "nomic-embed-text"
+        # pull leaves the v1.5 tag missing, so a 404 fails the run outright.
+        run: ollama pull nomic-embed-text:v1.5
+
+      - name: Run hybrid condition with regression floors
+        run: |
+          mkdir -p "$(dirname "$EMBED_CACHE_PATH")"
+          go run ./bench/longmemeval \
+            -data "$DATASET_PATH" \
+            -condition hybrid \
+            -ollama http://localhost:11434 \
+            -embed-cache "$EMBED_CACHE_PATH" \
+            -floors "r5=0.91,ndcg10=0.89"
+        # Floors derived from published hybrid OVERALL numbers
+        # (docs/benchmarks.md, 2026-07-15 run, n=470): R@5 0.930 -> floor
+        # 0.91, NDCG@10 0.903 -> floor 0.89. Same ~0.01-0.02 safety margin
+        # as the fts job. First run on a cold embed-cache embeds the whole
+        # dataset on CPU and is slow (hence the generous timeout above);
+        # once actions/cache has a warm entry under
+        # longmemeval-embed-cache-v1, subsequent runs are fast (only new/
+        # changed content gets embedded).

--- a/bench/longmemeval/main.go
+++ b/bench/longmemeval/main.go
@@ -15,12 +15,20 @@
 //
 //	go run ./bench/longmemeval --data ~/.cache/ghost-bench/longmemeval_s_cleaned.json \
 //	    --condition fts|vector|hybrid [--questions N] [--out per-question.jsonl] \
-//	    [--ollama http://localhost:11434] [--embed-cache ~/.cache/ghost-bench/nomic-cache.jsonl]
+//	    [--ollama http://localhost:11434] [--embed-cache ~/.cache/ghost-bench/nomic-cache.jsonl] \
+//	    [--floors "r5=0.74,ndcg10=0.72"]
 //
 // The fts condition needs no embeddings and runs in minutes. vector/hybrid
 // embed every turn and question through local Ollama (nomic-embed-text:v1.5),
 // memoized in an append-only content-hash cache so shared sessions across
 // questions and repeat runs cost nothing.
+//
+// --floors takes a comma-separated metric=min spec over the OVERALL
+// (all-questions) aggregate — accepted keys r1, r5, r10, mrr10, ndcg10,
+// case-insensitive. After the normal table prints, any violated floor logs a
+// "FLOOR VIOLATION: metric = got < min" line to stderr and the process exits
+// 1, for use as a CI regression gate. An unknown key or malformed spec is
+// validated before the benchmark runs and exits 1 immediately.
 //
 // See docs/benchmarks.md ("Phase 1") for methodology and reporting rules.
 package main
@@ -34,6 +42,8 @@ import (
 	"log/slog"
 	"os"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/wcatz/ghost/internal/bench"
@@ -82,6 +92,84 @@ func (a *agg) add(r1, r5, r10, mrr, ndcg float64) {
 	a.ndcg += ndcg
 }
 
+// floorMetricKeys are the only metric names -floors accepts, matching the
+// per-question-type table's columns.
+var floorMetricKeys = map[string]bool{
+	"r1": true, "r5": true, "r10": true, "mrr10": true, "ndcg10": true,
+}
+
+// overallMetrics averages an agg's sums into the canonical, floor-key-named
+// metrics map. agg accumulates sums across questions (see add); this is the
+// only place those sums become means.
+func overallMetrics(a *agg) map[string]float64 {
+	if a.n == 0 {
+		return map[string]float64{"r1": 0, "r5": 0, "r10": 0, "mrr10": 0, "ndcg10": 0}
+	}
+	n := float64(a.n)
+	return map[string]float64{
+		"r1":     a.r1 / n,
+		"r5":     a.r5 / n,
+		"r10":    a.r10 / n,
+		"mrr10":  a.mrr / n,
+		"ndcg10": a.ndcg / n,
+	}
+}
+
+// parseFloors parses a comma-separated "metric=min" spec (e.g.
+// "r5=0.74,ndcg10=0.72") into a floor map. Metric keys are case-insensitive
+// and must be one of floorMetricKeys. Returns an error on any unknown key or
+// malformed pair — called before the benchmark runs, so a bad spec fails
+// fast. An empty (or all-whitespace) spec parses to an empty, non-nil map.
+func parseFloors(spec string) (map[string]float64, error) {
+	floors := make(map[string]float64)
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return floors, nil
+	}
+	for _, pair := range strings.Split(spec, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("malformed floor %q: expected metric=min", pair)
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		if !floorMetricKeys[key] {
+			return nil, fmt.Errorf("unknown floor metric %q: must be one of r1, r5, r10, mrr10, ndcg10", key)
+		}
+		val, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("malformed floor value for %q: %w", key, err)
+		}
+		floors[key] = val
+	}
+	return floors, nil
+}
+
+// checkFloors compares overall metrics against floors and returns one
+// "FLOOR VIOLATION: ..." message per breach (overall < floor), in stable
+// key-sorted order. Exact equality is not a violation. Empty floors always
+// yields no violations.
+func checkFloors(overall map[string]float64, floors map[string]float64) []string {
+	keys := make([]string, 0, len(floors))
+	for k := range floors {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var violations []string
+	for _, k := range keys {
+		floor := floors[k]
+		got := overall[k]
+		if got < floor {
+			violations = append(violations, fmt.Sprintf("FLOOR VIOLATION: %s = %.3f < %.3f", k, got, floor))
+		}
+	}
+	return violations
+}
+
 func main() {
 	dataPath := flag.String("data", "", "path to longmemeval_s_cleaned.json (required)")
 	condition := flag.String("condition", "fts", "fts | vector | hybrid")
@@ -89,7 +177,16 @@ func main() {
 	outPath := flag.String("out", "", "per-question JSONL results log")
 	ollamaURL := flag.String("ollama", "http://localhost:11434", "Ollama URL for vector/hybrid")
 	embedCache := flag.String("embed-cache", "", "append-only embedding cache JSONL (vector/hybrid)")
+	floorsSpec := flag.String("floors", "", "comma-separated metric=min floors over OVERALL metrics, e.g. \"r5=0.74,ndcg10=0.72\" (keys: r1, r5, r10, mrr10, ndcg10)")
 	flag.Parse()
+
+	// Parse -floors before any other validation: an unknown key or malformed
+	// spec must fail fast, before the (potentially long) benchmark runs.
+	floors, err := parseFloors(*floorsSpec)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
 
 	if *dataPath == "" {
 		fmt.Fprintln(os.Stderr, "error: --data is required")
@@ -200,6 +297,13 @@ func main() {
 	if embedder != nil {
 		hits, misses := embedder.Stats()
 		fmt.Printf("Embedding cache: %d hits, %d computed.\n", hits, misses)
+	}
+
+	if violations := checkFloors(overallMetrics(overall), floors); len(violations) > 0 {
+		for _, v := range violations {
+			fmt.Fprintln(os.Stderr, v)
+		}
+		os.Exit(1)
 	}
 }
 

--- a/bench/longmemeval/main_test.go
+++ b/bench/longmemeval/main_test.go
@@ -24,3 +24,112 @@ func TestIsAbstention(t *testing.T) {
 		t.Error("plain id must not be abstention")
 	}
 }
+
+func TestParseFloors(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		want    map[string]float64
+		wantErr bool
+	}{
+		{"empty spec", "", map[string]float64{}, false},
+		{"single pair", "r5=0.74", map[string]float64{"r5": 0.74}, false},
+		{"multiple pairs", "r5=0.74,ndcg10=0.72", map[string]float64{"r5": 0.74, "ndcg10": 0.72}, false},
+		{"all known keys", "r1=0.1,r5=0.2,r10=0.3,mrr10=0.4,ndcg10=0.5",
+			map[string]float64{"r1": 0.1, "r5": 0.2, "r10": 0.3, "mrr10": 0.4, "ndcg10": 0.5}, false},
+		{"case-insensitive keys", "R5=0.74,NDCG10=0.72", map[string]float64{"r5": 0.74, "ndcg10": 0.72}, false},
+		{"tolerates whitespace", " r5 = 0.74 , mrr10 = 0.9 ", map[string]float64{"r5": 0.74, "mrr10": 0.9}, false},
+		{"unknown metric key", "bogus=1", nil, true},
+		{"unknown key among valid ones", "r5=0.7,bogus=1", nil, true},
+		{"missing equals sign", "r5", nil, true},
+		{"non-numeric value", "r5=notanumber", nil, true},
+		{"empty value", "r5=", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseFloors(tt.spec)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseFloors(%q) = %v, nil; want error", tt.spec, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseFloors(%q): unexpected error: %v", tt.spec, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseFloors(%q) = %v, want %v", tt.spec, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOverallMetrics(t *testing.T) {
+	// Mirrors the published fts OVERALL row: agg holds sums across n
+	// questions, not means — overallMetrics must divide by n, not pass
+	// sums straight through (that would silently defeat every floor).
+	a := &agg{n: 2, r1: 1.0, r5: 1.6, r10: 1.8, mrr: 1.5, ndcg: 1.4}
+	got := overallMetrics(a)
+	want := map[string]float64{"r1": 0.5, "r5": 0.8, "r10": 0.9, "mrr10": 0.75, "ndcg10": 0.7}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("overallMetrics(%+v) = %v, want %v", a, got, want)
+	}
+}
+
+func TestOverallMetricsZeroQuestions(t *testing.T) {
+	got := overallMetrics(&agg{})
+	for k, v := range got {
+		if v != 0 {
+			t.Errorf("overallMetrics(empty)[%q] = %v, want 0", k, v)
+		}
+	}
+}
+
+func TestCheckFloors(t *testing.T) {
+	// Published fts OVERALL numbers (docs/benchmarks.md).
+	overall := map[string]float64{"r1": 0.429, "r5": 0.751, "r10": 0.832, "mrr10": 0.758, "ndcg10": 0.738}
+
+	t.Run("empty floors is never a violation", func(t *testing.T) {
+		if got := checkFloors(overall, map[string]float64{}); len(got) != 0 {
+			t.Errorf("expected no violations, got %v", got)
+		}
+	})
+
+	t.Run("floors below observed pass", func(t *testing.T) {
+		got := checkFloors(overall, map[string]float64{"r5": 0.74, "ndcg10": 0.72})
+		if len(got) != 0 {
+			t.Errorf("expected no violations, got %v", got)
+		}
+	})
+
+	t.Run("single violation formatted", func(t *testing.T) {
+		got := checkFloors(overall, map[string]float64{"r5": 0.80})
+		if len(got) != 1 {
+			t.Fatalf("expected 1 violation, got %v", got)
+		}
+		want := "FLOOR VIOLATION: r5 = 0.751 < 0.800"
+		if got[0] != want {
+			t.Errorf("violation = %q, want %q", got[0], want)
+		}
+	})
+
+	t.Run("multiple violations in stable sorted order", func(t *testing.T) {
+		got := checkFloors(overall, map[string]float64{"r5": 0.90, "r1": 0.99, "ndcg10": 0.1})
+		if len(got) != 2 {
+			t.Fatalf("expected 2 violations (r1, r5 fail; ndcg10 passes), got %v", got)
+		}
+		if got[0] != "FLOOR VIOLATION: r1 = 0.429 < 0.990" {
+			t.Errorf("got[0] = %q", got[0])
+		}
+		if got[1] != "FLOOR VIOLATION: r5 = 0.751 < 0.900" {
+			t.Errorf("got[1] = %q", got[1])
+		}
+	})
+
+	t.Run("exact equality is not a violation", func(t *testing.T) {
+		got := checkFloors(overall, map[string]float64{"r5": 0.751})
+		if len(got) != 0 {
+			t.Errorf("expected no violation at exact equality, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Wires the LongMemEval-S retrieval benchmark (`bench/longmemeval/`) into CI as a real regression gate, and adds the mechanism needed for that: a `-floors` flag on the harness so a run can fail (exit 1) instead of just printing a table.

**What runs when:**

| Trigger | `fts` job | `hybrid` job |
|---|---|---|
| `pull_request` (paths: `internal/memory/**`, `bench/longmemeval/**`, this workflow) | yes | no — cold-cache embedding is too slow for PR latency |
| `schedule` (weekly, Monday 06:00 UTC) | yes | yes |
| `workflow_dispatch` (input `condition`: `both`/`fts`/`hybrid`, default `both`) | yes, unless `condition=hybrid` | yes, unless `condition=fts` |

**Floor derivation** (published OVERALL numbers, `docs/benchmarks.md`, 2026-07-15 run, n=470) minus a ~0.01–0.02 safety margin — enough to catch a real regression, loose enough to tolerate RRF tie jitter (the repo's own stated policy: assert floors, not exact rankings):

| condition | metric | published | floor | margin |
|---|---|---|---|---|
| fts | R@5 | 0.751 | 0.74 | 0.011 |
| fts | NDCG@10 | 0.738 | 0.72 | 0.018 |
| hybrid | R@5 | 0.930 | 0.91 | 0.020 |
| hybrid | NDCG@10 | 0.903 | 0.89 | 0.013 |

**Cache strategy:**
- Dataset (`longmemeval_s_cleaned.json`, ~277MB, `xiaowu0162/longmemeval-cleaned`) cached via `actions/cache` (key `longmemeval-s-cleaned-v1`); downloaded only on a cache miss. Verified the resolve URL (`.../resolve/main/longmemeval_s_cleaned.json`) directly — 302 to a signed CDN URL, then 200, `content-length: 277383467`.
- Embedding cache (Ollama `nomic-embed-text:v1.5`) cached via `actions/cache` (key `longmemeval-embed-cache-v1`), append-only content-hash keyed, so repeat runs and new content share it.
- Caveat: PR-scoped caches don't cross-populate between branches, so a new PR touching the watched paths pays the dataset download once until the first scheduled (default-branch) run seeds the shared cache. Self-heals weekly.

**Known slow-path note:** `docs/benchmarks.md` reports the original cold local embedding pass took ~12h on ARM64 CPU. The `hybrid` job's `timeout-minutes: 120` is generous per the task spec, but if the very first cold run doesn't finish inside that window the job is cancelled and the embed-cache may not get seeded — in that case a manual longer-running `workflow_dispatch` (or a locally-produced cache uploaded once) may be needed to seed `longmemeval-embed-cache-v1` before the weekly schedule becomes fast. Once seeded, only new/changed content re-embeds.

## Changes

1. `bench/longmemeval/main.go` (+tests): `-floors "metric=min,..."` flag (keys `r1`, `r5`, `r10`, `mrr10`, `ndcg10`, case-insensitive) checked against the OVERALL aggregate after the normal table prints. Any violation logs `FLOOR VIOLATION: metric = got < min` to stderr and exits 1. Spec parsing/validation runs before `-data` is required, so a malformed/unknown-key spec fails fast, before any benchmark run — verified locally: `go run ./bench/longmemeval -floors "bogus=1"` (no `-data`) fails on the unknown key first.
2. `.github/workflows/longmemeval.yml`: new workflow per the trigger/job matrix above. Does not touch `ci.yml` or `release.yml`.

## Test plan

- [x] TDD: wrote failing tests (`TestParseFloors`, `TestOverallMetrics`, `TestCheckFloors`) first — confirmed RED (compile error, missing functions) — then implemented — GREEN.
- [x] `go vet ./bench/longmemeval/`, `go test ./bench/longmemeval/`, `gofmt -l bench/longmemeval/` all clean.
- [x] `go run ./bench/longmemeval -floors "bogus=1"` (no `-data`) fails fast on the unknown key, before complaining about missing `-data`.
- [x] `actionlint .github/workflows/longmemeval.yml` clean (installed locally via `go install github.com/rhysd/actionlint/cmd/actionlint@latest`, no pre-existing binary on PATH).
- [x] Verified the HF resolve URL with `curl -sIL`: 302 → 200, `content-length: 277383467` (~277MB), matches expectation.
- [ ] Not run locally: the actual benchmark (dataset not present in the worktree, ~277MB, deliberately not downloaded per task instructions) and the `hybrid` job's live Ollama path — these will get their first real signal from CI itself (PR run exercises `fts`; `hybrid` needs a scheduled or manual dispatch run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)