### PR TITLE
feat(memory): PRAGMA user_version schema migrations in OpenDB

### DIFF
--- a/internal/memory/migrate.go
+++ b/internal/memory/migrate.go
@@ -1,0 +1,215 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// schemaVersion is the current schema version, stamped into PRAGMA user_version.
+// Bump it and append to migrations whenever initSQL changes in a way that
+// CREATE TABLE IF NOT EXISTS cannot deliver to existing databases (new columns,
+// CHECK values, foreign keys, dropped tables).
+const schemaVersion = 1
+
+// migrations[i] upgrades a database from user_version i to i+1. Each step is
+// frozen in time — it must keep working against the schema as it existed when
+// the step was written, so it carries its own DDL copies rather than reusing
+// initSQL (which keeps moving). Steps introspect sqlite_master and skip work
+// that is already done, so a hand-migrated database is stamped without harm.
+var migrations = []func(*sql.Tx) error{
+	migrateV1,
+}
+
+// migrate brings an existing database up to schemaVersion. Fresh databases
+// (detected by the caller) are stamped directly and never pass through here.
+// Table rebuilds require foreign_keys=OFF, which is a no-op inside a
+// transaction — so the pragma is toggled on a pinned connection around each
+// step, and foreign_key_check runs before the version stamp is committed.
+func migrate(db *sql.DB, from int) error {
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("pin connection: %w", err)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	for v := from; v < schemaVersion; v++ {
+		if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys=OFF"); err != nil {
+			return fmt.Errorf("migration %d: foreign_keys off: %w", v+1, err)
+		}
+		err := func() error {
+			tx, err := conn.BeginTx(ctx, nil)
+			if err != nil {
+				return fmt.Errorf("begin: %w", err)
+			}
+			defer tx.Rollback() //nolint:errcheck
+			if err := migrations[v](tx); err != nil {
+				return err
+			}
+			var table, rowid, parent, fkid any
+			if err := tx.QueryRow("PRAGMA foreign_key_check").Scan(&table, &rowid, &parent, &fkid); err != sql.ErrNoRows {
+				return fmt.Errorf("foreign_key_check failed: table=%v rowid=%v parent=%v (%v)", table, rowid, parent, err)
+			}
+			if _, err := tx.Exec(fmt.Sprintf("PRAGMA user_version = %d", v+1)); err != nil {
+				return fmt.Errorf("stamp user_version: %w", err)
+			}
+			return tx.Commit()
+		}()
+		if _, ferr := conn.ExecContext(ctx, "PRAGMA foreign_keys=ON"); ferr != nil && err == nil {
+			err = fmt.Errorf("foreign_keys on: %w", ferr)
+		}
+		if err != nil {
+			return fmt.Errorf("migration %d: %w", v+1, err)
+		}
+	}
+	return nil
+}
+
+// migrateV1 fixes drift accumulated before versioning existed:
+//  1. memories.source CHECK gains 'onboarding' and 'decision_log' — without
+//     them every decision-log memory mirror insert fails the constraint.
+//  2. memory_snapshots.project_id gains REFERENCES projects(id) ON DELETE CASCADE.
+//  3. Pre-v0.8.0 assistant-era tables (notifications, reminders, scheduled_jobs)
+//     are dropped.
+//
+// SQLite cannot ALTER a CHECK constraint or add a foreign key, so both fixes
+// are full table rebuilds. The memories rebuild preserves rowids (the FTS
+// external-content index is keyed on them) and rebuilds the FTS index after.
+func migrateV1(tx *sql.Tx) error {
+	stale, err := tableDDLLacks(tx, "memories", "'decision_log'")
+	if err != nil {
+		return err
+	}
+	if stale {
+		if err := rebuildMemoriesV1(tx); err != nil {
+			return fmt.Errorf("rebuild memories: %w", err)
+		}
+	}
+
+	stale, err = tableDDLLacks(tx, "memory_snapshots", "REFERENCES projects")
+	if err != nil {
+		return err
+	}
+	if stale {
+		if err := rebuildSnapshotsV1(tx); err != nil {
+			return fmt.Errorf("rebuild memory_snapshots: %w", err)
+		}
+	}
+
+	for _, t := range []string{"notifications", "reminders", "scheduled_jobs"} {
+		if _, err := tx.Exec("DROP TABLE IF EXISTS " + t); err != nil {
+			return fmt.Errorf("drop %s: %w", t, err)
+		}
+	}
+	return nil
+}
+
+// tableDDLLacks reports whether the named table exists and its stored DDL does
+// NOT contain marker — i.e. the table needs rebuilding. A missing table needs
+// no rebuild: initSQL has already created it in current form.
+func tableDDLLacks(tx *sql.Tx, table, marker string) (bool, error) {
+	var ddl string
+	err := tx.QueryRow(
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`, table,
+	).Scan(&ddl)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read %s DDL: %w", table, err)
+	}
+	return !strings.Contains(ddl, marker), nil
+}
+
+func rebuildMemoriesV1(tx *sql.Tx) error {
+	stmts := []string{
+		`DROP TRIGGER IF EXISTS memories_ai`,
+		`DROP TRIGGER IF EXISTS memories_ad`,
+		`DROP TRIGGER IF EXISTS memories_au`,
+		`DROP TABLE IF EXISTS memories_fts`,
+		`CREATE TABLE memories_v1_new (
+    id            TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    category      TEXT NOT NULL DEFAULT 'fact'
+                  CHECK (category IN (
+                      'architecture', 'decision', 'pattern', 'convention',
+                      'gotcha', 'dependency', 'preference', 'fact'
+                  )),
+    content       TEXT NOT NULL,
+    importance    REAL NOT NULL DEFAULT 0.5,
+    access_count  INTEGER NOT NULL DEFAULT 0,
+    last_accessed TEXT,
+    source        TEXT NOT NULL DEFAULT 'reflection'
+                  CHECK (source IN ('reflection', 'chat', 'manual', 'tool', 'mcp', 'onboarding', 'decision_log')),
+    tags          TEXT DEFAULT '[]',
+    pinned        INTEGER NOT NULL DEFAULT 0,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+)`,
+		`INSERT INTO memories_v1_new (rowid, id, project_id, category, content, importance,
+    access_count, last_accessed, source, tags, pinned, created_at, updated_at)
+SELECT rowid, id, project_id, category, content, importance,
+    access_count, last_accessed, source, tags, pinned, created_at, updated_at
+FROM memories`,
+		`DROP TABLE memories`,
+		`ALTER TABLE memories_v1_new RENAME TO memories`,
+		`CREATE VIRTUAL TABLE memories_fts USING fts5(
+    content,
+    content=memories,
+    content_rowid=rowid,
+    tokenize='porter unicode61'
+)`,
+		`CREATE TRIGGER memories_ai AFTER INSERT ON memories BEGIN
+    INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+END`,
+		`CREATE TRIGGER memories_ad AFTER DELETE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content) VALUES('delete', old.rowid, old.content);
+END`,
+		`CREATE TRIGGER memories_au AFTER UPDATE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content) VALUES('delete', old.rowid, old.content);
+    INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+END`,
+		`INSERT INTO memories_fts(memories_fts) VALUES('rebuild')`,
+		`CREATE INDEX IF NOT EXISTS idx_memories_project_cat ON memories(project_id, category)`,
+		`CREATE INDEX IF NOT EXISTS idx_memories_project_imp ON memories(project_id, importance DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_memories_project_source ON memories(project_id, source)`,
+	}
+	for _, s := range stmts {
+		if _, err := tx.Exec(s); err != nil {
+			return fmt.Errorf("%q: %w", s[:min(40, len(s))], err)
+		}
+	}
+	return nil
+}
+
+func rebuildSnapshotsV1(tx *sql.Tx) error {
+	stmts := []string{
+		`CREATE TABLE memory_snapshots_v1_new (
+    id            TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    snapshot_id   TEXT NOT NULL,
+    project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    category      TEXT NOT NULL,
+    content       TEXT NOT NULL,
+    importance    REAL NOT NULL,
+    source        TEXT NOT NULL,
+    tags          TEXT DEFAULT '[]',
+    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+)`,
+		`INSERT INTO memory_snapshots_v1_new (id, snapshot_id, project_id, category,
+    content, importance, source, tags, created_at)
+SELECT id, snapshot_id, project_id, category,
+    content, importance, source, tags, created_at
+FROM memory_snapshots`,
+		`DROP TABLE memory_snapshots`,
+		`ALTER TABLE memory_snapshots_v1_new RENAME TO memory_snapshots`,
+		`CREATE INDEX IF NOT EXISTS idx_snapshots_project ON memory_snapshots(project_id, snapshot_id)`,
+	}
+	for _, s := range stmts {
+		if _, err := tx.Exec(s); err != nil {
+			return fmt.Errorf("%q: %w", s[:min(40, len(s))], err)
+		}
+	}
+	return nil
+}

--- a/internal/memory/migrate_test.go
+++ b/internal/memory/migrate_test.go
@@ -1,0 +1,271 @@
+package memory
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// legacySQL approximates a pre-versioning database: memories.source CHECK
+// without 'onboarding'/'decision_log', memory_snapshots without its FK, and
+// the pre-v0.8.0 assistant-era tables still present.
+const legacySQL = `
+CREATE TABLE projects (
+    id          TEXT PRIMARY KEY,
+    path        TEXT NOT NULL UNIQUE,
+    name        TEXT NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE memories (
+    id            TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    category      TEXT NOT NULL DEFAULT 'fact'
+                  CHECK (category IN (
+                      'architecture', 'decision', 'pattern', 'convention',
+                      'gotcha', 'dependency', 'preference', 'fact'
+                  )),
+    content       TEXT NOT NULL,
+    importance    REAL NOT NULL DEFAULT 0.5,
+    access_count  INTEGER NOT NULL DEFAULT 0,
+    last_accessed TEXT,
+    source        TEXT NOT NULL DEFAULT 'reflection'
+                  CHECK (source IN ('reflection', 'chat', 'manual', 'tool', 'mcp')),
+    tags          TEXT DEFAULT '[]',
+    pinned        INTEGER NOT NULL DEFAULT 0,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE VIRTUAL TABLE memories_fts USING fts5(
+    content,
+    content=memories,
+    content_rowid=rowid,
+    tokenize='porter unicode61'
+);
+
+CREATE TRIGGER memories_ai AFTER INSERT ON memories BEGIN
+    INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+CREATE TRIGGER memories_ad AFTER DELETE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content) VALUES('delete', old.rowid, old.content);
+END;
+
+CREATE TRIGGER memories_au AFTER UPDATE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content) VALUES('delete', old.rowid, old.content);
+    INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+CREATE TABLE memory_snapshots (
+    id            TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    snapshot_id   TEXT NOT NULL,
+    project_id    TEXT NOT NULL,
+    category      TEXT NOT NULL,
+    content       TEXT NOT NULL,
+    importance    REAL NOT NULL,
+    source        TEXT NOT NULL,
+    tags          TEXT DEFAULT '[]',
+    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE notifications (id INTEGER PRIMARY KEY, body TEXT);
+CREATE TABLE reminders (id INTEGER PRIMARY KEY, body TEXT);
+CREATE TABLE scheduled_jobs (id INTEGER PRIMARY KEY, body TEXT);
+`
+
+// newLegacyDB writes a legacy-schema database with sample rows and returns its path.
+func newLegacyDB(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "ghost.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+	if _, err := db.Exec(legacySQL); err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+	seed := []string{
+		`INSERT INTO projects (id, path, name) VALUES ('p1', '/tmp/legacy-p1', 'p1')`,
+		`INSERT INTO memories (id, project_id, category, content, source) VALUES
+			('m1', 'p1', 'fact', 'obsidian vault mirror is one-way', 'mcp'),
+			('m2', 'p1', 'gotcha', 'fts rebuild preserves rowids', 'reflection')`,
+		`INSERT INTO memory_snapshots (id, snapshot_id, project_id, category, content, importance, source)
+			VALUES ('s1', 'snap1', 'p1', 'fact', 'snapshot row', 0.5, 'mcp')`,
+		`INSERT INTO notifications (body) VALUES ('stale')`,
+	}
+	for _, s := range seed {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("seed legacy db: %v", err)
+		}
+	}
+	return dbPath
+}
+
+func schemaVersionOf(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var v int
+	if err := db.QueryRow("PRAGMA user_version").Scan(&v); err != nil {
+		t.Fatalf("read user_version: %v", err)
+	}
+	return v
+}
+
+// TestMigrateLegacyDB: opening a legacy database must rebuild memories with the
+// widened source CHECK, add the memory_snapshots FK, drop assistant-era tables,
+// keep all rows and FTS integrity, and stamp user_version — all in one OpenDB.
+func TestMigrateLegacyDB(t *testing.T) {
+	dbPath := newLegacyDB(t)
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB on legacy db: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	if v := schemaVersionOf(t, db); v != schemaVersion {
+		t.Errorf("user_version = %d, want %d", v, schemaVersion)
+	}
+
+	// Rows survived the rebuild.
+	var n int
+	if err := db.QueryRow(`SELECT count(*) FROM memories`).Scan(&n); err != nil || n != 2 {
+		t.Fatalf("memories after migration: n=%d err=%v, want 2", n, err)
+	}
+	if err := db.QueryRow(`SELECT count(*) FROM memory_snapshots`).Scan(&n); err != nil || n != 1 {
+		t.Fatalf("memory_snapshots after migration: n=%d err=%v, want 1", n, err)
+	}
+
+	// The widened CHECK accepts the sources that used to fail.
+	for _, src := range []string{"onboarding", "decision_log"} {
+		if _, err := db.Exec(
+			`INSERT INTO memories (id, project_id, content, source) VALUES (?, 'p1', 'probe', ?)`,
+			"probe_"+src, src,
+		); err != nil {
+			t.Errorf("insert with source=%s still fails: %v", src, err)
+		}
+	}
+
+	// FTS was rebuilt and still matches pre-migration content.
+	if err := db.QueryRow(
+		`SELECT count(*) FROM memories_fts WHERE memories_fts MATCH 'obsidian'`,
+	).Scan(&n); err != nil || n != 1 {
+		t.Errorf("fts match after migration: n=%d err=%v, want 1", n, err)
+	}
+	// ...and the recreated triggers index new rows.
+	if _, err := db.Exec(
+		`INSERT INTO memories (id, project_id, content, source) VALUES ('m3', 'p1', 'zanzibar trigger probe', 'mcp')`,
+	); err != nil {
+		t.Fatalf("insert after migration: %v", err)
+	}
+	if err := db.QueryRow(
+		`SELECT count(*) FROM memories_fts WHERE memories_fts MATCH 'zanzibar'`,
+	).Scan(&n); err != nil || n != 1 {
+		t.Errorf("fts trigger after migration: n=%d err=%v, want 1", n, err)
+	}
+
+	// The snapshots FK cascades on project delete.
+	if _, err := db.Exec(`DELETE FROM projects WHERE id = 'p1'`); err != nil {
+		t.Fatalf("delete project: %v", err)
+	}
+	if err := db.QueryRow(`SELECT count(*) FROM memory_snapshots`).Scan(&n); err != nil || n != 0 {
+		t.Errorf("memory_snapshots after project delete: n=%d err=%v, want 0 (FK cascade)", n, err)
+	}
+
+	// Assistant-era tables are gone.
+	for _, table := range []string{"notifications", "reminders", "scheduled_jobs"} {
+		var c int
+		err := db.QueryRow(
+			`SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?`, table,
+		).Scan(&c)
+		if err != nil || c != 0 {
+			t.Errorf("legacy table %s still present (c=%d err=%v)", table, c, err)
+		}
+	}
+}
+
+// TestMigrateFreshDBStamped: a brand-new database gets the current schema from
+// initSQL and is stamped at schemaVersion without running any migration.
+func TestMigrateFreshDBStamped(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "ghost.db")
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+	if v := schemaVersionOf(t, db); v != schemaVersion {
+		t.Errorf("fresh db user_version = %d, want %d", v, schemaVersion)
+	}
+}
+
+// TestMigrateHandMigratedDB: a database whose tables already match the current
+// schema but whose user_version is still 0 (hand-migrated) must be stamped
+// without a rebuild — the introspection guards skip work that is already done.
+func TestMigrateHandMigratedDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "ghost.db")
+
+	// Create a current-schema database, then reset its version stamp to 0.
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO projects (id, path, name) VALUES ('p1', '/tmp/hand-p1', 'p1')`,
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO memories (id, project_id, content, source) VALUES ('m1', 'p1', 'kept', 'decision_log')`,
+	); err != nil {
+		t.Fatalf("seed memory: %v", err)
+	}
+	if _, err := db.Exec(`PRAGMA user_version = 0`); err != nil {
+		t.Fatalf("reset version: %v", err)
+	}
+	_ = db.Close()
+
+	db, err = OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB (second): %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	if v := schemaVersionOf(t, db); v != schemaVersion {
+		t.Errorf("user_version = %d, want %d", v, schemaVersion)
+	}
+	var content string
+	if err := db.QueryRow(`SELECT content FROM memories WHERE id = 'm1'`).Scan(&content); err != nil || content != "kept" {
+		t.Errorf("memory lost on stamp-only migration: %q %v", content, err)
+	}
+}
+
+// TestMigrateIdempotent: opening an already-migrated database repeatedly is a no-op.
+func TestMigrateIdempotent(t *testing.T) {
+	dbPath := newLegacyDB(t)
+	for i := 0; i < 3; i++ {
+		db, err := OpenDB(dbPath)
+		if err != nil {
+			t.Fatalf("OpenDB round %d: %v", i, err)
+		}
+		var n int
+		if err := db.QueryRow(`SELECT count(*) FROM memories`).Scan(&n); err != nil || n != 2 {
+			t.Fatalf("round %d: memories n=%d err=%v, want 2", i, n, err)
+		}
+		_ = db.Close()
+	}
+	// The file on disk holds the stamp (not just the connection).
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+	if v := schemaVersionOf(t, db); v != schemaVersion {
+		t.Errorf("persisted user_version = %d, want %d", v, schemaVersion)
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Errorf("db missing: %v", err)
+	}
+}

--- a/internal/memory/schema.go
+++ b/internal/memory/schema.go
@@ -11,7 +11,9 @@ import (
 // initSQL is the schema for the ghost database — the single source of truth.
 // Kept as a Go constant rather than go:embed because embed paths cannot use "..".
 // Note: CREATE TABLE IF NOT EXISTS never migrates an existing database — a new
-// column or CHECK value only reaches DBs created after the change.
+// column or CHECK value only reaches DBs created after the change. When you
+// alter an existing table here, bump schemaVersion and append a migration
+// step in migrate.go so existing databases receive it too.
 const initSQL = `
 CREATE TABLE IF NOT EXISTS projects (
     id          TEXT PRIMARY KEY,
@@ -219,9 +221,42 @@ func OpenDB(dbPath string) (*sql.DB, error) {
 	}
 
 	db.SetMaxOpenConns(1) // SQLite is single-writer; prevent connection pool contention
+
+	// Distinguish a fresh database from an existing one BEFORE initSQL runs:
+	// fresh databases get the current schema from initSQL and are stamped at
+	// schemaVersion directly; existing ones must pass through migrate(), since
+	// CREATE TABLE IF NOT EXISTS never alters tables that already exist.
+	var tableCount int
+	if err := db.QueryRow(
+		`SELECT count(*) FROM sqlite_master WHERE type='table'`,
+	).Scan(&tableCount); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("inspect schema: %w", err)
+	}
+
 	if _, err := db.Exec(initSQL); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("init schema: %w", err)
+	}
+
+	if tableCount == 0 {
+		if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("stamp schema version: %w", err)
+		}
+		return db, nil
+	}
+
+	var version int
+	if err := db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("read schema version: %w", err)
+	}
+	if version < schemaVersion {
+		if err := migrate(db, version); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("migrate schema v%d→v%d: %w", version, schemaVersion, err)
+		}
 	}
 
 	return db, nil


### PR DESCRIPTION
## Problem

`initSQL` is `CREATE TABLE IF NOT EXISTS` only — it never migrates an existing database. Any schema change (widened CHECK, new FK, dropped table) reached only databases created after the change. Concrete live bug found on a real install: the old `memories.source` CHECK predates `'onboarding'`/`'decision_log'`, so every `ghost_decision_record` memory-mirror insert failed the constraint silently.

## Solution

`OpenDB` now versions the schema with `PRAGMA user_version`:

- **Fresh databases** get the current schema from `initSQL` and are stamped at `schemaVersion` directly.
- **Existing databases** run frozen migration steps from their stored version up to `schemaVersion`. Steps carry their own DDL copies (migrations must not chase the moving `initSQL`) and introspect `sqlite_master` to skip work already done — a hand-migrated database is stamped without a rebuild.
- `PRAGMA foreign_key_check` runs inside each step's transaction before the version stamp commits; `foreign_keys` is toggled OFF around each step on a pinned connection (required for table rebuilds, a no-op inside a transaction).

## Migration v1

1. Rebuild `memories` with `'onboarding'` and `'decision_log'` in the source CHECK — preserving rowids (the FTS external-content index is keyed on them), then recreate the FTS table + triggers + indexes and `INSERT INTO memories_fts(memories_fts) VALUES('rebuild')`.
2. Rebuild `memory_snapshots` with `REFERENCES projects(id) ON DELETE CASCADE`.
3. Drop pre-v0.8.0 assistant-era tables: `notifications`, `reminders`, `scheduled_jobs`.

## Tests

- `TestMigrateLegacyDB` — legacy fixture (old CHECK, no snapshot FK, assistant tables) migrates in one `OpenDB`: rows survive, new sources insert, FTS matches old content and indexes new rows via recreated triggers, snapshot FK cascades, legacy tables gone, version stamped
- `TestMigrateFreshDBStamped` — new DB stamped without migrating
- `TestMigrateHandMigratedDB` — current-schema DB at version 0 is stamped, no rebuild, data intact
- `TestMigrateIdempotent` — repeated opens are no-ops; stamp persists on disk

`go vet ./...` clean, full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic database schema versioning and migration support.
  * Existing databases are upgraded while preserving stored memories, snapshots, search indexes, and triggers.
  * Legacy tables are removed during migration.
  * Fresh databases are initialized and stamped with the current schema version.

* **Bug Fixes**
  * Added missing memory validation support and snapshot project relationships.
  * Ensured migrations are safe to repeat without data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->