### PR TITLE
fix(reflection): haiku tier truncation and tag cross-assignment

### DIFF
--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -31,9 +31,13 @@ func NewClient(apiKey string, logger *slog.Logger) *Client {
 
 // Reflect calls Haiku (non-streaming) for memory extraction/reflection.
 func (c *Client) Reflect(ctx context.Context, prompt string) (string, TokenUsage, error) {
+	// 8192, not 2000: reflection returns the COMPLETE consolidated memory set
+	// as one JSON object (10-25 memories plus learned_context). At 2000 the
+	// response truncated mid-JSON on any real corpus, which parsed to zero
+	// memories and silently knocked the haiku tier out of every consolidation.
 	reqBody := apiRequest{
 		Model:     ModelHaiku45,
-		MaxTokens: 2000,
+		MaxTokens: 8192,
 		System: []SystemBlock{
 			CachedBlock("You analyze a software developer's coding patterns and produce structured memory output. You must return ONLY valid JSON — no markdown fences, no extra text. Be specific and actionable."),
 		},
@@ -73,7 +77,8 @@ func (c *Client) Reflect(ctx context.Context, prompt string) (string, TokenUsage
 		Content []struct {
 			Text string `json:"text"`
 		} `json:"content"`
-		Usage struct {
+		StopReason string `json:"stop_reason"`
+		Usage      struct {
 			InputTokens  int `json:"input_tokens"`
 			OutputTokens int `json:"output_tokens"`
 		} `json:"usage"`
@@ -90,6 +95,13 @@ func (c *Client) Reflect(ctx context.Context, prompt string) (string, TokenUsage
 	usage := TokenUsage{
 		InputTokens:  result.Usage.InputTokens,
 		OutputTokens: result.Usage.OutputTokens,
+	}
+
+	// A max_tokens stop means the JSON was cut mid-object — unparseable at
+	// best, silently incomplete at worst. Fail loudly so the tiered
+	// consolidator logs the real reason instead of "returned 0 memories".
+	if result.StopReason == "max_tokens" {
+		return "", usage, fmt.Errorf("reflect response truncated at max_tokens (%d output tokens) — memory set incomplete", usage.OutputTokens)
 	}
 
 	return text, usage, nil

--- a/internal/reflection/consolidator_test.go
+++ b/internal/reflection/consolidator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/wcatz/ghost/internal/memory"
@@ -235,7 +236,10 @@ func TestParseReflectionResponse_NormalizesScope(t *testing.T) {
 		{"category":"fact","content":"bad scope","importance":0.6,"tags":[],"scope":"invalid"}
 	]}`
 
-	result := parseReflectionResponse(input)
+	result, err := parseReflectionResponse(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if result.Memories[0].Scope != "global" {
 		t.Errorf("expected global scope preserved, got %q", result.Memories[0].Scope)
 	}
@@ -244,6 +248,54 @@ func TestParseReflectionResponse_NormalizesScope(t *testing.T) {
 	}
 	if result.Memories[2].Scope != "project" {
 		t.Errorf("expected invalid scope normalized to project, got %q", result.Memories[2].Scope)
+	}
+}
+
+// TestParseReflectionResponse_MalformedJSON: unparseable output (e.g. a
+// response truncated mid-JSON) must surface as an error — the old fallback
+// returned it as learned_context with zero memories, which the tiered quality
+// gate misread as "consolidated everything away" with no hint of the cause.
+func TestParseReflectionResponse_MalformedJSON(t *testing.T) {
+	truncated := `{"learned_context":"ctx","memories":[{"category":"fact","content":"cut off mid-obj`
+	if _, err := parseReflectionResponse(truncated); err == nil {
+		t.Fatal("expected error for truncated JSON, got nil")
+	}
+
+	prose := "I could not produce JSON, here is a summary instead."
+	if _, err := parseReflectionResponse(prose); err == nil {
+		t.Fatal("expected error for non-JSON prose, got nil")
+	}
+}
+
+// TestParseReflectionResponse_StripsFences: fenced JSON still parses.
+func TestParseReflectionResponse_StripsFences(t *testing.T) {
+	fenced := "```json\n{\"learned_context\":\"ctx\",\"memories\":[{\"category\":\"fact\",\"content\":\"ok\",\"importance\":0.7,\"tags\":[\"a\"]}]}\n```"
+	result, err := parseReflectionResponse(fenced)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Memories) != 1 || result.Memories[0].Content != "ok" {
+		t.Fatalf("fenced JSON not parsed: %+v", result)
+	}
+}
+
+// TestBuildReflectionPrompt_IncludesTags: existing tags must be serialized with
+// their memory. Omitting them forced the LLM to invent fresh tags for every
+// memory, cross-assigning keywords from unrelated memories in the corpus.
+func TestBuildReflectionPrompt_IncludesTags(t *testing.T) {
+	prompt := BuildReflectionPrompt(ReflectionInput{
+		ProjectName:     "ghost",
+		ProjectLanguage: "go",
+		ExistingMemories: []memory.Memory{
+			{Category: "fact", Content: "obsidian mirror is one-way", Importance: 0.7, Tags: []string{"obsidian", "vault"}},
+			{Category: "gotcha", Content: "no tags on this one", Importance: 0.5},
+		},
+	})
+	if !strings.Contains(prompt, "tags:[obsidian,vault]") {
+		t.Errorf("prompt missing serialized tags:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "keep its existing tags") {
+		t.Errorf("prompt missing tag-preservation rule")
 	}
 }
 

--- a/internal/reflection/prompt.go
+++ b/internal/reflection/prompt.go
@@ -86,6 +86,12 @@ func BuildReflectionPrompt(input ReflectionInput) string {
 			if m.AccessCount > 0 {
 				line += fmt.Sprintf(", used:%d", m.AccessCount)
 			}
+			// Tags travel with their memory — omitting them forced the model to
+			// invent fresh tags for every memory, cross-assigning keywords from
+			// unrelated memories elsewhere in the corpus.
+			if len(m.Tags) > 0 {
+				line += fmt.Sprintf(", tags:[%s]", strings.Join(m.Tags, ","))
+			}
 			line += fmt.Sprintf(") %s\n", quoteData(m.Content))
 			sb.WriteString(line)
 		}
@@ -100,6 +106,7 @@ Produce a JSON object with two fields:
    - Keep identity facts (architecture, conventions) — never drop these
    - Drop stale situational memories (old gotchas that were fixed)
    - Each memory: "category" (architecture/decision/pattern/convention/gotcha/dependency/preference/fact), "content" (1-2 sentences), "importance" (0.0-1.0), "tags" (1-3 keywords), "scope" ("project" or "global")
+   - Tags: when carrying a memory forward, keep its existing tags (shown as tags:[...] above); when merging memories, union their tags. Only invent tags for memories that have none — and derive them from THAT memory's content, never from neighboring memories
    - Aim for 10-25 high-quality memories, not 50 repetitive ones
    - Scope: most memories are "project". Mark as "global" ONLY if the knowledge applies across ALL repositories — examples: user preferences, cross-repo workflows (deploying from one repo to another), personal tooling choices, SSH hosts, infrastructure topology. Project-specific architecture, patterns, or conventions are always "project".
 

--- a/internal/reflection/tier_haiku.go
+++ b/internal/reflection/tier_haiku.go
@@ -3,6 +3,7 @@ package reflection
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/wcatz/ghost/internal/ai"
@@ -36,10 +37,10 @@ func (h *HaikuConsolidator) Consolidate(ctx context.Context, input ReflectionInp
 	if err != nil {
 		return ReflectionResult{}, err
 	}
-	return parseReflectionResponse(responseText), nil
+	return parseReflectionResponse(responseText)
 }
 
-func parseReflectionResponse(text string) ReflectionResult {
+func parseReflectionResponse(text string) (ReflectionResult, error) {
 	text = strings.TrimSpace(text)
 
 	// Strip markdown code fences.
@@ -53,9 +54,17 @@ func parseReflectionResponse(text string) ReflectionResult {
 		text = strings.TrimSpace(text)
 	}
 
+	// Unparseable output is an error, not a result: the old fallback returned
+	// the raw text as learned_context with ZERO memories, which read as "the
+	// model consolidated everything away" — the tiered quality gate then fell
+	// through to sqlite with no hint of the real cause (truncated/malformed JSON).
 	var result ReflectionResult
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
-		return ReflectionResult{LearnedContext: text}
+		snippet := text
+		if len(snippet) > 120 {
+			snippet = snippet[:120] + "..."
+		}
+		return ReflectionResult{}, fmt.Errorf("reflection output is not valid JSON: %w (starts: %q)", err, snippet)
 	}
 
 	// Validate importance ranges and scope.
@@ -74,5 +83,5 @@ func parseReflectionResponse(text string) ReflectionResult {
 		}
 	}
 
-	return result
+	return result, nil
 }


### PR DESCRIPTION
## Bug 1 — Haiku tier always returned 0 memories

Observed live: `ghost reflect ghost --tier auto` logged `WARN consolidator returned too few memories, trying next tier (output=0)` on every run, silently degrading every consolidation to the mechanical SQLite tier.

Root cause chain:
- [`Reflect`](../blob/main/internal/ai/client.go) capped output at `MaxTokens: 2000`, but the reflection prompt demands the **complete consolidated memory set** (10-25 memories + a 200-word learned_context) as one JSON object — that truncates mid-JSON on any real corpus.
- `stop_reason` was never checked, so truncation looked like a successful response.
- `parseReflectionResponse` swallowed the unmarshal failure and returned `{learned_context: <raw text>, memories: []}` — zero memories, no error.

Fixes:
- `MaxTokens` 2000 → 8192
- `stop_reason == "max_tokens"` now returns an explicit error with the output token count
- `parseReflectionResponse` returns an error on unparseable output instead of an empty result, so the tiered consolidator logs the real cause when falling through

## Bug 2 — tags cross-assigned between memories

Observed live: after reflection, the Obsidian-mirror memory carried tags `[cost, api, telegram]`, a bench finding carried `[vscode, webview, regex]` — keywords from *other* memories in the corpus.

Root cause: `BuildReflectionPrompt` serialized each memory without its tags, then asked the model to emit 1-3 keyword tags per memory — forcing it to invent tags with the whole corpus in context.

Fixes:
- existing tags are serialized with each memory (`tags:[...]`)
- prompt rules now require keeping a memory's existing tags, unioning on merge, and inventing tags only for untagged memories from that memory's own content

## Tests

- `TestParseReflectionResponse_MalformedJSON` — truncated JSON and prose both error
- `TestParseReflectionResponse_StripsFences` — fenced JSON still parses
- `TestBuildReflectionPrompt_IncludesTags` — tags serialized + preservation rule present
- existing scope-normalization test updated for the new signature

`go vet ./...` clean, full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)