### PR TITLE
fix(tasks): accept short-ID prefixes in task tools

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -831,13 +831,13 @@ func (s *Server) registerTools() {
 
 	// ghost_task_complete — mark a task as done.
 	type taskCompleteArgs struct {
-		TaskID string `json:"task_id" jsonschema:"Task ID"`
+		TaskID string `json:"task_id" jsonschema:"Task ID — full ID or unique short prefix (e.g. the 8-char ID shown by ghost_task_list)"`
 		Notes  string `json:"notes,omitempty" jsonschema:"Completion notes"`
 	}
 
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_task_complete",
-		Description: "Mark a task as done with optional completion notes.",
+		Description: "Mark a task as done with optional completion notes. Accepts a full task ID or a unique short prefix (like git short SHAs).",
 		Annotations: &mcp.ToolAnnotations{
 			DestructiveHint: boolPtr(false),
 			IdempotentHint:  true,
@@ -1026,7 +1026,7 @@ func (s *Server) registerTools() {
 	// ghost_task_update — update a task's status, priority, or description.
 	// Priority and description are optional — omitting them preserves current values.
 	type taskUpdateArgs struct {
-		TaskID      string  `json:"task_id" jsonschema:"Task ID to update"`
+		TaskID      string  `json:"task_id" jsonschema:"Task ID to update — full ID or unique short prefix (e.g. the 8-char ID shown by ghost_task_list)"`
 		Status      string  `json:"status,omitempty" jsonschema:"New status: pending, active, blocked, done (omit to preserve current)"`
 		Priority    *int    `json:"priority,omitempty" jsonschema:"Priority 0-4 (0=critical, 2=normal, 4=low). Omit to keep current value."`
 		Description *string `json:"description,omitempty" jsonschema:"Updated description. Omit to keep current value."`
@@ -1034,7 +1034,7 @@ func (s *Server) registerTools() {
 
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_task_update",
-		Description: "Update a task's status, priority, or description. All fields are optional — omit any field to preserve its current value. Only pass what you want to change.",
+		Description: "Update a task's status, priority, or description. All fields are optional — omit any field to preserve its current value. Only pass what you want to change. Accepts a full task ID or a unique short prefix (like git short SHAs).",
 		Annotations: &mcp.ToolAnnotations{
 			DestructiveHint: boolPtr(false),
 			IdempotentHint:  true,
@@ -1075,7 +1075,9 @@ func (s *Server) registerTools() {
 			description = *args.Description
 		}
 
-		if err := s.store.UpdateTask(ctx, args.TaskID, status, priority, description); err != nil {
+		// Pass the resolved full ID, not the caller's (possibly prefix) input,
+		// so the fetch above and the write below can't hit different tasks.
+		if err := s.store.UpdateTask(ctx, current.ID, status, priority, description); err != nil {
 			return nil, nil, fmt.Errorf("update task: %w", err)
 		}
 		return &mcp.CallToolResult{

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1430,6 +1430,88 @@ func TestStoreTasks(t *testing.T) {
 	}
 }
 
+func TestStoreTaskIDPrefix(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	fullID, err := s.CreateTask(ctx, testProject, "Prefix me", "Resolved by short ID", 2)
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	prefix := fullID[:8]
+
+	// GetTask resolves an 8-char prefix (what the session hook and task list show).
+	got, err := s.GetTask(ctx, prefix)
+	if err != nil {
+		t.Fatalf("GetTask by prefix: %v", err)
+	}
+	if got.ID != fullID {
+		t.Errorf("GetTask by prefix resolved %q, want %q", got.ID, fullID)
+	}
+
+	// UpdateTask and CompleteTask resolve prefixes too.
+	if err := s.UpdateTask(ctx, prefix, "active", 1, "updated via prefix"); err != nil {
+		t.Fatalf("UpdateTask by prefix: %v", err)
+	}
+	got, err = s.GetTask(ctx, fullID)
+	if err != nil {
+		t.Fatalf("GetTask after update: %v", err)
+	}
+	if got.Status != "active" || got.Description != "updated via prefix" {
+		t.Errorf("UpdateTask by prefix did not apply: status=%q desc=%q", got.Status, got.Description)
+	}
+	if err := s.CompleteTask(ctx, prefix, "done via prefix"); err != nil {
+		t.Fatalf("CompleteTask by prefix: %v", err)
+	}
+	got, err = s.GetTask(ctx, fullID)
+	if err != nil {
+		t.Fatalf("GetTask after complete: %v", err)
+	}
+	if got.Status != "done" || got.Notes != "done via prefix" {
+		t.Errorf("CompleteTask by prefix did not apply: status=%q notes=%q", got.Status, got.Notes)
+	}
+
+	// Ambiguous prefix: two tasks sharing the first 8 chars must error, not
+	// pick one arbitrarily.
+	for _, id := range []string{"AAAABBBB000000000000000000000001", "AAAABBBB000000000000000000000002"} {
+		if _, err := s.db.ExecContext(ctx,
+			`INSERT INTO tasks (id, project_id, title) VALUES (?, ?, ?)`, id, testProject, "twin "+id[len(id)-1:]); err != nil {
+			t.Fatalf("insert fixture task: %v", err)
+		}
+	}
+	if _, err := s.GetTask(ctx, "AAAABBBB"); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("GetTask ambiguous prefix: want ambiguity error, got %v", err)
+	}
+	if err := s.CompleteTask(ctx, "AAAABBBB", ""); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("CompleteTask ambiguous prefix: want ambiguity error, got %v", err)
+	}
+	// A longer, unique prefix disambiguates.
+	got, err = s.GetTask(ctx, "AAAABBBB000000000000000000000001")
+	if err != nil {
+		t.Fatalf("GetTask exact ID among twins: %v", err)
+	}
+	if got.Title != "twin 1" {
+		t.Errorf("expected twin 1, got %q", got.Title)
+	}
+
+	// Unknown IDs now fail loudly everywhere — CompleteTask/UpdateTask used to
+	// silently no-op on a missing ID.
+	if _, err := s.GetTask(ctx, "ZZZZ9999"); err == nil || !strings.Contains(err.Error(), "task not found") {
+		t.Errorf("GetTask unknown: want not-found error, got %v", err)
+	}
+	if err := s.CompleteTask(ctx, "ZZZZ9999", ""); err == nil || !strings.Contains(err.Error(), "task not found") {
+		t.Errorf("CompleteTask unknown: want not-found error, got %v", err)
+	}
+	if err := s.UpdateTask(ctx, "ZZZZ9999", "active", 1, ""); err == nil || !strings.Contains(err.Error(), "task not found") {
+		t.Errorf("UpdateTask unknown: want not-found error, got %v", err)
+	}
+
+	// Empty ID is rejected, never treated as a match-everything prefix.
+	if _, err := s.GetTask(ctx, ""); err == nil {
+		t.Error("GetTask empty id: want error, got nil")
+	}
+}
+
 func TestStoreGetLatestConversationNoRows(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()

--- a/internal/memory/tasks.go
+++ b/internal/memory/tasks.go
@@ -76,33 +76,82 @@ func (s *Store) ListTasks(ctx context.Context, projectID, status string, limit i
 	return tasks, rows.Err()
 }
 
-// CompleteTask marks a task as done.
+// resolveTaskID expands a task ID or unique prefix to the full stored ID,
+// like git short SHAs. Session-hook and task-list output truncate IDs to 8
+// characters, so callers routinely hold a prefix rather than the full 32-char
+// ID. Caller must hold s.mu (read or write).
+func (s *Store) resolveTaskID(ctx context.Context, idOrPrefix string) (string, error) {
+	if idOrPrefix == "" {
+		return "", fmt.Errorf("task id is required")
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id FROM tasks WHERE substr(id, 1, length(?1)) = ?1 LIMIT 2
+	`, idOrPrefix)
+	if err != nil {
+		return "", fmt.Errorf("resolve task id: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return "", err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+
+	switch len(ids) {
+	case 0:
+		return "", fmt.Errorf("task not found: %s", idOrPrefix)
+	case 1:
+		return ids[0], nil
+	default:
+		return "", fmt.Errorf("ambiguous task id prefix %q matches multiple tasks — use more characters", idOrPrefix)
+	}
+}
+
+// CompleteTask marks a task as done. Accepts a full task ID or a unique prefix.
 func (s *Store) CompleteTask(ctx context.Context, taskID, notes string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	_, err := s.db.ExecContext(ctx, `
+	id, err := s.resolveTaskID(ctx, taskID)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.db.ExecContext(ctx, `
 		UPDATE tasks SET status = 'done', notes = ?, completed_at = datetime('now'), updated_at = datetime('now')
 		WHERE id = ?
-	`, notes, taskID)
+	`, notes, id)
 	if err != nil {
 		return fmt.Errorf("complete task: %w", err)
 	}
 	return nil
 }
 
-// GetTask returns a single task by ID.
+// GetTask returns a single task by ID. Accepts a full task ID or a unique prefix.
 func (s *Store) GetTask(ctx context.Context, taskID string) (Task, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	id, err := s.resolveTaskID(ctx, taskID)
+	if err != nil {
+		return Task{}, err
+	}
+
 	var t Task
-	err := s.db.QueryRowContext(ctx, `
+	err = s.db.QueryRowContext(ctx, `
 		SELECT id, project_id, title, description, status, priority,
 		       COALESCE(blocked_by, ''), COALESCE(branch, ''), COALESCE(pr_number, 0),
 		       COALESCE(notes, ''), created_at, updated_at, COALESCE(completed_at, '')
 		FROM tasks WHERE id = ?
-	`, taskID).Scan(
+	`, id).Scan(
 		&t.ID, &t.ProjectID, &t.Title, &t.Description, &t.Status,
 		&t.Priority, &t.BlockedBy, &t.Branch, &t.PRNumber, &t.Notes,
 		&t.CreatedAt, &t.UpdatedAt, &t.CompletedAt,
@@ -113,15 +162,21 @@ func (s *Store) GetTask(ctx context.Context, taskID string) (Task, error) {
 	return t, nil
 }
 
-// UpdateTask updates a task's status, priority, or description.
+// UpdateTask updates a task's status, priority, or description. Accepts a
+// full task ID or a unique prefix.
 func (s *Store) UpdateTask(ctx context.Context, taskID, status string, priority int, description string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	_, err := s.db.ExecContext(ctx, `
+	id, err := s.resolveTaskID(ctx, taskID)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.db.ExecContext(ctx, `
 		UPDATE tasks SET status = ?, priority = ?, description = ?, updated_at = datetime('now')
 		WHERE id = ?
-	`, status, priority, description, taskID)
+	`, status, priority, description, id)
 	if err != nil {
 		return fmt.Errorf("update task: %w", err)
 	}


### PR DESCRIPTION
## Problem
The session-start hook and `ghost_task_list` render task IDs truncated to 8 characters (`shortID`), but `ghost_task_update` / `ghost_task_complete` required the full 32-char ID. Updating a task straight from injected context failed with *task not found*, and there was no MCP-visible way to recover the full ID (live friction 2026-07-19, tracked as Ghost task `F25BC87E`).

## Fix
Git-short-SHA-style resolution at the store layer:
- New `resolveTaskID`: expands a full ID **or unique prefix** to the stored ID via `substr(id, 1, length(?)) = ?`; errors on ambiguity ("use more characters") and on no match; rejects empty input so it can never act as a match-everything prefix.
- `GetTask`, `UpdateTask`, `CompleteTask` all resolve through it. The two mutators previously ran `UPDATE ... WHERE id = ?` and **silently updated zero rows** on an unknown ID — they now fail loudly with *task not found*.
- `ghost_task_update` writes through the resolved `current.ID` (not the caller's prefix) so the read and write cannot hit different tasks; tool descriptions and `task_id` schema hints now advertise prefix support.

No interface changes — `provider.MemoryStore` signatures are untouched.

## Tests
`TestStoreTaskIDPrefix`: 8-char prefix resolution across all three methods, ambiguity error on twin-prefix fixtures, exact-ID disambiguation among twins, loud not-found on all three methods, empty-ID rejection. Full `go test ./...` and `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)