### PR TITLE
chore(ci): add govulncheck dependency scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
           args: --new-from-rev=origin/main
 
       - name: Vulnerability scan
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        # Pinned for the same reproducibility reason as golangci-lint above —
+        # 'latest' can change scan behavior without a repository change.
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 
       - name: Test
         run: go test -race -count=1 ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
           version: v2.12.2
           args: --new-from-rev=origin/main
 
+      - name: Vulnerability scan
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
       - name: Test
         run: go test -race -count=1 ./...
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wcatz/ghost
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/knadh/koanf/parsers/yaml v1.1.0


### PR DESCRIPTION
## Summary
- Adds a `govulncheck` step to CI to catch known vulnerabilities in the stdlib and dependencies.
- Bumps the Go toolchain from 1.26.4 to 1.26.5 — govulncheck immediately flagged GO-2026-5856 (crypto/tls Encrypted Client Hello privacy leak), fixed in 1.26.5.

## Test plan
- [x] `go build ./cmd/ghost`
- [x] `go vet ./...`
- [x] `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` — clean after the toolchain bump
- [x] `go test -race -count=1 ./...` — full suite green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated vulnerability scanning to the continuous integration checks.
  * Updated the project’s Go toolchain version to 1.26.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->