### PR TITLE
feat(mcp): add recall_project and record_decision prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 - `cmd/ghost/main.go` — CLI entrypoint; subcommands: mcp, hook, reflect, supersede, obsidian, bench, upgrade, version
 - `internal/ai/` — Claude API client (non-streaming Reflect call, used by reflection + supersede)
 - `internal/memory/` — SQLite CRUD, FTS5 search, vector search, time-decay scoring
-- `internal/mcpserver/` — MCP server: 18 tools + 4 resources
+- `internal/mcpserver/` — MCP server: 18 tools + 4 resources + 2 prompts (`recall_project`, `record_decision`)
 - `internal/mcpinit/` — `ghost mcp init`, `ghost mcp status`, `ghost hook session-start`, `ghost hook stop`
 - `internal/claudeimport/` — One-time import of Claude Code auto-memory on first contact
 - `internal/embedding/` — Ollama async vectorization worker

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -136,6 +136,7 @@ func New(store provider.MemoryStore, logger *slog.Logger, version string) *Serve
 
 	s.registerTools()
 	s.registerResources()
+	s.registerPrompts()
 	return s
 }
 
@@ -1288,6 +1289,64 @@ func (s *Server) registerResources() {
 				MIMEType: "text/plain",
 				Text:     text,
 			}},
+		}, nil
+	})
+}
+
+// registerPrompts registers MCP prompt templates — user-invokable shortcuts
+// (e.g. slash commands in Claude Code) that wrap Ghost's existing workflows.
+func (s *Server) registerPrompts() {
+	s.mcp.AddPrompt(&mcp.Prompt{
+		Name:        "recall_project",
+		Description: "Recall everything Ghost knows about a project on demand — memories and learned context, same data as the ghost://project/{id}/context resource.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "project_id", Description: "Project name (e.g. 'ghost') or hash ID.", Required: true},
+		},
+	}, func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		rawID := req.Params.Arguments["project_id"]
+		if rawID == "" {
+			return nil, fmt.Errorf("project_id argument is required")
+		}
+		projectID := s.resolveProjectID(ctx, rawID)
+		text, err := s.buildProjectContext(ctx, projectID)
+		if err != nil {
+			return nil, fmt.Errorf("recall project context for %q: %w", rawID, err)
+		}
+		if text == "" {
+			text = "No memories or learned context saved yet for this project."
+		}
+		return &mcp.GetPromptResult{
+			Description: "Ghost's accumulated knowledge for " + rawID,
+			Messages: []*mcp.PromptMessage{
+				{Role: "user", Content: &mcp.TextContent{
+					Text: "Recall what Ghost knows about project \"" + rawID + "\" before continuing:\n\n" + text,
+				}},
+			},
+		}, nil
+	})
+
+	s.mcp.AddPrompt(&mcp.Prompt{
+		Name:        "record_decision",
+		Description: "Walk through structuring a design decision (title, decision, rationale, alternatives) and save it with ghost_decision_record.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "project_id", Description: "Project name (e.g. 'ghost') or hash ID.", Required: true},
+			{Name: "topic", Description: "What the decision is about, in a few words.", Required: true},
+		},
+	}, func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		projectID := req.Params.Arguments["project_id"]
+		topic := req.Params.Arguments["topic"]
+		if projectID == "" || topic == "" {
+			return nil, fmt.Errorf("project_id and topic arguments are required")
+		}
+		return &mcp.GetPromptResult{
+			Description: "Structure and record a decision about " + topic,
+			Messages: []*mcp.PromptMessage{
+				{Role: "user", Content: &mcp.TextContent{
+					Text: "Help me record a design decision about \"" + topic + "\" for project \"" + projectID + "\". " +
+						"Ask me for (or infer from context): a short title, the decision itself, the rationale, and any " +
+						"alternatives considered. Then call ghost_decision_record with project_id=\"" + projectID + "\" to save it.",
+				}},
+			},
 		}, nil
 	})
 }

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/wcatz/ghost/internal/memory"
 )
 
@@ -870,6 +871,92 @@ func TestPromoteMemory(t *testing.T) {
 			t.Error("expected missing memory_id error")
 		}
 	})
+}
+
+// connectedClient spins up a Server and a Client wired together over an
+// in-memory transport, and returns the connected ClientSession. Callers must
+// close the returned session's connection via t.Cleanup handling in Connect.
+func connectedClient(t *testing.T, srv *Server) *mcp.ClientSession {
+	t.Helper()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	ctx := context.Background()
+	if _, err := srv.mcp.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func TestPrompts_RecallProject(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+
+	ctx := context.Background()
+	if _, _, err := store.Upsert(ctx, "abc123", "fact", "seed memory for recall test", "manual", 0.5, []string{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	session := connectedClient(t, srv)
+
+	res, err := session.GetPrompt(ctx, &mcp.GetPromptParams{
+		Name:      "recall_project",
+		Arguments: map[string]string{"project_id": "test-project"},
+	})
+	if err != nil {
+		t.Fatalf("GetPrompt recall_project: %v", err)
+	}
+	if len(res.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(res.Messages))
+	}
+	text, ok := res.Messages[0].Content.(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", res.Messages[0].Content)
+	}
+	if !strings.Contains(text.Text, "seed memory for recall test") {
+		t.Errorf("expected recalled memory in prompt text, got: %s", text.Text)
+	}
+
+	if _, err := session.GetPrompt(ctx, &mcp.GetPromptParams{Name: "recall_project"}); err == nil {
+		t.Error("expected error for missing project_id argument")
+	}
+}
+
+func TestPrompts_RecordDecision(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	res, err := session.GetPrompt(ctx, &mcp.GetPromptParams{
+		Name:      "record_decision",
+		Arguments: map[string]string{"project_id": "test-project", "topic": "auth strategy"},
+	})
+	if err != nil {
+		t.Fatalf("GetPrompt record_decision: %v", err)
+	}
+	text, ok := res.Messages[0].Content.(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", res.Messages[0].Content)
+	}
+	if !strings.Contains(text.Text, "auth strategy") || !strings.Contains(text.Text, "ghost_decision_record") {
+		t.Errorf("expected topic and tool reference in prompt text, got: %s", text.Text)
+	}
+
+	if _, err := session.GetPrompt(ctx, &mcp.GetPromptParams{
+		Name:      "record_decision",
+		Arguments: map[string]string{"project_id": "test-project"},
+	}); err == nil {
+		t.Error("expected error for missing topic argument")
+	}
 }
 
 func TestTruncateUTF8(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds Ghost's first MCP Prompts (`registerPrompts` in internal/mcpserver/mcpserver.go): a protocol feature Ghost had zero coverage of.
- `recall_project` — pulls a project's memories/learned context on demand, same data as the `ghost://project/{id}/context` resource but user-invokable (e.g. as a slash command in Claude Code).
- `record_decision` — guided template that walks through title/decision/rationale/alternatives and ends by calling `ghost_decision_record`.

## Test plan
- [x] New end-to-end tests using the SDK's in-memory transport (`TestPrompts_RecallProject`, `TestPrompts_RecordDecision`) — exercise both prompts through a real MCP client/server session, including missing-required-argument error paths.
- [x] `go vet ./...`, `go build ./cmd/ghost`
- [x] `go test -race -count=1 ./internal/mcpserver/...` — green