### PR TITLE
feat(mcp): support MCP resource subscriptions

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -130,14 +130,43 @@ func New(store provider.MemoryStore, logger *slog.Logger, version string) *Serve
 		Name:    "ghost",
 		Version: version,
 	}, &mcp.ServerOptions{
-		Instructions: mcpInstructions,
-		Logger:       logger,
+		Instructions:       mcpInstructions,
+		Logger:             logger,
+		SubscribeHandler:   s.handleSubscribe,
+		UnsubscribeHandler: s.handleUnsubscribe,
 	})
 
 	s.registerTools()
 	s.registerResources()
 	s.registerPrompts()
 	return s
+}
+
+// handleSubscribe validates that a client is subscribing to a known ghost://
+// resource or resource-template URI before the SDK starts tracking it.
+func (s *Server) handleSubscribe(ctx context.Context, req *mcp.SubscribeRequest) error {
+	if !strings.HasPrefix(req.Params.URI, "ghost://") {
+		return fmt.Errorf("unknown resource URI: %s", req.Params.URI)
+	}
+	return nil
+}
+
+// handleUnsubscribe accepts any unsubscribe request — the SDK already tracks
+// whether the session was subscribed and no-ops otherwise.
+func (s *Server) handleUnsubscribe(ctx context.Context, req *mcp.UnsubscribeRequest) error {
+	return nil
+}
+
+// notifyResourceUpdated sends a notifications/resources/updated push to any
+// MCP client subscribed to uri. Best-effort: logged, never fails the caller's
+// tool call.
+func (s *Server) notifyResourceUpdated(ctx context.Context, uri string) {
+	if s.mcp == nil {
+		return
+	}
+	if err := s.mcp.ResourceUpdated(ctx, &mcp.ResourceUpdatedNotificationParams{URI: uri}); err != nil {
+		s.logger.Warn("resource updated notification failed", "uri", uri, "error", err)
+	}
 }
 
 // SetEmbedder configures optional vector embedding for hybrid search.
@@ -257,6 +286,7 @@ func (s *Server) applyMemoryUpdate(ctx context.Context, args updateArgs) (string
 	if err := s.store.UpdateMemory(ctx, resolvedProjectID, args.MemoryID, content, category, args.Importance, args.Tags); err != nil {
 		return "", fmt.Errorf("update failed: %w", err)
 	}
+	s.notifyResourceUpdated(ctx, "ghost://project/"+resolvedProjectID+"/context")
 
 	// A content change dropped the embedding — nudge the worker to re-embed.
 	if content != nil && s.projectCh != nil {
@@ -299,6 +329,8 @@ func (s *Server) promoteMemory(ctx context.Context, projectID, memoryID string) 
 	if err := s.store.PromoteToGlobal(ctx, resolvedProjectID, memoryID); err != nil {
 		return "", fmt.Errorf("promote failed: %w", err)
 	}
+	s.notifyResourceUpdated(ctx, "ghost://project/"+resolvedProjectID+"/context")
+	s.notifyResourceUpdated(ctx, "ghost://memories/global")
 	return fmt.Sprintf("Memory promoted to global scope (id: %s).", memoryID), nil
 }
 
@@ -425,6 +457,7 @@ func (s *Server) registerTools() {
 		if err != nil {
 			return nil, nil, fmt.Errorf("save failed: %w", err)
 		}
+		s.notifyResourceUpdated(ctx, "ghost://project/"+args.ProjectID+"/context")
 
 		// Notify embedding worker of new/updated memory.
 		if s.projectCh != nil {
@@ -601,6 +634,7 @@ func (s *Server) registerTools() {
 		if err := s.store.Delete(ctx, args.MemoryID); err != nil {
 			return nil, nil, fmt.Errorf("delete failed: %w", err)
 		}
+		s.notifyResourceUpdated(ctx, "ghost://project/"+resolvedProjectID+"/context")
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "Memory deleted."}},
@@ -742,6 +776,7 @@ func (s *Server) registerTools() {
 		if err != nil {
 			return nil, nil, fmt.Errorf("save failed: %w", err)
 		}
+		s.notifyResourceUpdated(ctx, "ghost://memories/global")
 		action := "saved"
 		if merged {
 			action = "merged with existing"
@@ -789,6 +824,7 @@ func (s *Server) registerTools() {
 		if err != nil {
 			return nil, nil, fmt.Errorf("create task: %w", err)
 		}
+		s.notifyResourceUpdated(ctx, "ghost://project/"+args.ProjectID+"/tasks")
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Task created (id: %s)", id)}},
 		}, nil, nil
@@ -860,9 +896,14 @@ func (s *Server) registerTools() {
 		if args.TaskID == "" {
 			return nil, nil, fmt.Errorf("task_id is required")
 		}
+		task, err := s.store.GetTask(ctx, args.TaskID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("task not found: %w", err)
+		}
 		if err := s.store.CompleteTask(ctx, args.TaskID, args.Notes); err != nil {
 			return nil, nil, fmt.Errorf("complete task: %w", err)
 		}
+		s.notifyResourceUpdated(ctx, "ghost://project/"+task.ProjectID+"/tasks")
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "Task completed."}},
 		}, nil, nil
@@ -911,6 +952,7 @@ func (s *Server) registerTools() {
 		if err != nil {
 			return nil, nil, fmt.Errorf("record decision: %w", err)
 		}
+		s.notifyResourceUpdated(ctx, "ghost://project/"+args.ProjectID+"/decisions")
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Decision recorded (id: %s)", id)}},
 		}, nil, nil
@@ -1031,6 +1073,9 @@ func (s *Server) registerTools() {
 		if err := s.store.TogglePin(ctx, args.MemoryID, args.Pinned); err != nil {
 			return nil, nil, fmt.Errorf("toggle pin: %w", err)
 		}
+		if mems, err := s.store.GetByIDs(ctx, []string{args.MemoryID}); err == nil && len(mems) > 0 {
+			s.notifyResourceUpdated(ctx, "ghost://project/"+mems[0].ProjectID+"/context")
+		}
 		action := "pinned"
 		if !args.Pinned {
 			action = "unpinned"
@@ -1098,6 +1143,7 @@ func (s *Server) registerTools() {
 		if err := s.store.UpdateTask(ctx, current.ID, status, priority, description); err != nil {
 			return nil, nil, fmt.Errorf("update task: %w", err)
 		}
+		s.notifyResourceUpdated(ctx, "ghost://project/"+current.ProjectID+"/tasks")
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "Task updated."}},
 		}, nil, nil

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -956,6 +957,65 @@ func TestPrompts_RecordDecision(t *testing.T) {
 		Arguments: map[string]string{"project_id": "test-project"},
 	}); err == nil {
 		t.Error("expected error for missing topic argument")
+	}
+}
+
+func TestResourceSubscription_NotifiesOnMemorySave(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	if _, err := srv.mcp.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+
+	updated := make(chan string, 1)
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, &mcp.ClientOptions{
+		ResourceUpdatedHandler: func(ctx context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
+			updated <- req.Params.URI
+		},
+	})
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	const uri = "ghost://project/abc123/context"
+	if err := session.Subscribe(ctx, &mcp.SubscribeParams{URI: uri}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if _, _, err := store.Upsert(ctx, "abc123", "fact", "triggers subscription notify", "manual", 0.5, []string{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	srv.notifyResourceUpdated(ctx, uri)
+
+	select {
+	case got := <-updated:
+		if got != uri {
+			t.Errorf("notified URI = %q, want %q", got, uri)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resources/updated notification")
+	}
+
+	if err := session.Unsubscribe(ctx, &mcp.UnsubscribeParams{URI: uri}); err != nil {
+		t.Fatalf("Unsubscribe: %v", err)
+	}
+}
+
+func TestResourceSubscription_RejectsUnknownURI(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	if err := session.Subscribe(ctx, &mcp.SubscribeParams{URI: "http://not-ghost/resource"}); err == nil {
+		t.Error("expected error subscribing to non-ghost:// URI")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `SubscribeHandler`/`UnsubscribeHandler` to the MCP server so clients can subscribe to `ghost://` resources and resource templates and receive `notifications/resources/updated` pushes.
- Subscription requests to non-`ghost://` URIs are rejected.
- Mutating tool handlers (`ghost_memory_save`, `ghost_memory_update`, `ghost_memory_delete`, `ghost_memory_promote`, `ghost_memory_pin`, `ghost_save_global`, `ghost_task_create`, `ghost_task_update`, `ghost_task_complete`, `ghost_decision_record`) now call `ResourceUpdated` for the affected resource after a successful write, so subscribed clients get pushed updates instead of needing to re-poll.

## Test plan
- [x] `go vet ./...`
- [x] `go build -o /dev/null ./cmd/ghost`
- [x] `go test -race -count=1 ./...`
- [x] New tests: `TestResourceSubscription_NotifiesOnMemorySave` (end-to-end subscribe → mutate → notification received), `TestResourceSubscription_RejectsUnknownURI`