### PR TITLE
feat(obsidian): auto-start vault sync from the session-start hook

### DIFF
--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -76,6 +76,8 @@ type sessionStartInput struct {
 // Its stdout becomes visible in Claude's context as a system-reminder.
 // It automatically loads project context from the ghost DB based on cwd.
 func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
+	ensureObsidianSyncRunning()
+
 	data, _ := io.ReadAll(stdin)
 
 	var input sessionStartInput

--- a/internal/mcpinit/obsidiansync.go
+++ b/internal/mcpinit/obsidiansync.go
@@ -1,0 +1,70 @@
+package mcpinit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/wcatz/ghost/internal/config"
+)
+
+// ensureObsidianSyncRunning starts `ghost obsidian sync` as a detached
+// background process if one isn't already running, so the Obsidian vault
+// mirror stays current for the rest of the machine's uptime instead of only
+// reflecting whatever was in the DB the last time someone ran the command by
+// hand. Best-effort and silent: any failure here must never block or fail
+// the session-start hook.
+func ensureObsidianSyncRunning() {
+	dataDir, err := config.DataDir()
+	if err != nil {
+		return
+	}
+	pidPath := filepath.Join(dataDir, "obsidian-sync.pid")
+	if isAlive(pidPath) {
+		return
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	logFile, err := os.OpenFile(filepath.Join(dataDir, "obsidian-sync.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+
+	cmd := exec.Command(exe, "obsidian", "sync")
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	// New session: survives this short-lived hook process exiting, and won't
+	// receive signals sent to Claude Code's process group.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		return
+	}
+	_ = os.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), 0o600)
+	_ = cmd.Process.Release()
+}
+
+// isAlive reports whether pidPath names a PID file for a process that is
+// still running. It never treats a stale or missing PID file as an error —
+// the caller's only decision is "spawn a new one, or not".
+func isAlive(pidPath string) bool {
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		return false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/internal/mcpinit/obsidiansync.go
+++ b/internal/mcpinit/obsidiansync.go
@@ -35,6 +35,7 @@ func ensureObsidianSyncRunning() {
 	if err != nil {
 		return
 	}
+	defer logFile.Close() //nolint:errcheck
 
 	cmd := exec.Command(exe, "obsidian", "sync")
 	cmd.Stdout = logFile
@@ -43,7 +44,6 @@ func ensureObsidianSyncRunning() {
 	// receive signals sent to Claude Code's process group.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if err := cmd.Start(); err != nil {
-		_ = logFile.Close()
 		return
 	}
 	_ = os.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), 0o600)

--- a/internal/mcpinit/obsidiansync_test.go
+++ b/internal/mcpinit/obsidiansync_test.go
@@ -1,0 +1,46 @@
+package mcpinit
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestIsAlive_MissingFile(t *testing.T) {
+	if isAlive(filepath.Join(t.TempDir(), "nope.pid")) {
+		t.Error("isAlive() = true for a missing pidfile, want false")
+	}
+}
+
+func TestIsAlive_Garbage(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "obsidian-sync.pid")
+	if err := os.WriteFile(pidPath, []byte("not-a-pid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if isAlive(pidPath) {
+		t.Error("isAlive() = true for a non-numeric pidfile, want false")
+	}
+}
+
+func TestIsAlive_LiveProcess(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "obsidian-sync.pid")
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !isAlive(pidPath) {
+		t.Error("isAlive() = false for this test process's own PID, want true")
+	}
+}
+
+func TestIsAlive_DeadProcess(t *testing.T) {
+	// PID 1 belongs to init/systemd, never to us; a PID far above any real
+	// process on a test runner is the reliable way to name a dead one.
+	pidPath := filepath.Join(t.TempDir(), "obsidian-sync.pid")
+	if err := os.WriteFile(pidPath, []byte("999999"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if isAlive(pidPath) {
+		t.Error("isAlive() = true for an implausible PID, want false")
+	}
+}


### PR DESCRIPTION
## Summary
- The Obsidian vault mirror (`ghost obsidian sync`) was never wired to run automatically — no hook, no systemd unit, nothing. It only reflected whatever was in the DB the last time someone happened to run the command by hand (found 15+ hours stale).
- `HandleSessionStartHook` now calls `ensureObsidianSyncRunning()`, which spawns a detached `ghost obsidian sync` (own session, logs to `obsidian-sync.log`) if one isn't already alive per a pidfile at `$XDG_DATA_HOME/ghost/obsidian-sync.pid`.
- Verified manually: repeated hook invocations reuse the same running process (no duplicate spawns), and the vault picked up 82 changed files on the next 30s poll after being stale.

## Test plan
- [x] `go vet ./...`
- [x] `go build -o /dev/null ./cmd/ghost`
- [x] `go test -race -count=1 ./...`
- [x] Manual: built binary, ran `hook session-start` twice, confirmed single detached `obsidian sync` process and pidfile reuse
- [x] Manual: confirmed vault directory timestamps advance after being stale

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Obsidian vault synchronization now starts automatically when a session begins.
  * Synchronization runs in the background and avoids launching duplicate processes.
  * Sync activity is recorded in a log for troubleshooting.

* **Bug Fixes**
  * Stale or invalid synchronization process records are handled automatically.

* **Tests**
  * Added coverage for detecting active, inactive, missing, and invalid synchronization processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->