### PR TITLE
fix(obsidian): make session-start auto-sync opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ ghost obsidian export --out ~/Documents/GhostVault   # one-shot mirror
 ghost obsidian sync --interval 30s                   # keep it fresh
 ```
 
+Set `obsidian.auto_sync: true` in config to have the session-start hook spawn `ghost obsidian sync` in the background automatically instead of running it by hand — off by default, so nobody gets a vault directory or a background process without asking for it.
+
 ## MCP surface
 
 18 tools, 4 resources:

--- a/internal/config/config.example.yaml
+++ b/internal/config/config.example.yaml
@@ -41,6 +41,11 @@
 # --- Obsidian Vault Mirror ---
 # One-way Markdown mirror of memories, decisions, and tasks
 # (ghost obsidian export|sync). Empty vault_dir means ~/Documents/GhostVault.
+# auto_sync (default false) makes the session-start hook spawn `ghost
+# obsidian sync` in the background automatically. Leave it off if you don't
+# use Obsidian — it's opt-in so nobody gets a vault directory or a background
+# process they didn't ask for.
 # obsidian:
 #   vault_dir: ""                    # or set GHOST_OBSIDIAN_VAULT_DIR
 #   interval: "30s"                  # sync poll cadence (Go duration, e.g. "1m")
+#   auto_sync: false                 # true = auto-start sync from session-start

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,7 @@ type LinkingConfig struct {
 type ObsidianConfig struct {
 	VaultDir string `koanf:"vault_dir"` // empty = ~/Documents/GhostVault, resolved by the CLI
 	Interval string `koanf:"interval"`  // sync poll cadence, time.ParseDuration format
+	AutoSync bool   `koanf:"auto_sync"` // if true, session-start spawns `ghost obsidian sync` automatically
 }
 
 // defaults is the base layer — always loaded first.
@@ -75,6 +76,7 @@ var defaults = map[string]interface{}{
 	"linking.threshold":    0.70,
 	"obsidian.vault_dir":   "",
 	"obsidian.interval":    "30s",
+	"obsidian.auto_sync":   false,
 }
 
 // Load reads configuration with layered precedence.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -324,4 +324,7 @@ func TestObsidianDefaults(t *testing.T) {
 	if cfg.Obsidian.Interval != "30s" {
 		t.Errorf("Interval default = %q, want 30s", cfg.Obsidian.Interval)
 	}
+	if cfg.Obsidian.AutoSync {
+		t.Error("AutoSync default = true, want false (opt-in only)")
+	}
 }

--- a/internal/mcpinit/obsidiansync.go
+++ b/internal/mcpinit/obsidiansync.go
@@ -15,9 +15,16 @@ import (
 // background process if one isn't already running, so the Obsidian vault
 // mirror stays current for the rest of the machine's uptime instead of only
 // reflecting whatever was in the DB the last time someone ran the command by
-// hand. Best-effort and silent: any failure here must never block or fail
-// the session-start hook.
+// hand. Opt-in via obsidian.auto_sync (default false) — most users never run
+// Obsidian at all, and this must not create a vault directory or spawn a
+// process on their machines without asking. Best-effort and silent
+// otherwise: any failure here must never block or fail the session-start hook.
 func ensureObsidianSyncRunning() {
+	cfg, err := config.Load()
+	if err != nil || !cfg.Obsidian.AutoSync {
+		return
+	}
+
 	dataDir, err := config.DataDir()
 	if err != nil {
 		return

--- a/internal/mcpinit/obsidiansync_test.go
+++ b/internal/mcpinit/obsidiansync_test.go
@@ -7,6 +7,22 @@ import (
 	"testing"
 )
 
+func TestEnsureObsidianSyncRunning_DisabledByDefault(t *testing.T) {
+	// Isolate from the host: obsidian.auto_sync defaults to false, and this
+	// must not touch a real home/config/data dir either way.
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	dataDir := filepath.Join(tmpDir, "data")
+	t.Setenv("XDG_DATA_HOME", dataDir)
+
+	ensureObsidianSyncRunning()
+
+	if _, err := os.Stat(filepath.Join(dataDir, "ghost", "obsidian-sync.pid")); !os.IsNotExist(err) {
+		t.Errorf("expected no pidfile to be created when auto_sync is off (err=%v)", err)
+	}
+}
+
 func TestIsAlive_MissingFile(t *testing.T) {
 	if isAlive(filepath.Join(t.TempDir(), "nope.pid")) {
 		t.Error("isAlive() = true for a missing pidfile, want false")


### PR DESCRIPTION
## Summary
- #203 made session-start unconditionally spawn `ghost obsidian sync` and create a vault directory for every user — fine for me, wrong for anyone who ships/installs this binary and doesn't use Obsidian.
- Added `obsidian.auto_sync` (default `false`). Session-start now checks it before doing anything; `ghost obsidian export|sync` run manually are unaffected.
- Documented in `config.example.yaml` and README.

## Test plan
- [x] `go vet ./...`
- [x] `go build -o /dev/null ./cmd/ghost`
- [x] `go test -race -count=1 ./...` (one pre-existing unrelated flake in `internal/obsidian.TestSyncRetriesFailedExport`, passes in isolation — not touched by this change)
- [x] New test: `TestObsidianDefaults` asserts `AutoSync` defaults to false
- [x] New test: `TestEnsureObsidianSyncRunning_DisabledByDefault` asserts no pidfile/process when unset