### PR TITLE
fix(mcpinit): split detached-process setup by platform for windows cross-build

### DIFF
--- a/internal/mcpinit/obsidiansync.go
+++ b/internal/mcpinit/obsidiansync.go
@@ -49,7 +49,7 @@ func ensureObsidianSyncRunning() {
 	cmd.Stderr = logFile
 	// New session: survives this short-lived hook process exiting, and won't
 	// receive signals sent to Claude Code's process group.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	detachProcess(cmd)
 	if err := cmd.Start(); err != nil {
 		return
 	}

--- a/internal/mcpinit/obsidiansync_unix.go
+++ b/internal/mcpinit/obsidiansync_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package mcpinit
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachProcess starts cmd in a new session so it survives this short-lived
+// hook process exiting and won't receive signals sent to Claude Code's
+// process group.
+func detachProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/mcpinit/obsidiansync_windows.go
+++ b/internal/mcpinit/obsidiansync_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package mcpinit
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachProcess starts cmd in a new process group so it survives this
+// short-lived hook process exiting and won't receive signals (e.g. console
+// close) sent to Claude Code's process group. Windows has no setsid
+// equivalent, so CREATE_NEW_PROCESS_GROUP is the closest analog.
+func detachProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}


### PR DESCRIPTION
## Summary
- Fixes the v0.14.0 GoReleaser release failure: \`syscall.SysProcAttr{Setsid: true}\` doesn't compile on windows/amd64 or windows/arm64.
- Splits the detached-process setup into \`obsidiansync_unix.go\` (setsid) and \`obsidiansync_windows.go\` (CREATE_NEW_PROCESS_GROUP), selected via build tags.
- CI only builds for linux, so this wasn't caught until the release cross-build ran.

## Test plan
- [x] \`go build\` for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64 — all clean
- [x] \`go vet ./...\`
- [x] \`go test -race -count=1 ./...\` — full suite green