### PR TITLE
docs(architecture): fix pinned-decay claim and disabled graph bonus

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,7 +130,10 @@ embedding.Worker goroutine:
              
 Search with embeddings enabled:
   store.SearchHybrid() → 70% vector (cosine) + 30% FTS5, RRF fusion (k=60)
-                       + additive graph bonus: 2-hop link expansion from top-3 seeds
+                       (optional additive graph bonus — 2-hop link expansion from
+                        top-3 seeds — ships DISABLED: DefaultSearchParams sets
+                        GraphWeight=0 after a bench sweep showed it demoting exact
+                        matches; opt in via SearchHybridParams)
 
 Search without embeddings:
   store.SearchFTS() → FTS5 only (porter unicode61 tokenizer)
@@ -169,15 +172,18 @@ schema changes only reach databases created after the change.
 
 ## Time-Decay Scoring
 
-Memories are scored by `importance × decay_factor` where:
+Memories are scored by `importance × decay_factor × pinned_boost`, where
+`decay_factor = max(floor, 1 / (1 + age_days / scale))`:
 
-| Category | Half-life |
-|----------|-----------|
-| preference, convention, fact | none (no decay) |
-| architecture, pattern | 45-day |
-| decision, gotcha, dependency | 30-day |
+| Category | Scale (half-life) | Floor |
+|----------|-------------------|-------|
+| preference, convention, fact | none (no decay) | — |
+| architecture, pattern | 45-day | 0.3 |
+| decision, gotcha, dependency | 30-day | 0.15 |
 
-Pinned memories bypass decay entirely and always rank first.
+Pinned memories get a 1.5× boost (`pinned_boost`) on top of their decayed score —
+they do **not** bypass decay, so a sufficiently stale pinned memory can still rank
+below a fresh unpinned one. See `GetTopMemories` in `internal/memory/store.go`.
 
 ## Build
 


### PR DESCRIPTION
## What

Fact-check pass over \`docs/architecture.md\` against current source turned up three claims that drifted from the code. This corrects them; no code changes.

### 1. Pinned-memory decay (the wrong one)
\`docs/architecture.md:180\` claimed *"Pinned memories bypass decay entirely and always rank first."* The actual query in \`GetTopMemories\` ([store.go:448](../blob/main/internal/memory/store.go#L448)) only multiplies the decayed score by \`1.5\` for pinned rows — they still decay, and a stale pinned memory can rank below a fresh unpinned one. \`README.md:153\` already states this correctly; only the architecture doc was wrong.

### 2. Scoring formula was incomplete
Documented as \`importance × decay_factor\`; actual formula is \`importance × decay_factor × pinned_boost\`. Added the pinned term, the \`decay_factor\` expression, and the decay floors (0.3 / 0.15) to match the query and the README table.

### 3. Graph bonus presented as active
The hybrid-search diagram listed the additive graph bonus as part of the search path. \`DefaultSearchParams\` ships \`GraphWeight = 0\` (disabled after a bench sweep showed it demoting exact matches). Diagram now marks it disabled/opt-in.

## Verification
- \`benchmarks.md\` was also fact-checked in the same pass (ran \`ghost bench\` + the staleness/recency tests, web-verified both arXiv citations) — it was clean, no changes needed.
- All numbers above verified against source: \`store.go:439-449\`, \`vector.go:172\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to clarify that graph-based search expansion is disabled by default.
  * Documented how graph weighting can be enabled through search settings.
  * Clarified time-decay scoring, including a minimum decay floor.
  * Updated pinned-item behavior: pinned items now receive a boost while continuing to follow time-based decay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->