### PR TITLE
fix(mcpserver): notify resource subscribers under both project name and hash

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,7 +130,10 @@ embedding.Worker goroutine:
              
 Search with embeddings enabled:
   store.SearchHybrid() → 70% vector (cosine) + 30% FTS5, RRF fusion (k=60)
-                       + additive graph bonus: 2-hop link expansion from top-3 seeds
+                       (optional additive graph bonus — 2-hop link expansion from
+                        top-3 seeds — ships DISABLED: DefaultSearchParams sets
+                        GraphWeight=0 after a bench sweep showed it demoting exact
+                        matches; opt in via SearchHybridParams)
 
 Search without embeddings:
   store.SearchFTS() → FTS5 only (porter unicode61 tokenizer)
@@ -169,15 +172,18 @@ schema changes only reach databases created after the change.
 
 ## Time-Decay Scoring
 
-Memories are scored by `importance × decay_factor` where:
+Memories are scored by `importance × decay_factor × pinned_boost`, where
+`decay_factor = max(floor, 1 / (1 + age_days / scale))`:
 
-| Category | Half-life |
-|----------|-----------|
-| preference, convention, fact | none (no decay) |
-| architecture, pattern | 45-day |
-| decision, gotcha, dependency | 30-day |
+| Category | Scale (half-life) | Floor |
+|----------|-------------------|-------|
+| preference, convention, fact | none (no decay) | — |
+| architecture, pattern | 45-day | 0.3 |
+| decision, gotcha, dependency | 30-day | 0.15 |
 
-Pinned memories bypass decay entirely and always rank first.
+Pinned memories get a 1.5× boost (`pinned_boost`) on top of their decayed score —
+they do **not** bypass decay, so a sufficiently stale pinned memory can still rank
+below a fresh unpinned one. See `GetTopMemories` in `internal/memory/store.go`.
 
 ## Build
 

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -169,6 +169,37 @@ func (s *Server) notifyResourceUpdated(ctx context.Context, uri string) {
 	}
 }
 
+// notifyProjectResource pushes a resources/updated notification for a
+// project-scoped resource (suffix is "context", "decisions", or "tasks") under
+// every URI alias a client might have subscribed with. Resource identity is
+// echoed back verbatim from the read request, so a client that read a resource
+// by project name subscribes under the name form, while callers here typically
+// hold the resolved hash ID (or read it straight from the DB row). Since MCP
+// delivers resources/updated by exact URI match, we emit on both the hash ID
+// and the project name. Best-effort — the ListProjects lookup error is swallowed.
+func (s *Server) notifyProjectResource(ctx context.Context, projectID, suffix string) {
+	emitted := map[string]bool{}
+	emit := func(id string) {
+		if id == "" || emitted[id] {
+			return
+		}
+		emitted[id] = true
+		s.notifyResourceUpdated(ctx, "ghost://project/"+id+"/"+suffix)
+	}
+	emit(projectID)
+	// projectID may be either the hash ID or the name depending on the call
+	// site; find the project by either and emit its counterpart alias.
+	if projects, err := s.store.ListProjects(ctx); err == nil {
+		for _, p := range projects {
+			if p.ID == projectID || p.Name == projectID {
+				emit(p.ID)
+				emit(p.Name)
+				break
+			}
+		}
+	}
+}
+
 // SetEmbedder configures optional vector embedding for hybrid search.
 func (s *Server) SetEmbedder(e Embedder, projectCh chan<- string) {
 	s.embedder = e
@@ -286,7 +317,7 @@ func (s *Server) applyMemoryUpdate(ctx context.Context, args updateArgs) (string
 	if err := s.store.UpdateMemory(ctx, resolvedProjectID, args.MemoryID, content, category, args.Importance, args.Tags); err != nil {
 		return "", fmt.Errorf("update failed: %w", err)
 	}
-	s.notifyResourceUpdated(ctx, "ghost://project/"+resolvedProjectID+"/context")
+	s.notifyProjectResource(ctx, resolvedProjectID, "context")
 
 	// A content change dropped the embedding — nudge the worker to re-embed.
 	if content != nil && s.projectCh != nil {
@@ -329,7 +360,7 @@ func (s *Server) promoteMemory(ctx context.Context, projectID, memoryID string) 
 	if err := s.store.PromoteToGlobal(ctx, resolvedProjectID, memoryID); err != nil {
 		return "", fmt.Errorf("promote failed: %w", err)
 	}
-	s.notifyResourceUpdated(ctx, "ghost://project/"+resolvedProjectID+"/context")
+	s.notifyProjectResource(ctx, resolvedProjectID, "context")
 	s.notifyResourceUpdated(ctx, "ghost://memories/global")
 	return fmt.Sprintf("Memory promoted to global scope (id: %s).", memoryID), nil
 }
@@ -457,7 +488,7 @@ func (s *Server) registerTools() {
 		if err != nil {
 			return nil, nil, fmt.Errorf("save failed: %w", err)
 		}
-		s.notifyResourceUpdated(ctx, "ghost://project/"+args.ProjectID+"/context")
+		s.notifyProjectResource(ctx, args.ProjectID, "context")
 
 		// Notify embedding worker of new/updated memory.
 		if s.projectCh != nil {
@@ -634,7 +665,7 @@ func (s *Server) registerTools() {
 		if err := s.store.Delete(ctx, args.MemoryID); err != nil {
 			return nil, nil, fmt.Errorf("delete failed: %w", err)
 		}
-		s.notifyResourceUpdated(ctx, "ghost://project/"+resolvedProjectID+"/context")
+		s.notifyProjectResource(ctx, resolvedProjectID, "context")
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "Memory deleted."}},
@@ -824,7 +855,7 @@ func (s *Server) registerTools() {
 		if err != nil {
 			return nil, nil, fmt.Errorf("create task: %w", err)
 		}
-		s.notifyResourceUpdated(ctx, "ghost://project/"+args.ProjectID+"/tasks")
+		s.notifyProjectResource(ctx, args.ProjectID, "tasks")
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Task created (id: %s)", id)}},
 		}, nil, nil
@@ -903,7 +934,7 @@ func (s *Server) registerTools() {
 		if err := s.store.CompleteTask(ctx, args.TaskID, args.Notes); err != nil {
 			return nil, nil, fmt.Errorf("complete task: %w", err)
 		}
-		s.notifyResourceUpdated(ctx, "ghost://project/"+task.ProjectID+"/tasks")
+		s.notifyProjectResource(ctx, task.ProjectID, "tasks")
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "Task completed."}},
 		}, nil, nil
@@ -952,7 +983,7 @@ func (s *Server) registerTools() {
 		if err != nil {
 			return nil, nil, fmt.Errorf("record decision: %w", err)
 		}
-		s.notifyResourceUpdated(ctx, "ghost://project/"+args.ProjectID+"/decisions")
+		s.notifyProjectResource(ctx, args.ProjectID, "decisions")
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Decision recorded (id: %s)", id)}},
 		}, nil, nil
@@ -1074,7 +1105,7 @@ func (s *Server) registerTools() {
 			return nil, nil, fmt.Errorf("toggle pin: %w", err)
 		}
 		if mems, err := s.store.GetByIDs(ctx, []string{args.MemoryID}); err == nil && len(mems) > 0 {
-			s.notifyResourceUpdated(ctx, "ghost://project/"+mems[0].ProjectID+"/context")
+			s.notifyProjectResource(ctx, mems[0].ProjectID, "context")
 		}
 		action := "pinned"
 		if !args.Pinned {
@@ -1143,7 +1174,7 @@ func (s *Server) registerTools() {
 		if err := s.store.UpdateTask(ctx, current.ID, status, priority, description); err != nil {
 			return nil, nil, fmt.Errorf("update task: %w", err)
 		}
-		s.notifyResourceUpdated(ctx, "ghost://project/"+current.ProjectID+"/tasks")
+		s.notifyProjectResource(ctx, current.ProjectID, "tasks")
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "Task updated."}},
 		}, nil, nil

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -1007,6 +1007,60 @@ func TestResourceSubscription_NotifiesOnMemorySave(t *testing.T) {
 	}
 }
 
+func TestResourceSubscription_NotifiesNameSubscriberOnToolSave(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+
+	ctx := context.Background()
+
+	// Create a project whose hash ID differs from its name, exactly as the
+	// session-start hook does (path-hashed ID + human-readable name).
+	if err := store.EnsureProject(ctx, "6bdc098af7f5", "/home/wayne/git/myproj", "myproj"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	if _, err := srv.mcp.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+
+	updated := make(chan string, 4)
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, &mcp.ClientOptions{
+		ResourceUpdatedHandler: func(ctx context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
+			updated <- req.Params.URI
+		},
+	})
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	// Clients read (and thus subscribe to) resources by project name.
+	const nameURI = "ghost://project/myproj/context"
+	if err := session.Subscribe(ctx, &mcp.SubscribeParams{URI: nameURI}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// Drive the real tool handler, which resolves name -> hash internally.
+	if _, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_memory_save",
+		Arguments: map[string]any{"project_id": "myproj", "content": "name subscriber should be notified", "category": "fact"},
+	}); err != nil {
+		t.Fatalf("CallTool ghost_memory_save: %v", err)
+	}
+
+	select {
+	case got := <-updated:
+		if got != nameURI {
+			t.Errorf("notified URI = %q, want %q", got, nameURI)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resources/updated notification on name URI")
+	}
+}
+
 func TestResourceSubscription_RejectsUnknownURI(t *testing.T) {
 	store := testStore(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -1061,6 +1061,57 @@ func TestResourceSubscription_NotifiesNameSubscriberOnToolSave(t *testing.T) {
 	}
 }
 
+func TestResourceSubscription_NotifiesHashSubscriberOnToolSave(t *testing.T) {
+	// Guards the previously-working direction: emitting both aliases must not
+	// disturb delivery to a client subscribed by the resolved hash ID.
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+
+	ctx := context.Background()
+	if err := store.EnsureProject(ctx, "6bdc098af7f5", "/home/wayne/git/myproj", "myproj"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	if _, err := srv.mcp.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+
+	updated := make(chan string, 4)
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, &mcp.ClientOptions{
+		ResourceUpdatedHandler: func(ctx context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
+			updated <- req.Params.URI
+		},
+	})
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	const hashURI = "ghost://project/6bdc098af7f5/context"
+	if err := session.Subscribe(ctx, &mcp.SubscribeParams{URI: hashURI}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if _, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_memory_save",
+		Arguments: map[string]any{"project_id": "myproj", "content": "hash subscriber should still be notified", "category": "fact"},
+	}); err != nil {
+		t.Fatalf("CallTool ghost_memory_save: %v", err)
+	}
+
+	select {
+	case got := <-updated:
+		if got != hashURI {
+			t.Errorf("notified URI = %q, want %q", got, hashURI)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resources/updated notification on hash URI")
+	}
+}
+
 func TestResourceSubscription_RejectsUnknownURI(t *testing.T) {
 	store := testStore(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))


### PR DESCRIPTION
## Problem

MCP clients read (and therefore *subscribe* to) project-scoped resources by **project name** — e.g. `ghost://project/ghost/context`. The resource handler echoes the read URI back verbatim as the resource identity, so the name form is what a subscription is keyed on.

But every mutating tool resolves `project_id` from name → **hash ID** before building the `resources/updated` notification URI (`ghost://project/6bdc098af7f5/context`). Because the go-sdk delivers `resources/updated` by **exact URI string match**, name-subscribed clients silently never received an update after `save`, `update`, `promote`, `delete`, `decision_record`, `task_create`, `task_update`, or `pin`.

The two DB-sourced notify sites (`pin` reads `mems[0].ProjectID`, `task_update` reads `current.ProjectID`) are always hash-form and were equally broken.

## Fix

Route every project-scoped notify through a single helper, `notifyProjectResource(ctx, projectID, suffix)`, which emits on **both** the hash ID and the project name (deduped when they're equal). The `projectID` argument may arrive as either form depending on the call site, so the helper matches on `p.ID == projectID || p.Name == projectID` and emits both aliases. The `ListProjects` lookup is best-effort — swallowed on error, matching the existing best-effort notify path. The static `ghost://memories/global` site has no project component and is untouched.

## Test

Adds `TestResourceSubscription_NotifiesNameSubscriberOnToolSave`, which:
1. Creates a project with `id != name` (as the session-start hook does), then
2. subscribes by the **name** URI, and
3. drives the **real** `ghost_memory_save` tool handler via `CallTool` (name→hash resolution runs internally).

Verified it fails red (2s timeout) against the pre-fix code and passes after. The prior subscription test called `notifyResourceUpdated` directly and so masked the bug.

`go vet ./...` clean; `go test ./...` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project resource update notifications now reach subscribers using either project names or hashed project IDs.
  * Changes to project memory, tasks, decisions, and pinned memories consistently trigger updates for all supported project URI aliases.
  * Improved reliability when project alias lookup is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->