### PR TITLE
docs(mcpserver): fix stale global-resource count via shared constant

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -78,6 +78,11 @@ const (
 	maxContentLen   = 2000
 	maxTitleLen     = 300
 	maxAlternatives = 20
+
+	// globalMemoriesLimit bounds the ghost://memories/global resource. Shared by
+	// the resource Description and its handler so the advertised count and the
+	// fetched count cannot drift apart.
+	globalMemoriesLimit = 15
 )
 
 // validCategories is the canonical memory-category set, shared by save,
@@ -1247,11 +1252,11 @@ func (s *Server) registerResources() {
 		Title:    "Global Memories",
 		URI:      "ghost://memories/global",
 		MIMEType: "text/plain",
-		Description: "Top 50 cross-project Ghost memories: personal preferences, global conventions, " +
-			"toolchain facts. These apply to all projects. " +
-			"Add entries via the ghost_save_global tool.",
+		Description: fmt.Sprintf("Top %d cross-project Ghost memories: personal preferences, global conventions, "+
+			"toolchain facts. These apply to all projects. "+
+			"Add entries via the ghost_save_global tool.", globalMemoriesLimit),
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
-		memories, err := s.store.GetTopMemories(ctx, "_global", 15)
+		memories, err := s.store.GetTopMemories(ctx, "_global", globalMemoriesLimit)
 		if err != nil {
 			return nil, fmt.Errorf("get global memories: %w", err)
 		}


### PR DESCRIPTION
## What

The `ghost://memories/global` resource **Description** advertised "Top 50" cross-project memories, but its handler fetched only 15 (`GetTopMemories(ctx, "_global", 15)`). Harmless to behavior, but the advertised count was wrong and had already drifted once.

## Fix

Introduce a `globalMemoriesLimit = 15` constant, used by **both** the resource `Description` (via `fmt.Sprintf`) and the handler's fetch. The two counts now share one source of truth and cannot drift apart again.

## Scope

- Only the `ghost://memories/global` resource description/handler pair.
- The project-context resource's separate `GetTopMemories(ctx, "_global", 15)` embed advertises no count, so there was no drift there — left untouched.

## Verification

- `go build ./...` clean
- `go vet ./internal/mcpserver/` clean