### PR TITLE
feat(obsidian): readable aliases + vault usage docs (phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,25 @@ ghost obsidian sync --interval 30s                   # keep it fresh
 
 Set `obsidian.auto_sync: true` in config to have the session-start hook spawn `ghost obsidian sync` in the background automatically instead of running it by hand — off by default, so nobody gets a vault directory or a background process without asking for it.
 
+#### Using the vault
+
+Every note carries YAML frontmatter (`category`, `importance`, `pinned`, `project`, `tags`, `created`, `updated`, `source`) and an `aliases` entry — a short single-line preview of the content — so the graph view and Quick Switcher show a readable label instead of the id-suffixed filename. That structure turns the mirror into a queryable knowledge base with no extra tooling:
+
+- **Graph view** already maps your memories: each `## Related` wikilink is an edge, so the auto-linked graph renders natively. Colour nodes by folder (project) or tag to see clusters.
+- **[Dataview](https://github.com/blacksmithgu/obsidian-dataview) queries** over the frontmatter give live tables without touching Ghost — e.g. pinned gotchas, stale memories, or decisions by status:
+
+  ````markdown
+  ```dataview
+  TABLE importance, updated FROM "Ghost"
+  WHERE type = "memory" AND pinned = true AND category = "gotcha"
+  SORT importance DESC
+  ```
+  ````
+
+- **Backlinks** show what links into a memory; the **tag pane** browses `tags:`; **local graph** and **Canvas** explore or arrange nodes spatially.
+
+Because the mirror is one-way, edits inside the vault are informational only and are **not** synced back to Ghost — and if `sync` is running it will overwrite hand-edits on the next database change. Change memories through the MCP tools (or `ghost` CLI), not by editing notes.
+
 ## MCP surface
 
 18 tools, 4 resources:

--- a/internal/obsidian/render.go
+++ b/internal/obsidian/render.go
@@ -41,6 +41,23 @@ func slug(content string) string {
 	return s
 }
 
+// aliasLabel derives a short, readable display name from text: the first line,
+// whitespace-collapsed, capped at 60 runes. Obsidian shows it in the graph and
+// Quick Switcher instead of the id8-suffixed filename. Empty when text has no
+// usable content, in which case the caller omits the aliases key entirely.
+func aliasLabel(text string) string {
+	line := text
+	if i := strings.IndexByte(line, '\n'); i >= 0 {
+		line = line[:i]
+	}
+	line = strings.Join(strings.Fields(line), " ")
+	const max = 60
+	if r := []rune(line); len(r) > max {
+		line = strings.TrimRight(string(r[:max]), " ")
+	}
+	return line
+}
+
 func id8(id string) string {
 	if len(id) > 8 {
 		return id[:8]
@@ -117,6 +134,17 @@ func fm(b *strings.Builder, key, val string) {
 	fmt.Fprintf(b, "%s: %s\n", key, yamlScalar(val, false))
 }
 
+// fmAlias writes the aliases flow list when label is non-empty. The single-
+// line flow form preserves the one-line-per-key frontmatter invariant, and the
+// label is rendered through yamlScalar (flow=true) so a colon- or bracket-
+// bearing preview stays a valid quoted scalar.
+func fmAlias(b *strings.Builder, label string) {
+	if label == "" {
+		return
+	}
+	fmt.Fprintf(b, "aliases: [%s]\n", yamlScalar(label, true))
+}
+
 // fmTags writes the tags flow list. Each tag is rendered as a flow-sequence
 // item via yamlScalar (flow=true), which quotes any tag containing flow-
 // structural characters or a YAML indicator so the composed [a, b] list always
@@ -134,6 +162,7 @@ func renderMemory(m memory.Memory, links []memory.Link, fileFor map[string]strin
 	var b strings.Builder
 	b.WriteString("---\n")
 	fm(&b, "ghost_id", m.ID)
+	fmAlias(&b, aliasLabel(m.Content))
 	fm(&b, "type", "memory")
 	fm(&b, "category", m.Category)
 	fm(&b, "importance", strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.2f", m.Importance), "0"), "."))
@@ -172,6 +201,7 @@ func renderDecision(d memory.Decision) string {
 	var b strings.Builder
 	b.WriteString("---\n")
 	fm(&b, "ghost_id", d.ID)
+	fmAlias(&b, aliasLabel(d.Title))
 	fm(&b, "type", "decision")
 	fm(&b, "status", d.Status)
 	fm(&b, "project", d.ProjectID)
@@ -197,6 +227,7 @@ func renderTask(t memory.Task) string {
 	var b strings.Builder
 	b.WriteString("---\n")
 	fm(&b, "ghost_id", t.ID)
+	fmAlias(&b, aliasLabel(t.Title))
 	fm(&b, "type", "task")
 	fm(&b, "status", t.Status)
 	fm(&b, "priority", fmt.Sprintf("%d", t.Priority))

--- a/internal/obsidian/render_test.go
+++ b/internal/obsidian/render_test.go
@@ -43,6 +43,7 @@ func TestRenderMemory(t *testing.T) {
 	got := renderMemory(m, links, fileFor)
 	want := `---
 ghost_id: 74a37cba00112233
+aliases: ["Embedding backfill bug: ticker only swept seen projects."]
 type: memory
 category: gotcha
 importance: 0.8
@@ -70,6 +71,29 @@ Embedding backfill bug: ticker only swept seen projects.
 	}
 }
 
+// TestRenderMemoryAlias: notes carry an `aliases` flow list so Obsidian's
+// graph and Quick Switcher show a readable label instead of the id8-suffixed
+// filename. The alias is a single-line preview of the content; the flow form
+// keeps the one-line-per-key invariant prune depends on, and ghost_id stays
+// first.
+func TestRenderMemoryAlias(t *testing.T) {
+	m := memory.Memory{
+		ID: "74a37cba00112233", ProjectID: "ghost", Category: "gotcha",
+		Content:    "Embedding backfill bug: ticker only swept seen projects.",
+		Importance: 0.8, Source: "mcp",
+		CreatedAt: "2026-07-06 12:00:00", UpdatedAt: "2026-07-08 09:30:00",
+	}
+	got := renderMemory(m, nil, nil)
+	// Content holds ": " so the alias is quoted; it is under 60 chars so it is
+	// not truncated.
+	if !strings.Contains(got, "aliases: [\"Embedding backfill bug: ticker only swept seen projects.\"]\n") {
+		t.Errorf("expected quoted single-line alias:\n%s", got)
+	}
+	if !strings.HasPrefix(got, "---\nghost_id: 74a37cba00112233\n") {
+		t.Errorf("ghost_id must stay the first frontmatter line:\n%s", got)
+	}
+}
+
 // TestRenderHostileFrontmatter: frontmatter values must occupy exactly one
 // line per key (the ghost_id-first invariant prune depends on) and must not
 // change the YAML shape of their line, whatever the store holds. The note
@@ -91,6 +115,11 @@ func TestRenderHostileFrontmatter(t *testing.T) {
 	if !strings.Contains(got, "project: \"evil: proj ect\"\n") {
 		t.Errorf("hostile project value must be flattened and quoted:\n%s", got)
 	}
+	// Alias is the first content line; the ": " forces quoting so it stays a
+	// single valid scalar.
+	if !strings.Contains(got, `aliases: ["Body content: stays verbatim, even with colons"]`+"\n") {
+		t.Errorf("alias must be quoted single-line preview:\n%s", got)
+	}
 	// Tags: flow-structural characters force per-item quoting, preserving the
 	// tag content rather than stripping it.
 	if !strings.Contains(got, `tags: ["a,b", "x[0]", "quo\"te"]`+"\n") {
@@ -108,8 +137,8 @@ func TestRenderHostileFrontmatter(t *testing.T) {
 		t.Fatalf("no closing frontmatter fence:\n%s", got)
 	}
 	lines := strings.Split(rest[:end], "\n")
-	if len(lines) != 10 {
-		t.Errorf("frontmatter must hold exactly 10 single-line keys, got %d:\n%s", len(lines), rest[:end])
+	if len(lines) != 11 {
+		t.Errorf("frontmatter must hold exactly 11 single-line keys, got %d:\n%s", len(lines), rest[:end])
 	}
 	for _, line := range lines {
 		if !strings.Contains(line, ": ") {


### PR DESCRIPTION
## What

Phase 1 of the Obsidian research follow-up: make the exported vault pleasant to use *as-is*, with zero changes to the strictly one-way mirror.

### Render change (additive)
- Every mirrored note now emits an `aliases` frontmatter entry — a single-line, 60-rune preview of the memory content (decision/task use the title). Obsidian's graph view and Quick Switcher show this readable label instead of the `slug-id8.md` filename.
- Emitted as a **one-line flow list** immediately after `ghost_id`, preserving the one-line-per-key invariant that `prune`'s `hasGhostID` scan depends on. Quoted via `yamlScalar(flow=true)` so colon/bracket-bearing previews stay valid. Omitted entirely when the label is empty.

### Docs
- README now documents novel **read-only** vault use cases: graph view, Dataview queries over frontmatter, backlinks, tag pane — and reiterates the mirror is one-way (edits are not synced back; a running `sync` overwrites hand-edits).

## Node-name audit result
Filenames cap at ~52 chars on disk (fine); the ~48-char graph *label* was the real friction. The `id8` suffix is load-bearing (uniqueness, `fileFor` key, prune's canonical-identity check), so the fix is `aliases`, not a filename change.

## Testing
- New `TestRenderMemoryAlias` (written test-first, watched fail).
- Updated `TestRenderMemory` (exact output) and `TestRenderHostileFrontmatter` (10→11 keys, alias-quoting assertion) to the new contract.
- `go vet ./...`, `gofmt`, and `go test ./...` all green.

Sync-back (phase 2) is intentionally **not** in this PR — it awaits a separate approval-gated design.