### PR TITLE
feat(bench): Phase 4 end-to-end LongMemEval-S scaffolding (OpenAI + Anthropic)

### DIFF
--- a/bench/longmemeval/main.go
+++ b/bench/longmemeval/main.go
@@ -15,8 +15,15 @@
 //
 //	go run ./bench/longmemeval --data ~/.cache/ghost-bench/longmemeval_s_cleaned.json \
 //	    --condition fts|vector|hybrid [--questions N] [--out per-question.jsonl] \
+//	    [--retrieval-out ranked.jsonl] \
 //	    [--ollama http://localhost:11434] [--embed-cache ~/.cache/ghost-bench/nomic-cache.jsonl] \
 //	    [--floors "r5=0.74,ndcg10=0.72"]
+//
+// --retrieval-out emits, per scored question, the full untruncated ranked
+// session list in the official LongMemEval retrieval_results format
+// ({question_id, ranked_items:[{corpus_id, text}]}), the input the Phase 4
+// (end-to-end, leaderboard-comparable) generation stage merges into the
+// dataset. See docs/benchmarks.md.
 //
 // The fts condition needs no embeddings and runs in minutes. vector/hybrid
 // embed every turn and question through local Ollama (nomic-embed-text:v1.5),
@@ -63,6 +70,27 @@ type question struct {
 	AnswerSessionIDs []string `json:"answer_session_ids"`
 	SessionIDs       []string `json:"haystack_session_ids"`
 	Sessions         [][]turn `json:"haystack_sessions"`
+}
+
+// rankedItem is one entry of the official LongMemEval retrieval_results format
+// (src/generation/run_generation.py reads entry['retrieval_results']
+// ['ranked_items'] as [{corpus_id, text}]). Ghost's corpus_id is the haystack
+// session id verbatim; text is unused by the flat-session reader (merge=none)
+// but kept for schema fidelity.
+type rankedItem struct {
+	CorpusID string `json:"corpus_id"`
+	Text     string `json:"text"`
+}
+
+// retrievalLine is one line of the --retrieval-out log: a question's full,
+// untruncated ranked session list in the official retrieval_results shape,
+// ready to merge into the dataset as the --in_file for the Phase 4 (end-to-end,
+// leaderboard-comparable) generation stage. Unlike perQuestion.TopSessions
+// (capped at 10 for the metrics log), this keeps every ranked session so a
+// downstream topk_context up to 50 has enough to slice.
+type retrievalLine struct {
+	QuestionID     string       `json:"question_id"`
+	RankedSessions []rankedItem `json:"ranked_items"`
 }
 
 // perQuestion is one line of the --out log, per the honest-reporting rules
@@ -175,6 +203,7 @@ func main() {
 	condition := flag.String("condition", "fts", "fts | vector | hybrid")
 	maxQuestions := flag.Int("questions", 0, "limit scored questions (0 = all)")
 	outPath := flag.String("out", "", "per-question JSONL results log")
+	retrievalOutPath := flag.String("retrieval-out", "", "JSONL of full ranked sessions per question in official retrieval_results format (Phase 4 generation input)")
 	ollamaURL := flag.String("ollama", "http://localhost:11434", "Ollama URL for vector/hybrid")
 	embedCache := flag.String("embed-cache", "", "append-only embedding cache JSONL (vector/hybrid)")
 	floorsSpec := flag.String("floors", "", "comma-separated metric=min floors over OVERALL metrics, e.g. \"r5=0.74,ndcg10=0.72\" (keys: r1, r5, r10, mrr10, ndcg10)")
@@ -227,6 +256,16 @@ func main() {
 		defer outFile.Close() //nolint:errcheck
 	}
 
+	var retrievalOutFile *os.File
+	if *retrievalOutPath != "" {
+		retrievalOutFile, err = os.Create(*retrievalOutPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		defer retrievalOutFile.Close() //nolint:errcheck
+	}
+
 	ctx := context.Background()
 	overall := &agg{}
 	byType := map[string]*agg{}
@@ -275,6 +314,14 @@ func main() {
 				TopSessions: top,
 			})
 			_, _ = fmt.Fprintf(outFile, "%s\n", line)
+		}
+		if retrievalOutFile != nil {
+			items := make([]rankedItem, len(rankedSessions))
+			for i, sid := range rankedSessions {
+				items[i] = rankedItem{CorpusID: sid, Text: ""}
+			}
+			line, _ := json.Marshal(retrievalLine{QuestionID: q.QuestionID, RankedSessions: items})
+			_, _ = fmt.Fprintf(retrievalOutFile, "%s\n", line)
 		}
 		if scored%50 == 0 {
 			fmt.Fprintf(os.Stderr, "progress: %d questions scored (%.0fs elapsed)\n", scored, time.Since(start).Seconds())

--- a/bench/longmemeval/phase4/.gitignore
+++ b/bench/longmemeval/phase4/.gitignore
@@ -1,0 +1,8 @@
+# Python bytecode
+__pycache__/
+*.pyc
+
+# Local run artifacts (never commit generated data / hypotheses / judged logs)
+*.jsonl
+merged.json
+venv/

--- a/bench/longmemeval/phase4/README.md
+++ b/bench/longmemeval/phase4/README.md
@@ -1,0 +1,116 @@
+# Phase 4 — end-to-end LongMemEval-S (retrieve → generate → judge)
+
+Phase 1 (`bench/longmemeval`, see [docs/benchmarks.md](../../../docs/benchmarks.md))
+scores **retrieval only**: does Ghost rank the gold session highly? Phase 4
+closes the loop — feed Ghost's retrieved sessions to an LLM, have it answer,
+and grade the answers with an LLM judge — so the number is comparable in shape
+to the LongMemEval leaderboard's QA accuracy.
+
+The pipeline is four stages. Retrieval is Ghost (Go); generation and judging
+reuse the **original** LongMemEval prompt/grading code, with only the API
+client swapped, so the numbers stay reproducible against the published harness.
+
+```
+┌── 1. retrieve (Ghost) ─────────────────────────────────────────────┐
+│ go run ./bench/longmemeval -data longmemeval_s_cleaned.json \       │
+│     -condition hybrid -ollama http://localhost:11434 \              │
+│     -embed-cache ~/.cache/ghost-bench/embed-cache.jsonl \           │
+│     -retrieval-out ranked.jsonl                                     │
+└────────────────────────────────────────────────────────────────────┘
+┌── 2. merge into dataset ───────────────────────────────────────────┐
+│ python merge_retrieval.py --dataset longmemeval_s_cleaned.json \    │
+│     --retrieval ranked.jsonl --out merged.json                      │
+└────────────────────────────────────────────────────────────────────┘
+┌── 3. generate hypotheses ──────────────────────────────────────────┐
+│ python phase4_run.py generate --provider … --model … \             │
+│     --dataset merged.json --out hyp.jsonl                           │
+└────────────────────────────────────────────────────────────────────┘
+┌── 4. judge + report ───────────────────────────────────────────────┐
+│ python phase4_run.py judge --provider … --model … \                │
+│     --dataset merged.json --hyp hyp.jsonl                           │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+## Setup
+
+The generation prompt assembly and the yes/no grading templates are imported
+**verbatim** from a LongMemEval checkout — they are not vendored here (to avoid
+duplicating upstream code and drifting from it):
+
+```bash
+git clone https://github.com/xiaowu0162/LongMemEval
+export LONGMEMEVAL_SRC="$PWD/LongMemEval/src"   # the src/ dir
+python -m venv venv && ./venv/bin/pip install tiktoken   # + LongMemEval deps
+```
+
+`phase4_run.py` imports `prepare_prompt` (from `src/generation/run_generation.py`)
+and `get_anscheck_prompt` (from `src/evaluation/evaluate_qa.py`). Pass the
+checkout with `--longmemeval-src` or the `$LONGMEMEVAL_SRC` env var.
+
+## Keys (never logged)
+
+- `openai`  → `OPENAI_API_KEY`
+- `anthropic` → `ANTHROPIC_API_KEY`, or falls back to `api.key` in
+  `~/.config/ghost/config.yaml` so Ghost's own key can be reused.
+
+The driver never prints a key and never dumps the request headers.
+
+## Fidelity — matches the official harness
+
+- Generation: single user message, `temperature=0`, `max_tokens=500` (non-CoT),
+  `max_retrieval_length = model_max_length − 500 − 1000`, prompt built by the
+  official `prepare_prompt` (default `flat-session`, `topk_context=5`,
+  `history_format=json`, `useronly=false`, `merge_key_expansion=none`).
+- Judging: official `get_anscheck_prompt(task, question, answer, response,
+  abstention)`, `temperature=0`, `max_tokens=10`, `label = "yes" in resp.lower()`.
+  Abstention questions (`*_abs`) get the abstention template automatically.
+- Aggregation: overall accuracy = mean of labels; per-`question_type` mean with
+  counts — identical to `evaluate_qa.py`.
+- Both stages are **append-only and resume-safe**: a crash at question N keeps
+  the first N, and re-running skips already-done `question_id`s.
+- Retries with backoff on 429 / 5xx / 529 (overloaded).
+
+Truncation uses tiktoken `o200k_base` (gpt-4o's tokenizer). For Claude this is
+approximate but conservative — Claude's 200k context comfortably exceeds the
+126500-token budget, so nothing gold gets truncated that gpt-4o would have kept.
+
+## Comparability
+
+- **`openai` with gpt-4o generator + gpt-4o judge** → leaderboard-comparable
+  (this is the official setup: `gpt-4o-2024-08-06`, `o200k_base`).
+- **`anthropic` (Claude generator/judge)** → **NOT** leaderboard-comparable. It
+  is an internal *"Ghost retrieval + Claude generation, Claude-judged"* check.
+  When generator and judge are the same family, note the self-preference caveat
+  (the official setup has the same property — gpt-4o judged gpt-4o); a different
+  strong judge (e.g. gen `claude-sonnet-5`, judge `claude-opus-4-8`) costs only
+  a few dollars extra because the judge emits ~10 tokens per question.
+
+## Cost (no API calls)
+
+```bash
+python cost_estimate.py --dataset merged.json --gen-model claude-sonnet-5 \
+    --judge-model claude-sonnet-5 --topk 5
+```
+
+Snapshot for the full 470 answerable questions at `topk_context=5`:
+
+| gen / judge | generate | judge | total |
+|---|---|---|---|
+| gpt-4o / gpt-4o | ~$18.8 | ~$0.9 | **~$20** |
+| claude-sonnet-5 / claude-sonnet-5 | ~$23.3 | ~$1.2 | **~$24** |
+| claude-sonnet-5 / claude-opus-4-8 | ~$23.3 | ~$6.0 | **~$29** |
+| claude-opus-4-8 / … (generator) | ~$116 | — | **avoid** |
+
+Prices are a static snapshot in `cost_estimate.py` — verify current rates.
+The 30 abstention (`*_abs`) questions are excluded (Ghost's retrieval scoring
+excludes them); a full leaderboard e2e would add them back.
+
+## Example — full 470, Anthropic Sonnet
+
+```bash
+export LONGMEMEVAL_SRC=/path/to/LongMemEval/src
+python phase4_run.py generate --provider anthropic --model claude-sonnet-5 \
+    --dataset merged.json --out hyp.sonnet.jsonl
+python phase4_run.py judge --provider anthropic --model claude-sonnet-5 \
+    --dataset merged.json --hyp hyp.sonnet.jsonl
+```

--- a/bench/longmemeval/phase4/README.md
+++ b/bench/longmemeval/phase4/README.md
@@ -10,7 +10,7 @@ The pipeline is four stages. Retrieval is Ghost (Go); generation and judging
 reuse the **original** LongMemEval prompt/grading code, with only the API
 client swapped, so the numbers stay reproducible against the published harness.
 
-```
+```text
 ┌── 1. retrieve (Ghost) ─────────────────────────────────────────────┐
 │ go run ./bench/longmemeval -data longmemeval_s_cleaned.json \       │
 │     -condition hybrid -ollama http://localhost:11434 \              │

--- a/bench/longmemeval/phase4/cost_estimate.py
+++ b/bench/longmemeval/phase4/cost_estimate.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Estimate Phase 4 generation+judge cost with NO API calls.
+
+Uses the official prepare_prompt for byte-accurate prompt assembly and counts
+tokens with tiktoken o200k_base (gpt-4o's tokenizer). For Anthropic models the
+count is approximate — Claude tokenizes differently — but tiktoken is a
+reasonable, conservative proxy for a dollar estimate.
+
+    python cost_estimate.py --dataset merged.json --longmemeval-src <src> \
+        [--gen-model gpt-4o] [--judge-model gpt-4o] [--topk 5 10 25 50]
+
+Pricing table (USD per 1M tokens) is a static snapshot — verify current rates
+before relying on the dollar figure.
+"""
+import argparse
+import json
+import os
+import sys
+
+# per-1M-token (input, output) — static snapshot, verify before trusting $.
+PRICES = {
+    "gpt-4o":          (2.50, 10.00),
+    "claude-sonnet-5": (3.00, 15.00),
+    "claude-opus-4-8": (15.00, 75.00),
+    "claude-haiku-4-5": (1.00, 5.00),
+}
+GEN_LENGTH = 500
+RESERVE = 1000
+MODEL_MAX = 128000
+
+
+def price(model):
+    for k, v in PRICES.items():
+        if model.startswith(k):
+            return v
+    sys.exit(f"error: no pricing for {model!r}; add it to PRICES")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--longmemeval-src")
+    ap.add_argument("--gen-model", default="gpt-4o")
+    ap.add_argument("--judge-model", default="gpt-4o")
+    ap.add_argument("--topk", type=int, nargs="+", default=[5, 10, 25, 50])
+    args = ap.parse_args()
+
+    src = args.longmemeval_src or os.environ.get("LONGMEMEVAL_SRC")
+    if not src:
+        sys.exit("error: pass --longmemeval-src or set $LONGMEMEVAL_SRC")
+    sys.path.insert(0, os.path.join(src, "generation"))
+    import tiktoken
+    from run_generation import prepare_prompt
+
+    data = json.load(open(args.dataset))
+    tok = tiktoken.get_encoding("o200k_base")
+    max_ret = MODEL_MAX - GEN_LENGTH - RESERVE
+    gin, gout = price(args.gen_model)
+    jin, jout = price(args.judge_model)
+
+    print(f"gen={args.gen_model} (${gin}/${gout} per 1M)  "
+          f"judge={args.judge_model} (${jin}/${jout} per 1M)")
+    for topk in args.topk:
+        tot_in = n = 0
+        for e in data:
+            p = prepare_prompt(e, "flat-session", topk, False, "json", False,
+                               tok, "openai", max_ret, "none")
+            tot_in += min(len(tok.encode(p, allowed_special={'<|endoftext|>'})), max_ret + 2000)
+            n += 1
+        gen_cost = tot_in / 1e6 * gin + n * GEN_LENGTH / 1e6 * gout
+        judge_cost = n * 800 / 1e6 * jin + n * 10 / 1e6 * jout
+        print(f"  topk={topk:2d}  avg_in={tot_in // n:>7} tok  "
+              f"gen=${gen_cost:7.2f}  judge=${judge_cost:6.2f}  "
+              f"TOTAL=${gen_cost + judge_cost:7.2f}  (n={n})")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/longmemeval/phase4/merge_retrieval.py
+++ b/bench/longmemeval/phase4/merge_retrieval.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Merge Ghost's ranked_items into the LongMemEval dataset as retrieval_results.
+
+Produces an augmented dataset (list JSON) that the official run_generation.py
+reads via --in_file: each entry gains
+    entry['retrieval_results'] = {'ranked_items': [{corpus_id, text}, ...]}
+Optionally restricts to a type-stratified subset (for a smoke run).
+
+Verifies corpus_id resolution: every ranked corpus_id must be a
+haystack_session_id (after run_generation's noans_->answer_ normalization), or
+the generator would silently see empty context. Aborts on any mismatch.
+
+Input `--retrieval` is the JSONL produced by:
+    go run ./bench/longmemeval -condition hybrid ... -retrieval-out ranked.jsonl
+"""
+import argparse
+import json
+import sys
+from collections import defaultdict
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", required=True,
+                    help="LongMemEval-S dataset JSON (longmemeval_s_cleaned.json)")
+    ap.add_argument("--retrieval", required=True, help="Ghost -retrieval-out JSONL")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--per-type", type=int, default=0,
+                    help="keep first N answerable questions of each type (0=all)")
+    args = ap.parse_args()
+
+    dataset = json.load(open(args.dataset))
+    ranked = {}
+    for line in open(args.retrieval):
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        ranked[obj["question_id"]] = obj["ranked_items"]
+
+    missing_ret = 0
+    bad_corpus = 0
+    kept = []
+    counts = defaultdict(int)
+    for entry in dataset:
+        qid = entry["question_id"]
+        if qid.endswith("_abs"):
+            continue  # abstention: excluded from retrieval scoring, skip
+        if qid not in ranked:
+            missing_ret += 1
+            continue
+        # verify every corpus_id resolves to a haystack session (post-normalize)
+        haystack = set(entry["haystack_session_ids"])
+        for it in ranked[qid]:
+            cid = it["corpus_id"].replace("noans_", "answer_")
+            if cid not in haystack:
+                bad_corpus += 1
+                print(f"BAD corpus_id {it['corpus_id']!r} not in haystack for {qid}",
+                      file=sys.stderr)
+        if args.per_type > 0:
+            if counts[entry["question_type"]] >= args.per_type:
+                continue
+            counts[entry["question_type"]] += 1
+        entry["retrieval_results"] = {"ranked_items": ranked[qid]}
+        kept.append(entry)
+
+    if bad_corpus:
+        print(f"ABORT: {bad_corpus} corpus_id(s) did not resolve", file=sys.stderr)
+        sys.exit(1)
+    if missing_ret:
+        print(f"WARN: {missing_ret} answerable questions had no retrieval line",
+              file=sys.stderr)
+
+    json.dump(kept, open(args.out, "w"))
+    print(f"Wrote {len(kept)} entries to {args.out}")
+    if args.per_type:
+        print("per-type:", dict(counts))
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/longmemeval/phase4/phase4_run.py
+++ b/bench/longmemeval/phase4/phase4_run.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Phase 4 end-to-end LongMemEval-S driver: retrieve -> generate -> judge.
+
+This is the generation + judging half of the Phase 4 pipeline. The retrieval
+half is Ghost itself:
+
+    go run ./bench/longmemeval -condition hybrid ... -retrieval-out ranked.jsonl
+    python merge_retrieval.py --dataset longmemeval_s_cleaned.json \
+        --retrieval ranked.jsonl --out merged.json
+    python phase4_run.py generate --dataset merged.json --out hyp.jsonl ...
+    python phase4_run.py judge    --dataset merged.json --hyp hyp.jsonl ...
+    python phase4_run.py report   --dataset merged.json --hyp hyp.jsonl
+
+Fidelity: prompt assembly (generation) and the yes/no grading templates
+(judging) are the ORIGINAL LongMemEval functions, imported verbatim from a
+LongMemEval checkout (`--longmemeval-src` or $LONGMEMEVAL_SRC pointing at its
+`src/` dir). Only the API client is swapped, so results are reproducible
+against the published harness. See bench/longmemeval/phase4/README.md.
+
+Providers: `openai` (leaderboard-comparable when gen+judge are gpt-4o) or
+`anthropic` (Claude gen/judge — NOT leaderboard-comparable; documented as an
+internal "Ghost retrieval + Claude, Claude-judged" check).
+
+No secret is ever logged. Keys come from the environment
+(OPENAI_API_KEY / ANTHROPIC_API_KEY); for anthropic, ~/.config/ghost/config.yaml
+(api.key) is a fallback so Ghost's own key can be reused.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections import defaultdict
+
+# Official generation defaults (run_generation.py, non-CoT).
+GEN_LENGTH = 500          # max_tokens for generation
+RESERVE = 1000            # headroom subtracted from model context for the prompt
+DEFAULT_MODEL_MAX = 128000  # gpt-4o context; Claude (200k) is safely larger
+
+# Backoff-eligible transient statuses (429 rate limit, 5xx, 529 overloaded).
+RETRY_STATUS = {429, 500, 502, 503, 529}
+
+
+# --------------------------------------------------------------------------
+# key sourcing (never logged)
+# --------------------------------------------------------------------------
+def get_key(provider):
+    if provider == "openai":
+        k = os.environ.get("OPENAI_API_KEY")
+        if not k:
+            sys.exit("error: OPENAI_API_KEY not set")
+        return k
+    # anthropic: env first, then Ghost config fallback
+    k = os.environ.get("ANTHROPIC_API_KEY")
+    if k:
+        return k
+    cfg = os.path.expanduser("~/.config/ghost/config.yaml")
+    if os.path.exists(cfg):
+        in_api = False
+        for line in open(cfg):
+            if re.match(r"^\S", line):                 # top-level key
+                in_api = line.strip().startswith("api:")
+                continue
+            if in_api:
+                m = re.match(r"\s+key:\s*(\S+)", line)
+                if m:
+                    return m.group(1).strip().strip('"').strip("'")
+    sys.exit("error: ANTHROPIC_API_KEY not set and no api.key in "
+             "~/.config/ghost/config.yaml")
+
+
+# --------------------------------------------------------------------------
+# HTTP with retry (stdlib only; no openai/anthropic SDK dependency)
+# --------------------------------------------------------------------------
+def _post(url, headers, body, max_retries=6):
+    data = json.dumps(body).encode()
+    for attempt in range(max_retries):
+        req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=300) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            status = e.code
+            if status in RETRY_STATUS and attempt < max_retries - 1:
+                wait = min(2 ** attempt, 30)
+                sys.stderr.write(f"  http {status}, retry in {wait}s "
+                                 f"({attempt + 1}/{max_retries})\n")
+                time.sleep(wait)
+                continue
+            # non-retryable: surface body WITHOUT any header (no key leak)
+            try:
+                detail = e.read().decode()[:300]
+            except Exception:
+                detail = ""
+            raise RuntimeError(f"HTTP {status}: {detail}") from None
+        except (urllib.error.URLError, TimeoutError) as e:
+            if attempt < max_retries - 1:
+                wait = min(2 ** attempt, 30)
+                sys.stderr.write(f"  net error, retry in {wait}s "
+                                 f"({attempt + 1}/{max_retries})\n")
+                time.sleep(wait)
+                continue
+            raise RuntimeError(f"network error: {e}") from None
+    raise RuntimeError("exhausted retries")
+
+
+def chat(provider, model, key, prompt, max_tokens):
+    """Single-user-message chat completion, temperature 0. Returns text."""
+    if provider == "openai":
+        body = {"model": model, "temperature": 0, "max_tokens": max_tokens, "n": 1,
+                "messages": [{"role": "user", "content": prompt}]}
+        headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
+        out = _post("https://api.openai.com/v1/chat/completions", headers, body)
+        return out["choices"][0]["message"]["content"]
+    # anthropic
+    body = {"model": model, "temperature": 0, "max_tokens": max_tokens,
+            "messages": [{"role": "user", "content": prompt}]}
+    headers = {"x-api-key": key, "anthropic-version": "2023-06-01",
+               "Content-Type": "application/json"}
+    out = _post("https://api.anthropic.com/v1/messages", headers, body)
+    # concatenate all text blocks (usually one)
+    return "".join(b.get("text", "") for b in out["content"] if b.get("type") == "text")
+
+
+# --------------------------------------------------------------------------
+# official prompt functions, imported from a LongMemEval checkout
+# --------------------------------------------------------------------------
+def import_official(longmemeval_src):
+    src = longmemeval_src or os.environ.get("LONGMEMEVAL_SRC")
+    if not src:
+        sys.exit("error: pass --longmemeval-src or set $LONGMEMEVAL_SRC "
+                 "(the LongMemEval repo's src/ dir)")
+    sys.path.insert(0, os.path.join(src, "generation"))
+    sys.path.insert(0, os.path.join(src, "evaluation"))
+    from run_generation import prepare_prompt          # noqa: E402
+    from evaluate_qa import get_anscheck_prompt         # noqa: E402
+    return prepare_prompt, get_anscheck_prompt
+
+
+def load_done(path):
+    """question_ids already present in an append-only JSONL (resume support)."""
+    done = set()
+    if os.path.exists(path):
+        for line in open(path):
+            line = line.strip()
+            if line:
+                done.add(json.loads(line)["question_id"])
+    return done
+
+
+# --------------------------------------------------------------------------
+# generate
+# --------------------------------------------------------------------------
+def cmd_generate(args):
+    prepare_prompt, _ = import_official(args.longmemeval_src)
+    import tiktoken
+    tok = tiktoken.get_encoding("o200k_base")
+    max_ret = args.model_max_length - GEN_LENGTH - RESERVE
+
+    key = get_key(args.provider)
+    data = json.load(open(args.dataset))
+    done = load_done(args.out)
+    if done:
+        sys.stderr.write(f"resume: {len(done)} already generated, skipping them\n")
+
+    n_done = len(done)
+    with open(args.out, "a") as fout:
+        for i, entry in enumerate(data):
+            qid = entry["question_id"]
+            if qid in done:
+                continue
+            prompt = prepare_prompt(
+                entry, args.retriever_type, args.topk_context, args.useronly,
+                args.history_format, args.cot, tok, "openai", max_ret, "none")
+            answer = chat(args.provider, args.model, key, prompt, GEN_LENGTH).strip()
+            fout.write(json.dumps({"question_id": qid, "hypothesis": answer}) + "\n")
+            fout.flush()
+            n_done += 1
+            if n_done % 10 == 0 or i == len(data) - 1:
+                sys.stderr.write(f"  generated {n_done}/{len(data)}\n")
+    sys.stderr.write(f"done: {args.out}\n")
+
+
+# --------------------------------------------------------------------------
+# judge
+# --------------------------------------------------------------------------
+def cmd_judge(args):
+    _, get_anscheck_prompt = import_official(args.longmemeval_src)
+    key = get_key(args.provider)
+
+    meta = {e["question_id"]: e for e in json.load(open(args.dataset))}
+    out_path = args.judged or (args.hyp + f".eval-results-{args.model}")
+    done = load_done(out_path)
+    if done:
+        sys.stderr.write(f"resume: {len(done)} already judged, skipping them\n")
+
+    hyps = [json.loads(l) for l in open(args.hyp) if l.strip()]
+    n_done = len(done)
+    with open(out_path, "a") as fout:
+        for h in hyps:
+            qid = h["question_id"]
+            if qid in done:
+                continue
+            e = meta[qid]
+            abstention = qid.endswith("_abs")
+            prompt = get_anscheck_prompt(
+                e["question_type"], e["question"], e["answer"], h["hypothesis"],
+                abstention=abstention)
+            resp = chat(args.provider, args.model, key, prompt, 10)
+            label = "yes" in resp.lower()
+            fout.write(json.dumps({
+                "question_id": qid, "question_type": e["question_type"],
+                "abstention": abstention, "autoeval_label": label,
+                "judge_raw": resp.strip()}) + "\n")
+            fout.flush()
+            n_done += 1
+            if n_done % 20 == 0 or n_done == len(hyps):
+                sys.stderr.write(f"  judged {n_done}/{len(hyps)}\n")
+    sys.stderr.write(f"done: {out_path}\n")
+    _report(out_path)
+
+
+# --------------------------------------------------------------------------
+# report (aggregate exactly like evaluate_qa.py)
+# --------------------------------------------------------------------------
+def _report(judged_path):
+    rows = [json.loads(l) for l in open(judged_path) if l.strip()]
+    if not rows:
+        sys.exit(f"error: no rows in {judged_path}")
+    labels = [1 if r["autoeval_label"] else 0 for r in rows]
+    by_type = defaultdict(list)
+    for r in rows:
+        by_type[r["question_type"]].append(1 if r["autoeval_label"] else 0)
+
+    overall = sum(labels) / len(labels)
+    print(f"\nQuestions judged : {len(labels)}")
+    print(f"Accuracy (overall): {overall:.4f}")
+    print("\nPer question_type:")
+    for t in sorted(by_type):
+        v = by_type[t]
+        print(f"  {t:28s} {sum(v)/len(v):.4f}  (n={len(v)})")
+
+
+def cmd_report(args):
+    path = args.judged or (args.hyp + f".eval-results-{args.model}")
+    _report(path)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    def add_common(p):
+        p.add_argument("--provider", choices=["openai", "anthropic"], required=True)
+        p.add_argument("--model", required=True,
+                       help="e.g. gpt-4o-2024-08-06 | claude-sonnet-5 | claude-opus-4-8")
+        p.add_argument("--longmemeval-src",
+                       help="LongMemEval repo src/ dir (or set $LONGMEMEVAL_SRC)")
+
+    g = sub.add_parser("generate", help="produce hypotheses JSONL")
+    add_common(g)
+    g.add_argument("--dataset", required=True, help="merged dataset (merge_retrieval.py --out)")
+    g.add_argument("--out", required=True, help="hypotheses JSONL (append/resume-safe)")
+    g.add_argument("--retriever-type", default="flat-session")
+    g.add_argument("--topk-context", type=int, default=5)
+    g.add_argument("--history-format", default="json")
+    g.add_argument("--useronly", action="store_true")
+    g.add_argument("--cot", action="store_true")
+    g.add_argument("--model-max-length", type=int, default=DEFAULT_MODEL_MAX)
+    g.set_defaults(func=cmd_generate)
+
+    j = sub.add_parser("judge", help="grade hypotheses yes/no and report")
+    add_common(j)
+    j.add_argument("--dataset", required=True, help="merged dataset (for gold answers/types)")
+    j.add_argument("--hyp", required=True, help="hypotheses JSONL from generate")
+    j.add_argument("--judged", help="output path (default: <hyp>.eval-results-<model>)")
+    j.set_defaults(func=cmd_judge)
+
+    r = sub.add_parser("report", help="re-aggregate an existing judged file")
+    r.add_argument("--hyp", required=True)
+    r.add_argument("--model", required=True)
+    r.add_argument("--judged")
+    r.set_defaults(func=cmd_report)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -2,7 +2,7 @@
 
 This document is the methodology for publishing retrieval-quality numbers honestly. The guiding rule: **a score only exists if anyone can re-run the harness with one command** — fixed seeds, published judge prompts (where a judge is used at all), and per-question logs.
 
-**Status:** Phase 1 (LongMemEval-S retrieval) and Phase 2 (`ghost bench`) have shipped with published numbers below. Phase 3 (staleness suite) ships report-only in CI. Phase 4 (end-to-end with the official judge) is next.
+**Status:** Phase 1 (LongMemEval-S retrieval) and Phase 2 (`ghost bench`) have shipped with published numbers below. Phase 3 (staleness suite) ships report-only in CI. Phase 4 (end-to-end retrieve→generate→judge) scaffolding has shipped; the paid full run is pending.
 
 ## Why these benchmarks and not others
 
@@ -103,9 +103,16 @@ The trap is untouched because its distractors are *not* supersession pairs — n
 
 **Current default is still off end to end.** Creation is opt-in (`--apply`) and consumption is opt-in (`SupersedeDemote`, reachable via `SearchHybridParams` but not yet wired into production `SearchHybrid`, which uses `DefaultSearchParams`). So no user's ranking changes until both are turned on. The final step — a config toggle wiring `SupersedeDemote` into production search — is deliberately separate: it changes live ranking, so it graduates only once link-creation precision is trusted beyond a small labeled set.
 
-## Phase 4 — end-to-end LongMemEval-S (leaderboard-comparable)
+## Phase 4 — end-to-end LongMemEval-S (retrieve → generate → judge)
 
-Only after phases 1–3: the official harness (`evaluate_qa.py`) with the **standard GPT-4o judge** — substituting a different judge makes numbers non-comparable, which is a known problem with some published scores. Fixed generator model, temperature 0, single deterministic run, per-case results JSON and full logs committed, an explicit note proving the memory system never saw oracle context, and generator model stated prominently (it dominates the score). Estimated cost: ~$30–80 in API calls.
+The scaffolding has **shipped** ([`bench/longmemeval/phase4/`](../bench/longmemeval/phase4/)); the paid full run has not been executed yet. The pipeline is four stages: Ghost retrieves (Go, `-retrieval-out ranked.jsonl`), `merge_retrieval.py` folds the ranking into the dataset, and `phase4_run.py` generates hypotheses then judges them. Generation prompt assembly (`prepare_prompt`) and the yes/no grading templates (`get_anscheck_prompt`) are imported **verbatim** from an upstream LongMemEval checkout — only the API client is swapped — so numbers stay reproducible against the published harness. Both stages are append-only and resume-safe. See the [phase4 README](../bench/longmemeval/phase4/README.md) for the full command sequence.
+
+Two backends are supported:
+
+- **`openai` with a gpt-4o generator + gpt-4o judge** — the official, leaderboard-comparable setup (`evaluate_qa.py`, `o200k_base`, temperature 0). Substituting a different judge makes numbers non-comparable, a known problem with some published scores. The generator dominates the score and must be stated prominently.
+- **`anthropic` (Claude generator/judge)** — **not** leaderboard-comparable; an internal "Ghost retrieval + Claude generation, Claude-judged" check. Same-family generator+judge carries a self-preference caveat (the official gpt-4o-judges-gpt-4o setup has the same property); a different strong judge (e.g. gen `claude-sonnet-5`, judge `claude-opus-4-8`) costs only a few dollars more since the judge emits ~10 tokens/question.
+
+Estimated cost at `topk_context=5` over the full 470 answerable questions: ~$20 (gpt-4o gen+judge) or ~$24 (claude-sonnet-5 gen+judge); Opus as *generator* is ~$116 and should be avoided. Use `cost_estimate.py` (no API calls) to re-anchor before spending. When the run executes: temperature 0, single deterministic run, per-case results JSON and full logs committed, an explicit note that the memory system never saw oracle context.
 
 Reference points, all judged with the official GPT-4o harness but with **different generators** (which dominate the score — compare within-generator only): Zep 71.2% and full-context 60.2% (GPT-4o generator); Mastra 94.87% (gpt-5-mini generator; 84.23% with GPT-4o); agentmemory 96.2% (Claude Opus 4.6 generator, temperature 0).
 


### PR DESCRIPTION
## What

Ships the **scaffolding** for Phase 4 (end-to-end LongMemEval-S: retrieve → generate → judge). No paid run has been executed — this is the reusable, documented pipeline, ready to run against either backend when we choose to spend.

Phase 1 (`bench/longmemeval`) scores retrieval only. Phase 4 closes the loop: feed Ghost's retrieved sessions to an LLM, have it answer, and grade with an LLM judge — an accuracy number comparable in shape to the LongMemEval leaderboard.

## Pipeline (4 stages)

1. **retrieve** — Ghost (Go), new `-retrieval-out ranked.jsonl` flag emits the full untruncated ranked session list per question in the official `retrieval_results` format.
2. **merge** — `merge_retrieval.py` folds the ranking into the dataset as `entry['retrieval_results']`, verifying every `corpus_id` resolves to a haystack session.
3. **generate** — `phase4_run.py generate`
4. **judge + report** — `phase4_run.py judge`

## Fidelity

`prepare_prompt` (generation) and `get_anscheck_prompt` (judging) are imported **verbatim** from an upstream LongMemEval checkout (`--longmemeval-src`); only the API client is swapped, so results stay reproducible against the published harness. Single user message, temp 0, `max_tokens` 500 (gen) / 10 (judge), tiktoken `o200k_base` truncation, append-only + resume-safe, retry on 429/5xx/529. Keys come from env (Ghost config fallback for anthropic) and are **never logged**.

## Comparability

- **`openai` gpt-4o gen + gpt-4o judge** → leaderboard-comparable (official setup).
- **`anthropic` (Claude)** → NOT leaderboard-comparable; an internal "Ghost retrieval + Claude, Claude-judged" check. Same-family judge caveat documented (the official gpt-4o-judges-gpt-4o setup shares it).

## Cost (no API calls; `cost_estimate.py`)

Full 470 answerable @ topk=5: ~\$20 (gpt-4o gen+judge), ~\$24 (claude-sonnet-5 gen+judge). Opus as *generator* ~\$116 — avoid.

## Verification

- `go vet ./bench/longmemeval/` clean; `-retrieval-out` builds and `rankedSessions` in scope.
- Python: `py_compile` clean; official-import path, key fallback (masked), and report aggregation validated offline. No secrets committed; run artifacts gitignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end LongMemEval Phase 4 workflow covering retrieval, merging, answer generation, judging, and reporting.
  * Added retrieval export in the standard JSONL format for downstream processing.
  * Added support for OpenAI and Anthropic generation and judging workflows.
  * Added resume-safe processing for long-running generation and evaluation tasks.
  * Added a cost estimation tool that calculates projected token usage and API costs.

* **Documentation**
  * Expanded benchmark documentation with setup instructions, configuration guidance, cost estimates, and comparability notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->