### PR TITLE
docs: document ghost resolve in CLAUDE.md and README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,14 +7,15 @@
 - MCP server via modelcontextprotocol/go-sdk (stdio transport)
 
 ## Architecture
-- `cmd/ghost/main.go` — CLI entrypoint; subcommands: mcp, hook, reflect, supersede, obsidian, bench, upgrade, version
-- `internal/ai/` — Claude API client (non-streaming Reflect call, used by reflection + supersede)
+- `cmd/ghost/main.go` — CLI entrypoint; subcommands: mcp, hook, reflect, resolve, supersede, obsidian, bench, upgrade, version
+- `internal/ai/` — Claude API client (non-streaming Reflect call, used by reflection + resolve + supersede)
 - `internal/memory/` — SQLite CRUD, FTS5 search, vector search, time-decay scoring
 - `internal/mcpserver/` — MCP server: 18 tools + 4 resources + 2 prompts (`recall_project`, `record_decision`)
 - `internal/mcpinit/` — `ghost mcp init`, `ghost mcp status`, `ghost hook session-start`, `ghost hook stop`
 - `internal/claudeimport/` — One-time import of Claude Code auto-memory on first contact
 - `internal/embedding/` — Ollama async vectorization worker
 - `internal/linking/` — Background worker linking similar memories into a graph
+- `internal/resolve/` — `ghost resolve`: LLM-classified de-weighting of resolved-evidence memories (drops from ranked injection, stays searchable); Haiku-only, no fallback, hard-fails without `ANTHROPIC_API_KEY`
 - `internal/supersede/` — `ghost supersede`: LLM-classified 'supersedes' link creation over live memories
 - `internal/bench/` — `ghost bench`: retrieval-quality benchmark harness (graded dataset + sweep + staleness/recency suites)
 - `internal/obsidian/` — One-way Markdown vault mirror (`ghost obsidian export|sync`)
@@ -31,6 +32,7 @@
 - Global memories: `_global` project, included in every project's context
 - Hybrid search: 70% vector (cosine, Ollama) + 30% FTS5, RRF fusion — falls back to FTS5-only
 - Memory links: `memory_links` edge table auto-populated by cosine similarity (internal/linking worker); links cascade-delete with memories and self-heal after reflection. A graph-expansion ranking bonus was evaluated and removed — dominated by a deeper vector-k (links and the vector leg are both cosine); the link graph is retained for Obsidian export and supersedes ranking (see `docs/superpowers/specs/2026-07-20-graph-expansion-stays-off-design.md`).
+- Resolution classifier: `ghost resolve` runs a keyword prefilter then a single KEEP-biased Haiku call per candidate to mark `resolved_at`, dropping resolved-evidence memories (changelogs, cost estimates, closed experiment notes) from ranked injection while keeping them searchable. Dry-run by default, `--apply` writes; a partial classify pass fails fatally rather than applying incomplete results. No fallback provider exists — `ANTHROPIC_API_KEY` is hard-required, same as `ghost supersede`. Never invoked from the stop hook (that path forbids DB access); standalone batch command only. See `docs/superpowers/specs/2026-07-26-resolution-classifier-design.md`.
 
 ## Critical Rules
 - Always `go vet ./...` before committing

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ ghost mcp status             # Deep health checks (incl. Ollama reachability, mo
 ghost hook session-start     # SessionStart hook — prints exactly what gets injected
 ghost hook stop              # Stop hook — blocks stop once if a tool-using session saved nothing
 ghost reflect <project>      # Memory consolidation (dry-run by default; --apply, --restore, --tier)
+ghost resolve <project>      # De-weight resolved-evidence memories from injection (dry-run by default; --apply)
 ghost supersede <project>    # Link superseded memories (dry-run by default; --apply, --threshold)
 ghost bench [--sweep]        # Retrieval-quality benchmark on the built-in dataset
 ghost obsidian export        # Mirror memories to an Obsidian vault (one-way; --out, --project)

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -838,7 +838,7 @@ Flags (reflect):
   --restore       Undo last consolidation
 
 Environment:
-  ANTHROPIC_API_KEY           Required for reflect --tier haiku
+  ANTHROPIC_API_KEY           Required for reflect --tier haiku, and always for supersede/resolve
   GHOST_DEBUG                 Enable debug logging
 `, version)
 }

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/wcatz/ghost",
     "source": "github"
   },
-  "version": "0.13.0",
+  "version": "0.15.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/wcatz/ghost:0.13.0",
+      "identifier": "ghcr.io/wcatz/ghost:0.15.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- CLAUDE.md was stale after #214 merged: subcommand list, internal/ package list, and Key Patterns section didn't mention `ghost resolve` / `internal/resolve/`.
- README's CLI reference table was also missing the `ghost resolve` line.

## Test plan
- [x] go vet ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `ghost resolve <project>` command to identify resolved evidence and reduce its priority in future results.
  * The command runs in dry-run mode by default, with `--apply` available to save changes.

* **Documentation**
  * Updated the architecture and CLI documentation with command behavior, processing rules, and usage constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->