### PR TITLE
Unify project-identifier resolution across CLI, MCP server, and hooks

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -149,6 +149,27 @@ func runHook() {
 	}
 }
 
+// resolveProjectOrExit resolves projectName to a project ID via store, printing
+// an error (with known-project names when available) and exiting the process
+// on failure or when no matching project is found.
+func resolveProjectOrExit(ctx context.Context, store *memory.Store, projectName string) string {
+	projectID, _, err := store.ResolveProject(ctx, projectName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if projectID == "" {
+		names, listErr := store.ListProjectNames(ctx)
+		if listErr != nil || len(names) == 0 {
+			fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
+		} else {
+			fmt.Fprintf(os.Stderr, "error: project %q not found. Known projects: %s\n", projectName, strings.Join(names, ", "))
+		}
+		os.Exit(1)
+	}
+	return projectID
+}
+
 // runReflect manually triggers memory consolidation for a project.
 // Defaults to dry-run (preview only). Use --apply to save results.
 // Use --restore to undo the last consolidation from snapshot.
@@ -186,20 +207,7 @@ Flags:
 
 	ctx := context.Background()
 
-	projectID, _, err := store.ResolveProject(ctx, projectName)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-	if projectID == "" {
-		names, listErr := store.ListProjectNames(ctx)
-		if listErr != nil || len(names) == 0 {
-			fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
-		} else {
-			fmt.Fprintf(os.Stderr, "error: project %q not found. Known projects: %s\n", projectName, strings.Join(names, ", "))
-		}
-		os.Exit(1)
-	}
+	projectID := resolveProjectOrExit(ctx, store, projectName)
 
 	if restore {
 		n, err := store.RestoreSnapshot(ctx, projectID)
@@ -482,20 +490,7 @@ ANTHROPIC_API_KEY if set, else falls back to a subscription-billed
 	defer store.Close() //nolint:errcheck
 	ctx := context.Background()
 
-	projectID, _, err := store.ResolveProject(ctx, projectName)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-	if projectID == "" {
-		names, listErr := store.ListProjectNames(ctx)
-		if listErr != nil || len(names) == 0 {
-			fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
-		} else {
-			fmt.Fprintf(os.Stderr, "error: project %q not found. Known projects: %s\n", projectName, strings.Join(names, ", "))
-		}
-		os.Exit(1)
-	}
+	projectID := resolveProjectOrExit(ctx, store, projectName)
 	provider, err := buildClassifyProvider(cfg, logger)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: ghost supersede %v\n", err)
@@ -576,20 +571,7 @@ subscription-billed 'claude' CLI call — requires one of the two.`)
 	defer store.Close() //nolint:errcheck
 	ctx := context.Background()
 
-	projectID, _, err := store.ResolveProject(ctx, projectName)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-	if projectID == "" {
-		names, listErr := store.ListProjectNames(ctx)
-		if listErr != nil || len(names) == 0 {
-			fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
-		} else {
-			fmt.Fprintf(os.Stderr, "error: project %q not found. Known projects: %s\n", projectName, strings.Join(names, ", "))
-		}
-		os.Exit(1)
-	}
+	projectID := resolveProjectOrExit(ctx, store, projectName)
 	provider, err := buildClassifyProvider(cfg, logger)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: ghost resolve %v\n", err)

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -186,13 +186,18 @@ Flags:
 
 	ctx := context.Background()
 
-	projectID, err := store.ResolveProjectByName(ctx, projectName)
+	projectID, _, err := store.ResolveProject(ctx, projectName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 	if projectID == "" {
-		fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
+		names, listErr := store.ListProjectNames(ctx)
+		if listErr != nil || len(names) == 0 {
+			fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
+		} else {
+			fmt.Fprintf(os.Stderr, "error: project %q not found. Known projects: %s\n", projectName, strings.Join(names, ", "))
+		}
 		os.Exit(1)
 	}
 
@@ -477,13 +482,18 @@ ANTHROPIC_API_KEY if set, else falls back to a subscription-billed
 	defer store.Close() //nolint:errcheck
 	ctx := context.Background()
 
-	projectID, err := store.ResolveProjectByName(ctx, projectName)
+	projectID, _, err := store.ResolveProject(ctx, projectName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 	if projectID == "" {
-		fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
+		names, listErr := store.ListProjectNames(ctx)
+		if listErr != nil || len(names) == 0 {
+			fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
+		} else {
+			fmt.Fprintf(os.Stderr, "error: project %q not found. Known projects: %s\n", projectName, strings.Join(names, ", "))
+		}
 		os.Exit(1)
 	}
 	provider, err := buildClassifyProvider(cfg, logger)
@@ -566,13 +576,18 @@ subscription-billed 'claude' CLI call — requires one of the two.`)
 	defer store.Close() //nolint:errcheck
 	ctx := context.Background()
 
-	projectID, err := store.ResolveProjectByName(ctx, projectName)
+	projectID, _, err := store.ResolveProject(ctx, projectName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 	if projectID == "" {
-		fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
+		names, listErr := store.ListProjectNames(ctx)
+		if listErr != nil || len(names) == 0 {
+			fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
+		} else {
+			fmt.Fprintf(os.Stderr, "error: project %q not found. Known projects: %s\n", projectName, strings.Join(names, ", "))
+		}
 		os.Exit(1)
 	}
 	provider, err := buildClassifyProvider(cfg, logger)

--- a/docs/superpowers/plans/2026-08-01-project-resolution-unification.md
+++ b/docs/superpowers/plans/2026-08-01-project-resolution-unification.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add `Store.ResolveProject` and `Store.ListProjectNames`
+## Task 1: Add `Store.ResolveProject` and `Store.ListProjectNames`
 
 **Files:**
 - Modify: `internal/memory/store.go` (add methods near `ResolveProjectByName`, currently at lines 295-309; add after `ListProjects`, currently lines 145-166)
@@ -261,7 +261,7 @@ git commit -m "feat(memory): add Store.ResolveProject and ListProjectNames"
 
 ---
 
-### Task 2: Migrate CLI (`cmd/ghost/main.go`) off `ResolveProjectByName`
+## Task 2: Migrate CLI (`cmd/ghost/main.go`) off `ResolveProjectByName`
 
 **Files:**
 - Modify: `cmd/ghost/main.go` (reflect subcommand ~line 188, resolve subcommand ~line 526 — verify exact line numbers first, since this file was already touched by unrelated commits since the spec was written)
@@ -321,7 +321,7 @@ git commit -m "feat(cli): list known projects on reflect/resolve name-not-found"
 
 ---
 
-### Task 3: Migrate MCP tool layer (`internal/mcpserver/mcpserver.go`) off `resolveProjectID`
+## Task 3: Migrate MCP tool layer (`internal/mcpserver/mcpserver.go`) off `resolveProjectID`
 
 **Files:**
 - Modify: `internal/mcpserver/mcpserver.go` (delete `resolveProjectID` at lines 251-299; update 16 call sites at lines 310, 380, 431, 521, 585, 655, 698, 893, 930, 980, 1071, 1307, 1357, 1416, 1457, 1509 — re-`grep` first, since Task 2 doesn't touch this file but line numbers may have shifted from other concurrent work)
@@ -451,7 +451,7 @@ git commit -m "feat(mcp): migrate resolveProjectID call sites onto Store.Resolve
 
 ---
 
-### Task 4: Migrate session-start hook (`internal/mcpinit/hook.go`) off `lookupProject`
+## Task 4: Migrate session-start hook (`internal/mcpinit/hook.go`) off `lookupProject`
 
 **Files:**
 - Modify: `internal/mcpinit/hook.go` (delete `lookupProject`, lines 341-358; update its one call site in `loadSessionContext`, line 238)
@@ -631,7 +631,7 @@ git commit -m "feat(hook): migrate lookupProject call sites onto Store.ResolvePr
 
 ---
 
-### Task 5: Remove `ResolveProjectByName` from the `provider.MemoryStore` interface
+## Task 5: Remove `ResolveProjectByName` from the `provider.MemoryStore` interface
 
 **Files:**
 - Modify: `internal/provider/provider.go` (line 72)

--- a/docs/superpowers/plans/2026-08-01-project-resolution-unification.md
+++ b/docs/superpowers/plans/2026-08-01-project-resolution-unification.md
@@ -1,0 +1,701 @@
+# Project Resolution Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace three divergent project-identifier-resolution implementations (`hook.go`'s `lookupProject`, `store.go`'s `ResolveProjectByName`, `mcpserver.go`'s `resolveProjectID`) with one `Store.ResolveProject` method used everywhere.
+
+**Architecture:** Add `Store.ResolveProject(ctx, input) (id, name string, err error)` implementing a 4-step lookup chain (exact ID → exact name → path-prefix → basename-of-input). Migrate all three call sites onto it, deleting the old functions. `ghost_memory_save`'s auto-create call site gets an explicit raw-input fallback so it keeps creating brand-new projects on first save.
+
+**Tech Stack:** Go 1.26, `database/sql` (modernc.org/sqlite), table-driven tests with `:memory:` SQLite.
+
+---
+
+### Task 1: Add `Store.ResolveProject` and `Store.ListProjectNames`
+
+**Files:**
+- Modify: `internal/memory/store.go` (add methods near `ResolveProjectByName`, currently at lines 295-309; add after `ListProjects`, currently lines 145-166)
+- Test: `internal/memory/store_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/memory/store_test.go`, replacing `TestStoreResolveProjectByName` (lines 966-985) entirely:
+
+```go
+func TestStoreResolveProject_ByID(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	id, name, err := s.ResolveProject(ctx, testProject)
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != testProject || name != "test" {
+		t.Errorf("got id=%q name=%q, want id=%q name=%q", id, name, testProject, "test")
+	}
+}
+
+func TestStoreResolveProject_ByName(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	id, name, err := s.ResolveProject(ctx, "test")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != testProject || name != "test" {
+		t.Errorf("got id=%q name=%q, want id=%q name=%q", id, name, testProject, "test")
+	}
+}
+
+func TestStoreResolveProject_PathPrefix(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	if err := s.EnsureProject(ctx, "ghostid", "/home/wayne/git/ghost", "ghost"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+
+	id, name, err := s.ResolveProject(ctx, "/home/wayne/git/ghost/internal/memory")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "ghostid" || name != "ghost" {
+		t.Errorf("got id=%q name=%q, want id=%q name=%q", id, name, "ghostid", "ghost")
+	}
+}
+
+func TestStoreResolveProject_LongestPathWins(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	if err := s.EnsureProject(ctx, "parent", "/home/wayne/git", "parent"); err != nil {
+		t.Fatalf("EnsureProject parent: %v", err)
+	}
+	if err := s.EnsureProject(ctx, "child", "/home/wayne/git/ghost", "ghost"); err != nil {
+		t.Fatalf("EnsureProject child: %v", err)
+	}
+
+	id, _, err := s.ResolveProject(ctx, "/home/wayne/git/ghost/cmd")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "child" {
+		t.Errorf("longest path should win, got %q, want %q", id, "child")
+	}
+}
+
+func TestStoreResolveProject_NoPrefixFalseMatch(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	if err := s.EnsureProject(ctx, "ghostid", "/home/wayne/git/ghost", "ghost"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+
+	id, name, err := s.ResolveProject(ctx, "/home/wayne/git/ghost-extra")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "" || name != "" {
+		t.Errorf("ghost-extra should NOT prefix-match ghost, got id=%q name=%q", id, name)
+	}
+}
+
+func TestStoreResolveProject_BasenameFallback(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	// Path shorter than the LENGTH(path) > 10 guard, so prefix matching can't fire —
+	// isolates the basename-of-input fallback (case 4).
+	if err := s.EnsureProject(ctx, "ghostid", "/x/ghost", "ghost"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+
+	id, name, err := s.ResolveProject(ctx, "/some/unrelated/path/ghost")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "ghostid" || name != "ghost" {
+		t.Errorf("basename fallback: got id=%q name=%q, want id=%q name=%q", id, name, "ghostid", "ghost")
+	}
+}
+
+func TestStoreResolveProject_NoMatch(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	id, name, err := s.ResolveProject(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "" || name != "" {
+		t.Errorf("expected empty on no match, got id=%q name=%q", id, name)
+	}
+}
+
+func TestStoreResolveProject_ClosedDB(t *testing.T) {
+	s := testStore(t)
+	s.Close() //nolint:errcheck
+	ctx := context.Background()
+
+	_, _, err := s.ResolveProject(ctx, "test")
+	if err == nil {
+		t.Fatal("expected error on closed DB, got nil")
+	}
+}
+
+func TestStoreListProjectNames(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	if err := s.EnsureProject(ctx, "ghostid", "/home/wayne/git/ghost", "ghost"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+
+	names, err := s.ListProjectNames(ctx)
+	if err != nil {
+		t.Fatalf("ListProjectNames: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("expected 2 names, got %d: %v", len(names), names)
+	}
+	// ListProjects orders by name ASC — "ghost" before "test".
+	if names[0] != "ghost" || names[1] != "test" {
+		t.Errorf("got %v, want [ghost test]", names)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/memory/... -run TestStoreResolveProject -v`
+Expected: FAIL — `s.ResolveProject undefined` (compile error), same for `TestStoreListProjectNames`.
+
+- [ ] **Step 3: Implement `ResolveProject` and `ListProjectNames`**
+
+Add to `internal/memory/store.go` immediately after `ResolveProjectByName` (delete `ResolveProjectByName` itself — see Task 4 for the interface-side removal):
+
+```go
+// ResolveProject resolves an identifier — a project name, hash ID, or
+// filesystem path — to that project's (id, name). Returns ("", "", nil)
+// on no match; a non-nil error only indicates a real DB failure.
+//
+// Lookup order, first hit wins:
+//  1. exact id = input
+//  2. exact name = input
+//  3. if input contains '/': input = path OR input LIKE path || '/%'
+//     (ordered by LENGTH(path) DESC — longest/most-specific match wins;
+//     LENGTH(path) > 10 guards against a short project path matching too
+//     broadly, matching the hook's original lookupProject behavior)
+//  4. name = basename(input)
+func (s *Store) ResolveProject(ctx context.Context, input string) (id, name string, err error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	err = s.db.QueryRowContext(ctx, `SELECT id, name FROM projects WHERE id = ? LIMIT 1`, input).Scan(&id, &name)
+	if err == nil {
+		return id, name, nil
+	}
+	if err != sql.ErrNoRows {
+		return "", "", fmt.Errorf("resolve project by id: %w", err)
+	}
+
+	err = s.db.QueryRowContext(ctx, `SELECT id, name FROM projects WHERE name = ? LIMIT 1`, input).Scan(&id, &name)
+	if err == nil {
+		return id, name, nil
+	}
+	if err != sql.ErrNoRows {
+		return "", "", fmt.Errorf("resolve project by name: %w", err)
+	}
+
+	if strings.Contains(input, "/") {
+		err = s.db.QueryRowContext(ctx, `
+			SELECT id, name FROM projects
+			WHERE (path = ? OR ? LIKE path || '/%') AND LENGTH(path) > 10
+			ORDER BY LENGTH(path) DESC LIMIT 1
+		`, input, input).Scan(&id, &name)
+		if err == nil {
+			return id, name, nil
+		}
+		if err != sql.ErrNoRows {
+			return "", "", fmt.Errorf("resolve project by path: %w", err)
+		}
+	}
+
+	base := filepath.Base(input)
+	err = s.db.QueryRowContext(ctx, `SELECT id, name FROM projects WHERE name = ? LIMIT 1`, base).Scan(&id, &name)
+	if err == nil {
+		return id, name, nil
+	}
+	if err != sql.ErrNoRows {
+		return "", "", fmt.Errorf("resolve project by basename: %w", err)
+	}
+
+	return "", "", nil
+}
+
+// ListProjectNames returns all known project names, ordered the same way as
+// ListProjects (name ASC) — used to format an actionable CLI error listing
+// known projects on a resolution miss.
+func (s *Store) ListProjectNames(ctx context.Context) ([]string, error) {
+	projects, err := s.ListProjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, len(projects))
+	for i, p := range projects {
+		names[i] = p.Name
+	}
+	return names, nil
+}
+```
+
+`context`, `database/sql`, `fmt`, `path/filepath`, and `strings` are already imported in `store.go` (lines 3-13) — no import changes needed.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/memory/... -run 'TestStoreResolveProject|TestStoreListProjectNames' -v`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/memory/store.go internal/memory/store_test.go
+git commit -m "feat(memory): add Store.ResolveProject and ListProjectNames"
+```
+
+---
+
+### Task 2: Migrate CLI (`cmd/ghost/main.go`) off `ResolveProjectByName`
+
+**Files:**
+- Modify: `cmd/ghost/main.go` (reflect subcommand ~line 188, resolve subcommand ~line 526 — verify exact line numbers first, since this file was already touched by unrelated commits since the spec was written)
+
+- [ ] **Step 1: Locate both call sites**
+
+Run: `grep -n "ResolveProjectByName" cmd/ghost/main.go`
+
+Both currently read:
+
+```go
+	projectID, err := store.ResolveProjectByName(ctx, projectName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if projectID == "" {
+		fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
+		os.Exit(1)
+	}
+```
+
+- [ ] **Step 2: Replace both occurrences**
+
+Replace each of the two blocks above with:
+
+```go
+	projectID, _, err := store.ResolveProject(ctx, projectName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if projectID == "" {
+		names, listErr := store.ListProjectNames(ctx)
+		if listErr != nil || len(names) == 0 {
+			fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
+		} else {
+			fmt.Fprintf(os.Stderr, "error: project %q not found. Known projects: %s\n", projectName, strings.Join(names, ", "))
+		}
+		os.Exit(1)
+	}
+```
+
+Check `cmd/ghost/main.go`'s imports for `strings` (`grep -n '"strings"' cmd/ghost/main.go`) — add it to the import block if missing.
+
+- [ ] **Step 3: Build and manually verify**
+
+Run: `go build -o /tmp/ghost-plan-test ./cmd/ghost && /tmp/ghost-plan-test reflect nonexistent-project-xyz`
+Expected output: `error: project "nonexistent-project-xyz" not found. Known projects: <comma-separated list>` (or the bare message if the store has zero projects).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/ghost/main.go
+git commit -m "feat(cli): list known projects on reflect/resolve name-not-found"
+```
+
+---
+
+### Task 3: Migrate MCP tool layer (`internal/mcpserver/mcpserver.go`) off `resolveProjectID`
+
+**Files:**
+- Modify: `internal/mcpserver/mcpserver.go` (delete `resolveProjectID` at lines 251-299; update 16 call sites at lines 310, 380, 431, 521, 585, 655, 698, 893, 930, 980, 1071, 1307, 1357, 1416, 1457, 1509 — re-`grep` first, since Task 2 doesn't touch this file but line numbers may have shifted from other concurrent work)
+- Test: `internal/mcpserver/mcpserver_test.go` (delete `TestResolveProjectID_*`, lines 34-89)
+
+`resolveProjectID` returns a single `string`, always non-empty (raw input echoed back on miss). `ResolveProject` returns `(id, name string, err error)`, with `("", "", nil)` on miss. Two call-site shapes:
+
+**Shape A — every site except `ghost_memory_save`:** these only ever used the returned ID, and never depended on a miss falling back to the raw input (the surrounding code either treats `projectID == ""` as "no such project, return empty/error" already, or the DB query below simply returns zero rows for an ID that doesn't exist — same net effect as passing through the raw unresolved input). Replace `s.resolveProjectID(ctx, ctx, X)` (single-value) with the ID half of `store.ResolveProject`:
+
+```go
+resolvedProjectID, _, err := s.store.ResolveProject(ctx, X)
+if err != nil {
+	return nil, nil, fmt.Errorf("resolve project: %w", err)
+}
+```
+
+Apply this pattern at every call site EXCEPT the one inside the `saveArgs` handler (Shape B below). This includes both `projectID :=` / `resolvedProjectID :=` forms and `args.ProjectID = s.resolveProjectID(...)` forms — for the latter, assign to a new local (e.g. `resolved`) and then set `args.ProjectID = resolved`, since `args.ProjectID` can no longer double as both input and output in one statement without shadowing the error.
+
+**Shape B — the `saveArgs` handler only (currently line 521, inside the function starting at line 506):** `ghost_memory_save` is the sole auto-create path — `EnsureProject` right below it must still receive a real, non-empty project identifier to create when the project is brand new. Per the spec: "`EnsureProject`'s auto-create call in `ghost_memory_save` is unchanged — it still runs after resolution, using whatever ID `ResolveProject` returned (or the raw input, if resolution missed, exactly as today)." Replace:
+
+```go
+		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
+```
+
+with:
+
+```go
+		if resolved, _, err := s.store.ResolveProject(ctx, args.ProjectID); err != nil {
+			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		} else if resolved != "" {
+			args.ProjectID = resolved
+		}
+		// else: no existing project matched — keep args.ProjectID as-is so
+		// EnsureProject below creates a new project using the raw input,
+		// preserving today's auto-create-on-first-save behavior.
+```
+
+- [ ] **Step 1: Update the failing tests first**
+
+In `internal/mcpserver/mcpserver_test.go`, replace `TestResolveProjectID_ByName`, `TestResolveProjectID_ByID`, `TestResolveProjectID_Unknown`, `TestResolveProjectID_NameTakesPrecedence` (lines 34-89) with:
+
+```go
+func TestResolveProject_ByName(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	id, _, err := store.ResolveProject(ctx, "test-project")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "abc123" {
+		t.Errorf("ResolveProject(name) = %q, want %q", id, "abc123")
+	}
+}
+
+func TestResolveProject_ByID(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	id, _, err := store.ResolveProject(ctx, "abc123")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "abc123" {
+		t.Errorf("ResolveProject(id) = %q, want %q", id, "abc123")
+	}
+}
+
+func TestResolveProject_Unknown(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	id, name, err := store.ResolveProject(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "" || name != "" {
+		t.Errorf("ResolveProject(unknown) = %q/%q, want empty/empty", id, name)
+	}
+}
+
+func TestResolveProject_IDTakesPrecedenceOverName(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// Create a second project where the name matches the first project's ID.
+	if err := store.EnsureProject(ctx, "def456", "/tmp/second", "abc123"); err != nil {
+		t.Fatalf("EnsureProject second: %v", err)
+	}
+
+	// "abc123" is both project 1's ID and project 2's name — ID match wins (case 1 before case 2).
+	id, _, err := store.ResolveProject(ctx, "abc123")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "abc123" {
+		t.Errorf("ResolveProject should prefer ID match, got %q, want %q", id, "abc123")
+	}
+}
+```
+
+Note the precedence flip from the old `resolveProjectID` (which tried name first, then ID) to `ResolveProject` (ID first, then name) — this matches the spec's stated lookup order ("1. exact id = input, 2. exact name = input"). `TestResolveProjectID_NameTakesPrecedence` asserted the *opposite* precedence and must be replaced, not kept — this is an intentional, spec-mandated behavior change for the one pathological case where a project's name collides with a different project's ID, not a regression in ordinary use.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/mcpserver/... -run TestResolveProject -v`
+Expected: FAIL (compile error — `s.store` field access from test needs `store.ResolveProject` which doesn't exist yet if Task 1 wasn't merged first; if Task 1 is already committed, this instead fails because `resolveProjectID`/call sites in `mcpserver.go` haven't been touched yet, which is fine — the new tests call `store.ResolveProject` directly and only need Task 1's method to exist).
+
+- [ ] **Step 3: Delete `resolveProjectID` and migrate all 16 call sites**
+
+Delete lines 251-299 (the full `resolveProjectID` function). Then, for each call site found via `grep -n "resolveProjectID" internal/mcpserver/mcpserver.go`, apply Shape A or Shape B as described above. Re-run the grep after editing to confirm zero remaining references:
+
+Run: `grep -n "resolveProjectID" internal/mcpserver/mcpserver.go`
+Expected: no output.
+
+- [ ] **Step 4: Run the full package test suite**
+
+Run: `go test ./internal/mcpserver/... -v`
+Expected: PASS, including the new `TestResolveProject_*` tests and all existing `ghost_memory_save`/`ghost_memory_search`/etc. handler tests (auto-create behavior must still pass for any existing test that saves to a brand-new project name).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcpserver/mcpserver.go internal/mcpserver/mcpserver_test.go
+git commit -m "feat(mcp): migrate resolveProjectID call sites onto Store.ResolveProject"
+```
+
+---
+
+### Task 4: Migrate session-start hook (`internal/mcpinit/hook.go`) off `lookupProject`
+
+**Files:**
+- Modify: `internal/mcpinit/hook.go` (delete `lookupProject`, lines 341-358; update its one call site in `loadSessionContext`, line 238)
+- Modify: `internal/mcpinit/stophook.go` (update its one call site, line 153)
+- Test: `internal/mcpinit/hook_test.go` (lines 34-98)
+
+`lookupProject(db *sql.DB, cwd string) (id, name string)` operates on a raw `*sql.DB`. `Store.ResolveProject` is a method on `*memory.Store`. Both `loadSessionContext` and the stop hook already have an open `*sql.DB` (via `roDSN`) — wrap it with `memory.NewStore(db, logger)` to get a `*memory.Store` without changing the connection or its read-only mode.
+
+- [ ] **Step 1: Check `memory.NewStore`'s signature**
+
+Run: `grep -n "^func NewStore" internal/memory/store.go`
+Expected: `func NewStore(db *sql.DB, logger *slog.Logger) *Store` (confirm exact signature before writing the wrapper — adjust the snippet below if the logger param differs).
+
+- [ ] **Step 2: Update the failing tests first**
+
+Replace `internal/mcpinit/hook_test.go` lines 34-98 (`TestLookupProject_ExactMatch` through `TestLookupProject_NoMatch`) with:
+
+```go
+func TestResolveProject_ExactMatch(t *testing.T) {
+	db := openTestDB(t)
+	insertProject(t, db, "abc123", "/home/wayne/git/ghost", "ghost")
+	s := memory.NewStore(db, testLogger())
+
+	id, name, err := s.ResolveProject(context.Background(), "/home/wayne/git/ghost")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "abc123" || name != "ghost" {
+		t.Errorf("exact match: got id=%q name=%q, want abc123/ghost", id, name)
+	}
+}
+
+func TestResolveProject_SubdirMatch(t *testing.T) {
+	db := openTestDB(t)
+	insertProject(t, db, "abc123", "/home/wayne/git/ghost", "ghost")
+	s := memory.NewStore(db, testLogger())
+
+	id, name, err := s.ResolveProject(context.Background(), "/home/wayne/git/ghost/internal/mcpinit")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "abc123" || name != "ghost" {
+		t.Errorf("subdir match: got id=%q name=%q, want abc123/ghost", id, name)
+	}
+}
+
+// TestResolveProject_NoPrefixFalseMatch is the regression test for the bug:
+// a CWD of /home/wayne/git/ghost-extra must NOT match a project at /home/wayne/git/ghost.
+func TestResolveProject_NoPrefixFalseMatch(t *testing.T) {
+	db := openTestDB(t)
+	insertProject(t, db, "abc123", "/home/wayne/git/ghost", "ghost")
+	s := memory.NewStore(db, testLogger())
+
+	id, name, err := s.ResolveProject(context.Background(), "/home/wayne/git/ghost-extra")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "" || name != "" {
+		t.Errorf("prefix false match: /home/wayne/git/ghost-extra should NOT match /home/wayne/git/ghost, got id=%q name=%q", id, name)
+	}
+}
+
+func TestResolveProject_LongestPathWins(t *testing.T) {
+	db := openTestDB(t)
+	insertProject(t, db, "parent", "/home/wayne/git", "parent")
+	insertProject(t, db, "child", "/home/wayne/git/ghost", "ghost")
+	s := memory.NewStore(db, testLogger())
+
+	id, _, err := s.ResolveProject(context.Background(), "/home/wayne/git/ghost/cmd")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "child" {
+		t.Errorf("longest path should win, got %q, want %q", id, "child")
+	}
+}
+
+func TestResolveProject_NameFallback(t *testing.T) {
+	db := openTestDB(t)
+	// Use a short path so path prefix matching won't trigger (LENGTH(path) > 10 guard).
+	// The basename fallback fires when cwd basename matches a project name.
+	insertProject(t, db, "abc123", "/x/ghost", "ghost")
+	s := memory.NewStore(db, testLogger())
+
+	// cwd basename is "ghost" — should match by name even when path doesn't match.
+	id, name, err := s.ResolveProject(context.Background(), filepath.Join("/some/unrelated/path", "ghost"))
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "abc123" || name != "ghost" {
+		t.Errorf("name fallback: got id=%q name=%q, want abc123/ghost", id, name)
+	}
+}
+
+func TestResolveProject_NoMatch(t *testing.T) {
+	db := openTestDB(t)
+	insertProject(t, db, "abc123", "/home/wayne/git/ghost", "ghost")
+	s := memory.NewStore(db, testLogger())
+
+	id, name, err := s.ResolveProject(context.Background(), "/home/user/other-project")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "" || name != "" {
+		t.Errorf("no match: expected empty, got id=%q name=%q", id, name)
+	}
+}
+```
+
+Add a small test helper right after `openTestDB` (same file) if the package doesn't already have one:
+
+Run: `grep -n "func testLogger" internal/mcpinit/*.go`
+
+If nothing is found, add:
+
+```go
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+```
+
+Add `"io"` and `"log/slog"` to `hook_test.go`'s import block if not already present (check with `grep -n '"io"\|"log/slog"' internal/mcpinit/hook_test.go` first — `context` also needs adding since the new tests use `context.Background()`).
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `go test ./internal/mcpinit/... -run TestResolveProject -v`
+Expected: FAIL — compile error, `s.ResolveProject` exists (from Task 1) but nothing in this package calls it yet; the failure here is really just confirming the test file compiles once `lookupProject`'s old tests are gone. If Task 1 already landed, this should actually PASS immediately since it only exercises `memory.Store` directly — that's fine, it still proves the new tests are wired correctly before touching `hook.go` itself.
+
+- [ ] **Step 4: Replace `lookupProject`'s call site in `loadSessionContext`**
+
+In `internal/mcpinit/hook.go`, replace line 238:
+
+```go
+	projectID, project = lookupProject(db, cwd)
+```
+
+with:
+
+```go
+	store := memory.NewStore(db, slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})))
+	projectID, project, err = store.ResolveProject(context.Background(), cwd)
+	if err != nil {
+		return
+	}
+```
+
+`loadSessionContext`'s named return signature (line 222) already declares `err` implicitly via its other statements using `:=` locally — check whether `err` is already a named return; if not, this needs a local `var err error` instead of reusing an outer one. Run `grep -n "^func loadSessionContext" -A3 internal/mcpinit/hook.go` to confirm the exact signature before editing, since the named returns are `(projectID, project string, memories []sessionMemory, learned string, tasks [][4]string, decisions [][2]string, interactionCount int)` — there is no named `err` return, so declare it locally:
+
+```go
+	store := memory.NewStore(db, slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})))
+	var resolveErr error
+	projectID, project, resolveErr = store.ResolveProject(context.Background(), cwd)
+	if resolveErr != nil {
+		return
+	}
+```
+
+Delete `lookupProject` itself (lines 341-358).
+
+Add `"context"` and `"log/slog"` to `hook.go`'s import block (check first with `grep -n '"context"\|"log/slog"' internal/mcpinit/hook.go` — `"context"` is likely already imported since `loadSessionContext` calls `memory.DemotionPenalties(context.Background(), ...)` at line 283; `"log/slog"` is new).
+
+- [ ] **Step 5: Replace `lookupProject`'s call site in `stophook.go`**
+
+Run: `grep -n -B5 -A2 "lookupProject" internal/mcpinit/stophook.go` to see the exact surrounding code (opens its own `*sql.DB`, same `roDSN` pattern) before editing. Apply the same `memory.NewStore` wrapper + `ResolveProject` call pattern as Step 4, adjusted to that function's existing variable names and error-handling style. Update the comment at line 127 (`// Known limitation: resolution here depends on lookupProject's path/basename ...`) to reference `ResolveProject` instead of `lookupProject`.
+
+- [ ] **Step 6: Run the full package test suite**
+
+Run: `go test ./internal/mcpinit/... -v`
+Expected: PASS, all tests including session-start-hook end-to-end tests and stop-hook tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/mcpinit/hook.go internal/mcpinit/hook_test.go internal/mcpinit/stophook.go
+git commit -m "feat(hook): migrate lookupProject call sites onto Store.ResolveProject"
+```
+
+---
+
+### Task 5: Remove `ResolveProjectByName` from the `provider.MemoryStore` interface
+
+**Files:**
+- Modify: `internal/provider/provider.go` (line 72)
+
+By this point, Task 1 already deleted the `ResolveProjectByName` method body on `*Store` (Task 1, Step 3 replaces it in place). This task removes the now-dead interface declaration and adds `ResolveProject`/`ListProjectNames` so the interface still accurately describes what `*Store` implements. No other type implements `provider.MemoryStore` (`claudeimport`, `mcpserver`, `embedding` only consume the interface — confirmed via `grep -rln "provider.MemoryStore" --include=*.go`, none define a second implementation), so this is a pure signature edit with no fakes/mocks to update.
+
+- [ ] **Step 1: Update the interface**
+
+In `internal/provider/provider.go`, replace line 72:
+
+```go
+	ResolveProjectByName(ctx context.Context, name string) (string, error)
+```
+
+with:
+
+```go
+	ResolveProject(ctx context.Context, input string) (id, name string, err error)
+	ListProjectNames(ctx context.Context) ([]string, error)
+```
+
+- [ ] **Step 2: Build the whole module**
+
+Run: `go build ./...`
+Expected: succeeds with no errors (this is the final cross-check that no remaining caller anywhere still references the deleted methods/functions).
+
+- [ ] **Step 3: Full test suite + vet**
+
+Run: `go vet ./... && go test ./...`
+Expected: PASS, no vet warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/provider/provider.go
+git commit -m "refactor(provider): replace ResolveProjectByName with ResolveProject in MemoryStore interface"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ `Store.ResolveProject` with the exact 4-step lookup order and `("", "", nil)`-on-miss contract — Task 1.
+- ✅ `ListProjectNames` — Task 1.
+- ✅ CLI near-miss listing on `reflect`/`resolve` — Task 2.
+- ✅ MCP tool layer migration, all 16 call sites, `resolveProjectID` deleted — Task 3.
+- ✅ `ghost_memory_save`'s `EnsureProject` auto-create preserved via explicit raw-input fallback — Task 3, Shape B.
+- ✅ Hook migration, `lookupProject` deleted, both `hook.go` and `stophook.go` call sites — Task 4.
+- ✅ Table-driven tests: exact ID, exact name, path-prefix + longest-wins, no-prefix-false-match, basename fallback, no-match, DB error — Task 1, Step 1.
+- ✅ Interface cleanup so `provider.MemoryStore` matches the real `*Store` API — Task 5.
+- ✅ Non-goals respected: no auto-create added to CLI paths, no fuzzy matching implemented.
+
+**Placeholder scan:** no TBD/TODO; every step shows complete code or an exact `grep`/`go test` command with expected output.
+
+**Type consistency:** `ResolveProject(ctx, input) (id, name string, err error)` is the same signature used consistently across Tasks 1, 2, 3, 4, and the interface in Task 5. `ListProjectNames(ctx) ([]string, error)` likewise consistent between Task 1 and Task 5.
+
+**Sequencing note:** Tasks 1 → 2 → 3 → 4 → 5 must run in this order — Task 2/3/4 all call `store.ResolveProject`, which doesn't exist until Task 1 lands; Task 5 removes the interface method whose implementation Task 1 already deleted, so it must run last.
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-01-project-resolution-unification.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -241,7 +241,7 @@ func loadSessionContext(cwd string) (projectID, project string, memories []sessi
 	}
 	defer db.Close() //nolint:errcheck
 
-	// Find matching project: try full path prefix first, then cwd basename name match
+	// Resolve cwd to a project: id, name, path-prefix, then basename fallback (see Store.ResolveProject).
 	store := memory.NewStore(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	projectID, project, err = store.ResolveProject(context.Background(), cwd)
 	if err != nil || projectID == "" {

--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -241,8 +242,9 @@ func loadSessionContext(cwd string) (projectID, project string, memories []sessi
 	defer db.Close() //nolint:errcheck
 
 	// Find matching project: try full path prefix first, then cwd basename name match
-	projectID, project = lookupProject(db, cwd)
-	if projectID == "" {
+	store := memory.NewStore(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	projectID, project, err = store.ResolveProject(context.Background(), cwd)
+	if err != nil || projectID == "" {
 		return
 	}
 
@@ -352,29 +354,6 @@ func loadSessionContext(cwd string) (projectID, project string, memories []sessi
 	).Scan(&interactionCount)
 
 	return
-}
-
-// lookupProject finds the project ID and name for the given cwd.
-// It checks for an exact path match or a proper subdirectory match first
-// (using path || '/' prefix to avoid false-matching sibling directories),
-// then falls back to matching on the basename of cwd against project names.
-// Returns ("", "") when no project matches.
-func lookupProject(db *sql.DB, cwd string) (id, name string) {
-	cwdBase := filepath.Base(cwd)
-	// path is escaped before use as a LIKE pattern so a literal '%' or '_' in
-	// a project's path (e.g. a directory named "foo_bar") can't act as an
-	// unintended wildcard and false-match an unrelated cwd.
-	row := db.QueryRow(`
-		SELECT id, name FROM projects
-		WHERE ((? = path OR ? LIKE REPLACE(REPLACE(REPLACE(path, '\', '\\'), '%', '\%'), '_', '\_') || '/%' ESCAPE '\')
-		       AND LENGTH(path) > 10)
-		   OR name = ?
-		ORDER BY LENGTH(path) DESC LIMIT 1
-	`, cwd, cwd, cwdBase)
-	if err := row.Scan(&id, &name); err != nil {
-		return "", ""
-	}
-	return id, name
 }
 
 // shortID returns the first 8 characters of an ID, or the full ID if shorter.

--- a/internal/mcpinit/hook_test.go
+++ b/internal/mcpinit/hook_test.go
@@ -136,13 +136,19 @@ func TestLookupProject_PathWithLikeWildcards(t *testing.T) {
 
 	// Without escaping, "foo_bar/%" as a LIKE pattern would also match
 	// "fooXbar/anything" since '_' matches any single character.
-	id, name := lookupProject(db, "/home/wayne/git/fooXbar/sub")
+	id, name, err := testStore(db).ResolveProject(context.Background(), "/home/wayne/git/fooXbar/sub")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
 	if id != "" || name != "" {
 		t.Errorf("unescaped underscore false match: got id=%q name=%q, want no match", id, name)
 	}
 
 	// The real subdirectory should still match correctly.
-	id, name = lookupProject(db, "/home/wayne/git/foo_bar/sub")
+	id, name, err = testStore(db).ResolveProject(context.Background(), "/home/wayne/git/foo_bar/sub")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
 	if id != "abc123" || name != "foo_bar" {
 		t.Errorf("exact underscore path: got id=%q name=%q, want abc123/foo_bar", id, name)
 	}

--- a/internal/mcpinit/hook_test.go
+++ b/internal/mcpinit/hook_test.go
@@ -1,9 +1,12 @@
 package mcpinit
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +15,12 @@ import (
 	"github.com/wcatz/ghost/internal/memory"
 	_ "modernc.org/sqlite"
 )
+
+// testStore wraps db in a memory.Store with a discard logger, matching the
+// package's existing convention (see init.go, status.go).
+func testStore(db *sql.DB) *memory.Store {
+	return memory.NewStore(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
 
 // openTestDB creates an in-memory SQLite DB with the ghost schema.
 func openTestDB(t *testing.T) *sql.DB {
@@ -37,7 +46,10 @@ func TestLookupProject_ExactMatch(t *testing.T) {
 	db := openTestDB(t)
 	insertProject(t, db, "abc123", "/home/wayne/git/ghost", "ghost")
 
-	id, name := lookupProject(db, "/home/wayne/git/ghost")
+	id, name, err := testStore(db).ResolveProject(context.Background(), "/home/wayne/git/ghost")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
 	if id != "abc123" || name != "ghost" {
 		t.Errorf("exact match: got id=%q name=%q, want abc123/ghost", id, name)
 	}
@@ -47,7 +59,10 @@ func TestLookupProject_SubdirMatch(t *testing.T) {
 	db := openTestDB(t)
 	insertProject(t, db, "abc123", "/home/wayne/git/ghost", "ghost")
 
-	id, name := lookupProject(db, "/home/wayne/git/ghost/internal/mcpinit")
+	id, name, err := testStore(db).ResolveProject(context.Background(), "/home/wayne/git/ghost/internal/mcpinit")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
 	if id != "abc123" || name != "ghost" {
 		t.Errorf("subdir match: got id=%q name=%q, want abc123/ghost", id, name)
 	}
@@ -59,7 +74,10 @@ func TestLookupProject_NoPrefixFalseMatch(t *testing.T) {
 	db := openTestDB(t)
 	insertProject(t, db, "abc123", "/home/wayne/git/ghost", "ghost")
 
-	id, name := lookupProject(db, "/home/wayne/git/ghost-extra")
+	id, name, err := testStore(db).ResolveProject(context.Background(), "/home/wayne/git/ghost-extra")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
 	if id != "" || name != "" {
 		t.Errorf("prefix false match: /home/wayne/git/ghost-extra should NOT match /home/wayne/git/ghost, got id=%q name=%q", id, name)
 	}
@@ -71,7 +89,10 @@ func TestLookupProject_LongestPathWins(t *testing.T) {
 	insertProject(t, db, "child", "/home/wayne/git/ghost", "ghost")
 
 	// CWD inside ghost should match the longer (more specific) path.
-	id, _ := lookupProject(db, "/home/wayne/git/ghost/cmd")
+	id, _, err := testStore(db).ResolveProject(context.Background(), "/home/wayne/git/ghost/cmd")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
 	if id != "child" {
 		t.Errorf("longest path should win, got %q, want %q", id, "child")
 	}
@@ -84,7 +105,10 @@ func TestLookupProject_NameFallback(t *testing.T) {
 	insertProject(t, db, "abc123", "/x/ghost", "ghost")
 
 	// cwd basename is "ghost" — should match by name even when path doesn't match.
-	id, name := lookupProject(db, filepath.Join("/some/unrelated/path", "ghost"))
+	id, name, err := testStore(db).ResolveProject(context.Background(), filepath.Join("/some/unrelated/path", "ghost"))
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
 	if id != "abc123" || name != "ghost" {
 		t.Errorf("name fallback: got id=%q name=%q, want abc123/ghost", id, name)
 	}
@@ -94,7 +118,10 @@ func TestLookupProject_NoMatch(t *testing.T) {
 	db := openTestDB(t)
 	insertProject(t, db, "abc123", "/home/wayne/git/ghost", "ghost")
 
-	id, name := lookupProject(db, "/home/user/other-project")
+	id, name, err := testStore(db).ResolveProject(context.Background(), "/home/user/other-project")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
 	if id != "" || name != "" {
 		t.Errorf("no match: expected empty, got id=%q name=%q", id, name)
 	}

--- a/internal/mcpinit/stophook.go
+++ b/internal/mcpinit/stophook.go
@@ -2,16 +2,19 @@ package mcpinit
 
 import (
 	"bufio"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 
 	"github.com/wcatz/ghost/internal/config"
+	"github.com/wcatz/ghost/internal/memory"
 )
 
 type stopHookInput struct {
@@ -124,9 +127,9 @@ func scanTranscript(r io.Reader) (toolCalls, ghostSaves int) {
 // If the Anthropic API is out of credit, the spawned process itself fails
 // fast and logs the failure to resolve.log — no local fallback runs in this
 // path, so auto-resolve simply does nothing until credits are restored.
-// Known limitation: resolution here depends on lookupProject's path/basename
-// match against the stored project row; a cwd with no matching project is a
-// silent no-op, same as an unconfigured user.
+// Known limitation: resolution here depends on Store.ResolveProject's
+// path/basename match against the stored project row; a cwd with no matching
+// project is a silent no-op, same as an unconfigured user.
 func spawnResolveIfConfigured(cwd string) {
 	if cwd == "" {
 		return
@@ -150,8 +153,9 @@ func spawnResolveIfConfigured(cwd string) {
 	}
 	defer db.Close() //nolint:errcheck
 
-	projectID, projectName := lookupProject(db, cwd)
-	if projectID == "" || projectName == "" {
+	store := memory.NewStore(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	projectID, projectName, err := store.ResolveProject(context.Background(), cwd)
+	if err != nil || projectID == "" || projectName == "" {
 		return
 	}
 

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -248,41 +248,7 @@ func (s *Server) Run(ctx context.Context) error {
 	return s.mcp.Run(ctx, &mcp.StdioTransport{})
 }
 
-// resolveProjectID resolves a project_id that may be a name (e.g. "ghost")
-// into the actual hash ID (e.g. "6bdc098af7f5") stored in the database.
-// Name lookup takes precedence to avoid collisions where a project name
-// happens to match another project's hash ID.
-func (s *Server) resolveProjectID(ctx context.Context, input string) string {
-	// Try name lookup first — most MCP clients pass project names.
-	resolved, err := s.store.ResolveProjectByName(ctx, input)
-	if err == nil && resolved != "" {
-		return resolved
-	}
-
-	// Fall back to direct ID match, then path match.
-	projects, err := s.store.ListProjects(ctx)
-	if err == nil {
-		for _, p := range projects {
-			if p.ID == input {
-				return input
-			}
-		}
-		// If input looks like an absolute path, match against project paths.
-		// This prevents creating duplicate projects when Claude passes a raw
-		// filesystem path instead of a project name or hash ID.
-		if filepath.IsAbs(input) {
-			for _, p := range projects {
-				if p.Path == input {
-					return p.ID
-				}
-			}
-		}
-	}
-
-	return input
-}
-
-// projectExists reports whether id (already resolved via resolveProjectID)
+// projectExists reports whether id (already resolved via Store.ResolveProject)
 // matches a registered project. Used to distinguish "this project was never
 // persisted" from "this project exists but has nothing" in empty-result
 // messages — the raw list otherwise reads identically either way. The error
@@ -328,7 +294,10 @@ func (s *Server) applyMemoryUpdate(ctx context.Context, args updateArgs) (string
 		return "", fmt.Errorf("invalid category %q — must be one of: architecture, decision, pattern, convention, gotcha, dependency, preference, fact", args.Category)
 	}
 
-	resolvedProjectID := s.resolveProjectID(ctx, args.ProjectID)
+	resolvedProjectID, _, err := s.store.ResolveProject(ctx, args.ProjectID)
+	if err != nil {
+		return "", fmt.Errorf("resolve project: %w", err)
+	}
 	mems, err := s.store.GetByIDs(ctx, []string{args.MemoryID})
 	if err != nil {
 		return "", fmt.Errorf("lookup failed: %w", err)
@@ -398,7 +367,10 @@ func (s *Server) promoteMemory(ctx context.Context, projectID, memoryID string) 
 	if projectID == "" || memoryID == "" {
 		return "", fmt.Errorf("project_id and memory_id are required")
 	}
-	resolvedProjectID := s.resolveProjectID(ctx, projectID)
+	resolvedProjectID, _, err := s.store.ResolveProject(ctx, projectID)
+	if err != nil {
+		return "", fmt.Errorf("resolve project: %w", err)
+	}
 
 	mems, err := s.store.GetByIDs(ctx, []string{memoryID})
 	if err != nil {
@@ -449,7 +421,11 @@ func (s *Server) registerTools() {
 		if args.Limit > 100 {
 			args.Limit = 100
 		}
-		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
+		resolved, _, err := s.store.ResolveProject(ctx, args.ProjectID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		}
+		args.ProjectID = resolved
 
 		// Use hybrid search (FTS5 + vector) when embedder is available.
 		var queryVec []float32
@@ -539,7 +515,16 @@ func (s *Server) registerTools() {
 			args.Tags = []string{}
 		}
 		args.Tags = validateTags(args.Tags)
-		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
+		resolved, _, err := s.store.ResolveProject(ctx, args.ProjectID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		}
+		if resolved != "" {
+			// Only overwrite with the resolved ID on a hit. On a miss, keep the
+			// raw input so EnsureProject below can auto-create a new project —
+			// preserving today's create-on-first-save behavior.
+			args.ProjectID = resolved
+		}
 
 		truncated := false
 		if len(args.Content) > maxContentLen {
@@ -602,7 +587,11 @@ func (s *Server) registerTools() {
 		if args.Limit > 100 {
 			args.Limit = 100
 		}
-		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
+		resolved, _, err := s.store.ResolveProject(ctx, args.ProjectID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		}
+		args.ProjectID = resolved
 
 		// First-contact import: if project has zero memories, try importing
 		// from Claude Code's auto-memory files (read-only, one-time).
@@ -680,7 +669,11 @@ func (s *Server) registerTools() {
 		if args.Limit > 100 {
 			args.Limit = 100
 		}
-		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
+		resolved, _, resolveErr := s.store.ResolveProject(ctx, args.ProjectID)
+		if resolveErr != nil {
+			return nil, nil, fmt.Errorf("resolve project: %w", resolveErr)
+		}
+		args.ProjectID = resolved
 
 		var memories []memory.Memory
 		var err error
@@ -735,7 +728,10 @@ func (s *Server) registerTools() {
 		if args.ProjectID == "" || args.MemoryID == "" {
 			return nil, nil, fmt.Errorf("project_id and memory_id are required")
 		}
-		resolvedProjectID := s.resolveProjectID(ctx, args.ProjectID)
+		resolvedProjectID, _, err := s.store.ResolveProject(ctx, args.ProjectID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		}
 
 		// Verify the memory exists and belongs to the specified project.
 		mems, err := s.store.GetByIDs(ctx, []string{args.MemoryID})
@@ -929,7 +925,11 @@ func (s *Server) registerTools() {
 		}
 		args.Title = truncateUTF8(args.Title, maxTitleLen)
 		args.Description = truncateUTF8(args.Description, maxContentLen)
-		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
+		resolved, _, err := s.store.ResolveProject(ctx, args.ProjectID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		}
+		args.ProjectID = resolved
 		priority := 2 // default: normal
 		if args.Priority != nil {
 			priority = *args.Priority
@@ -966,7 +966,10 @@ func (s *Server) registerTools() {
 		if args.Project == "" {
 			return nil, nil, fmt.Errorf("project is required")
 		}
-		projectID := s.resolveProjectID(ctx, args.Project)
+		projectID, _, err := s.store.ResolveProject(ctx, args.Project)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		}
 		rs, ok := s.store.(resolveCapableStore)
 		if !ok {
 			return nil, nil, fmt.Errorf("ghost_resolve: store does not support resolve operations")
@@ -1016,7 +1019,11 @@ func (s *Server) registerTools() {
 		if args.ProjectID == "" {
 			return nil, nil, fmt.Errorf("project_id is required")
 		}
-		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
+		resolved, _, err := s.store.ResolveProject(ctx, args.ProjectID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		}
+		args.ProjectID = resolved
 		if args.Limit <= 0 {
 			args.Limit = 30
 		}
@@ -1108,7 +1115,11 @@ func (s *Server) registerTools() {
 		for i, alt := range args.Alternatives {
 			args.Alternatives[i] = truncateUTF8(alt, maxTitleLen)
 		}
-		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
+		resolved, _, err := s.store.ResolveProject(ctx, args.ProjectID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		}
+		args.ProjectID = resolved
 		if args.Alternatives == nil {
 			args.Alternatives = []string{}
 		}
@@ -1354,7 +1365,11 @@ func (s *Server) registerTools() {
 		if args.Limit > 100 {
 			args.Limit = 100
 		}
-		args.ProjectID = s.resolveProjectID(ctx, args.ProjectID)
+		resolved, _, err := s.store.ResolveProject(ctx, args.ProjectID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		}
+		args.ProjectID = resolved
 
 		decisions, err := s.store.ListDecisions(ctx, args.ProjectID, args.Status, args.Limit)
 		if err != nil {
@@ -1404,7 +1419,10 @@ func (s *Server) registerResources() {
 		if err != nil {
 			return nil, err
 		}
-		projectID := s.resolveProjectID(ctx, rawID)
+		projectID, _, err := s.store.ResolveProject(ctx, rawID)
+		if err != nil {
+			return nil, fmt.Errorf("resolve project: %w", err)
+		}
 		text, err := s.buildProjectContext(ctx, projectID)
 		if err != nil {
 			return nil, fmt.Errorf("reading project context %q: %w", projectID, err)
@@ -1463,7 +1481,10 @@ func (s *Server) registerResources() {
 		if err != nil {
 			return nil, err
 		}
-		projectID := s.resolveProjectID(ctx, rawID)
+		projectID, _, err := s.store.ResolveProject(ctx, rawID)
+		if err != nil {
+			return nil, fmt.Errorf("resolve project: %w", err)
+		}
 
 		decisions, err := s.store.ListDecisions(ctx, projectID, "active", 20)
 		if err != nil {
@@ -1504,7 +1525,10 @@ func (s *Server) registerResources() {
 		if err != nil {
 			return nil, err
 		}
-		projectID := s.resolveProjectID(ctx, rawID)
+		projectID, _, err := s.store.ResolveProject(ctx, rawID)
+		if err != nil {
+			return nil, fmt.Errorf("resolve project: %w", err)
+		}
 
 		var sb strings.Builder
 		sb.WriteString("## Open Tasks\n\n")
@@ -1556,7 +1580,10 @@ func (s *Server) registerPrompts() {
 		if rawID == "" {
 			return nil, fmt.Errorf("project_id argument is required")
 		}
-		projectID := s.resolveProjectID(ctx, rawID)
+		projectID, _, err := s.store.ResolveProject(ctx, rawID)
+		if err != nil {
+			return nil, fmt.Errorf("resolve project: %w", err)
+		}
 		text, err := s.buildProjectContext(ctx, projectID)
 		if err != nil {
 			return nil, fmt.Errorf("recall project context for %q: %w", rawID, err)

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -298,6 +298,9 @@ func (s *Server) applyMemoryUpdate(ctx context.Context, args updateArgs) (string
 	if err != nil {
 		return "", fmt.Errorf("resolve project: %w", err)
 	}
+	if resolvedProjectID == "" {
+		return "", fmt.Errorf("project %q not found", args.ProjectID)
+	}
 	mems, err := s.store.GetByIDs(ctx, []string{args.MemoryID})
 	if err != nil {
 		return "", fmt.Errorf("lookup failed: %w", err)
@@ -370,6 +373,9 @@ func (s *Server) promoteMemory(ctx context.Context, projectID, memoryID string) 
 	resolvedProjectID, _, err := s.store.ResolveProject(ctx, projectID)
 	if err != nil {
 		return "", fmt.Errorf("resolve project: %w", err)
+	}
+	if resolvedProjectID == "" {
+		return "", fmt.Errorf("project %q not found", projectID)
 	}
 
 	mems, err := s.store.GetByIDs(ctx, []string{memoryID})
@@ -732,6 +738,9 @@ func (s *Server) registerTools() {
 		if err != nil {
 			return nil, nil, fmt.Errorf("resolve project: %w", err)
 		}
+		if resolvedProjectID == "" {
+			return nil, nil, fmt.Errorf("project %q not found", args.ProjectID)
+		}
 
 		// Verify the memory exists and belongs to the specified project.
 		mems, err := s.store.GetByIDs(ctx, []string{args.MemoryID})
@@ -929,6 +938,9 @@ func (s *Server) registerTools() {
 		if err != nil {
 			return nil, nil, fmt.Errorf("resolve project: %w", err)
 		}
+		if resolved == "" {
+			return nil, nil, fmt.Errorf("project %q not found", args.ProjectID)
+		}
 		args.ProjectID = resolved
 		priority := 2 // default: normal
 		if args.Priority != nil {
@@ -969,6 +981,9 @@ func (s *Server) registerTools() {
 		projectID, _, err := s.store.ResolveProject(ctx, args.Project)
 		if err != nil {
 			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		}
+		if projectID == "" {
+			return nil, nil, fmt.Errorf("project %q not found", args.Project)
 		}
 		rs, ok := s.store.(resolveCapableStore)
 		if !ok {
@@ -1118,6 +1133,9 @@ func (s *Server) registerTools() {
 		resolved, _, err := s.store.ResolveProject(ctx, args.ProjectID)
 		if err != nil {
 			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		}
+		if resolved == "" {
+			return nil, nil, fmt.Errorf("project %q not found", args.ProjectID)
 		}
 		args.ProjectID = resolved
 		if args.Alternatives == nil {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -89,6 +89,65 @@ func TestResolveProject_IDTakesPrecedenceOverName(t *testing.T) {
 	}
 }
 
+func TestGhostTaskCreate_RejectsUnknownProject(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_task_create",
+		Arguments: map[string]any{"project_id": "nonexistent-project", "title": "should not be created"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_task_create: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected error result for unknown project, got: %+v", result.Content)
+	}
+
+	tasks, err := store.ListTasks(ctx, "", "", 10)
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("task must not be persisted against an empty project id, found %d", len(tasks))
+	}
+}
+
+func TestGhostDecisionRecord_RejectsUnknownProject(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "ghost_decision_record",
+		Arguments: map[string]any{
+			"project_id": "nonexistent-project",
+			"title":      "should not be recorded",
+			"decision":   "some decision",
+			"rationale":  "some rationale",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_decision_record: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected error result for unknown project, got: %+v", result.Content)
+	}
+
+	decisions, err := store.ListDecisions(ctx, "", "", 10)
+	if err != nil {
+		t.Fatalf("ListDecisions: %v", err)
+	}
+	if len(decisions) != 0 {
+		t.Errorf("decision must not be persisted against an empty project id, found %d", len(decisions))
+	}
+}
+
 func TestFormatMemories(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -32,60 +32,60 @@ func testStore(t *testing.T) *memory.Store {
 	return s
 }
 
-func TestResolveProjectID_ByName(t *testing.T) {
+func TestResolveProject_ByName(t *testing.T) {
 	store := testStore(t)
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	srv := &Server{store: store, logger: logger}
-
 	ctx := context.Background()
-	got := srv.resolveProjectID(ctx, "test-project")
-	if got != "abc123" {
-		t.Errorf("resolveProjectID(name) = %q, want %q", got, "abc123")
+	id, name, err := store.ResolveProject(ctx, "test-project")
+	if err != nil {
+		t.Fatalf("ResolveProject(name): %v", err)
+	}
+	if id != "abc123" || name != "test-project" {
+		t.Errorf("ResolveProject(name) = (%q, %q), want (%q, %q)", id, name, "abc123", "test-project")
 	}
 }
 
-func TestResolveProjectID_ByID(t *testing.T) {
+func TestResolveProject_ByID(t *testing.T) {
 	store := testStore(t)
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	srv := &Server{store: store, logger: logger}
-
 	ctx := context.Background()
-	got := srv.resolveProjectID(ctx, "abc123")
-	if got != "abc123" {
-		t.Errorf("resolveProjectID(id) = %q, want %q", got, "abc123")
+	id, name, err := store.ResolveProject(ctx, "abc123")
+	if err != nil {
+		t.Fatalf("ResolveProject(id): %v", err)
+	}
+	if id != "abc123" || name != "test-project" {
+		t.Errorf("ResolveProject(id) = (%q, %q), want (%q, %q)", id, name, "abc123", "test-project")
 	}
 }
 
-func TestResolveProjectID_Unknown(t *testing.T) {
+func TestResolveProject_Unknown(t *testing.T) {
 	store := testStore(t)
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	srv := &Server{store: store, logger: logger}
-
 	ctx := context.Background()
-	got := srv.resolveProjectID(ctx, "nonexistent")
-	// Should fall through and return the input as-is.
-	if got != "nonexistent" {
-		t.Errorf("resolveProjectID(unknown) = %q, want %q", got, "nonexistent")
+	id, name, err := store.ResolveProject(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("ResolveProject(unknown): %v", err)
+	}
+	// No match should return empty id/name rather than echoing the input.
+	if id != "" || name != "" {
+		t.Errorf("ResolveProject(unknown) = (%q, %q), want (\"\", \"\")", id, name)
 	}
 }
 
-func TestResolveProjectID_NameTakesPrecedence(t *testing.T) {
+func TestResolveProject_IDTakesPrecedenceOverName(t *testing.T) {
 	store := testStore(t)
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-
-	// Create a second project where the name matches the first project's ID.
 	ctx := context.Background()
+
+	// Create a second project whose name matches the first project's ID.
 	if err := store.EnsureProject(ctx, "def456", "/tmp/second", "abc123"); err != nil {
 		t.Fatalf("EnsureProject second: %v", err)
 	}
 
-	srv := &Server{store: store, logger: logger}
-
-	// When "abc123" is passed, name lookup should match the second project's name.
-	got := srv.resolveProjectID(ctx, "abc123")
-	// Name "abc123" maps to project ID "def456".
-	if got != "def456" {
-		t.Errorf("resolveProjectID should prefer name lookup, got %q, want %q", got, "def456")
+	// When "abc123" is passed, ID lookup should match the first project's ID
+	// directly rather than falling through to a name match.
+	id, name, err := store.ResolveProject(ctx, "abc123")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "abc123" || name != "test-project" {
+		t.Errorf("ResolveProject should prefer ID lookup, got (%q, %q), want (%q, %q)", id, name, "abc123", "test-project")
 	}
 }
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -313,10 +313,12 @@ func (s *Store) mergeProjectLocked(ctx context.Context, oldID, newID string) err
 // Lookup order, first hit wins:
 //  1. exact id = input
 //  2. exact name = input
-//  3. if input contains '/': input = path OR input LIKE path || '/%'
+//  3. if input contains '/': input = path OR input has literal prefix path + "/"
 //     (ordered by LENGTH(path) DESC — longest/most-specific match wins;
 //     LENGTH(path) > 10 guards against a short project path matching too
-//     broadly, matching the hook's original lookupProject behavior)
+//     broadly, matching the hook's original lookupProject behavior; the
+//     prefix check is a literal substr comparison, not LIKE, so '%'/'_' in a
+//     stored path can't act as SQL wildcards against input)
 //  4. name = basename(input)
 func (s *Store) ResolveProject(ctx context.Context, input string) (id, name string, err error) {
 	s.mu.RLock()
@@ -339,9 +341,11 @@ func (s *Store) ResolveProject(ctx context.Context, input string) (id, name stri
 	}
 
 	if strings.Contains(input, "/") {
+		// Literal prefix comparison, not LIKE: a stored path containing '%' or
+		// '_' must not be treated as a SQL wildcard against input.
 		err = s.db.QueryRowContext(ctx, `
 			SELECT id, name FROM projects
-			WHERE (path = ? OR ? LIKE path || '/%') AND LENGTH(path) > 10
+			WHERE (path = ? OR substr(?, 1, LENGTH(path) + 1) = path || '/') AND LENGTH(path) > 10
 			ORDER BY LENGTH(path) DESC LIMIT 1
 		`, input, input).Scan(&id, &name)
 		if err == nil {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -306,20 +306,77 @@ func (s *Store) mergeProjectLocked(ctx context.Context, oldID, newID string) err
 	return nil
 }
 
-// ResolveProjectByName looks up a project by name and returns its hash ID.
-func (s *Store) ResolveProjectByName(ctx context.Context, name string) (string, error) {
+// ResolveProject resolves an identifier — a project name, hash ID, or
+// filesystem path — to that project's (id, name). Returns ("", "", nil)
+// on no match; a non-nil error only indicates a real DB failure.
+//
+// Lookup order, first hit wins:
+//  1. exact id = input
+//  2. exact name = input
+//  3. if input contains '/': input = path OR input LIKE path || '/%'
+//     (ordered by LENGTH(path) DESC — longest/most-specific match wins;
+//     LENGTH(path) > 10 guards against a short project path matching too
+//     broadly, matching the hook's original lookupProject behavior)
+//  4. name = basename(input)
+func (s *Store) ResolveProject(ctx context.Context, input string) (id, name string, err error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	var id string
-	err := s.db.QueryRowContext(ctx, `SELECT id FROM projects WHERE name = ? LIMIT 1`, name).Scan(&id)
-	if err == sql.ErrNoRows {
-		return "", nil
+	err = s.db.QueryRowContext(ctx, `SELECT id, name FROM projects WHERE id = ? LIMIT 1`, input).Scan(&id, &name)
+	if err == nil {
+		return id, name, nil
 	}
+	if err != sql.ErrNoRows {
+		return "", "", fmt.Errorf("resolve project by id: %w", err)
+	}
+
+	err = s.db.QueryRowContext(ctx, `SELECT id, name FROM projects WHERE name = ? LIMIT 1`, input).Scan(&id, &name)
+	if err == nil {
+		return id, name, nil
+	}
+	if err != sql.ErrNoRows {
+		return "", "", fmt.Errorf("resolve project by name: %w", err)
+	}
+
+	if strings.Contains(input, "/") {
+		err = s.db.QueryRowContext(ctx, `
+			SELECT id, name FROM projects
+			WHERE (path = ? OR ? LIKE path || '/%') AND LENGTH(path) > 10
+			ORDER BY LENGTH(path) DESC LIMIT 1
+		`, input, input).Scan(&id, &name)
+		if err == nil {
+			return id, name, nil
+		}
+		if err != sql.ErrNoRows {
+			return "", "", fmt.Errorf("resolve project by path: %w", err)
+		}
+	}
+
+	base := filepath.Base(input)
+	err = s.db.QueryRowContext(ctx, `SELECT id, name FROM projects WHERE name = ? LIMIT 1`, base).Scan(&id, &name)
+	if err == nil {
+		return id, name, nil
+	}
+	if err != sql.ErrNoRows {
+		return "", "", fmt.Errorf("resolve project by basename: %w", err)
+	}
+
+	return "", "", nil
+}
+
+// ListProjectNames returns all known project names, ordered the same way as
+// ListProjects (name ASC) — used to format an actionable CLI error listing
+// known projects on a resolution miss.
+func (s *Store) ListProjectNames(ctx context.Context) ([]string, error) {
+	projects, err := s.ListProjects(ctx)
 	if err != nil {
-		return "", fmt.Errorf("resolve project by name: %w", err)
+		return nil, err
 	}
-	return id, nil
+	names := make([]string, len(projects))
+	for i, p := range projects {
+		names[i] = p.Name
+	}
+	return names, nil
 }
 
 // Create inserts a new memory and returns its ID.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1163,6 +1163,32 @@ func TestStoreResolveProject_PathPrefix(t *testing.T) {
 	}
 }
 
+func TestStoreResolveProject_PathWithWildcardChars(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	// A stored path containing literal '%'/'_' must not act as a SQL LIKE
+	// wildcard against an unrelated input path.
+	if err := s.EnsureProject(ctx, "wildid", "/home/wayne/git/foo_bar", "foobar"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+
+	id, name, err := s.ResolveProject(ctx, "/home/wayne/git/fooXbar/sub")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "" || name != "" {
+		t.Errorf("'_' in stored path must not wildcard-match, got id=%q name=%q", id, name)
+	}
+
+	id, name, err = s.ResolveProject(ctx, "/home/wayne/git/foo_bar/sub")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "wildid" || name != "foobar" {
+		t.Errorf("exact literal prefix should still match, got id=%q name=%q, want id=%q name=%q", id, name, "wildid", "foobar")
+	}
+}
+
 func TestStoreResolveProject_LongestPathWins(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1121,26 +1121,142 @@ func TestStoreListProjects(t *testing.T) {
 	}
 }
 
-func TestStoreResolveProjectByName(t *testing.T) {
+func TestStoreResolveProject_ByID(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()
 
-	// testStore created project with name "test".
-	id, err := s.ResolveProjectByName(ctx, "test")
+	id, name, err := s.ResolveProject(ctx, testProject)
 	if err != nil {
-		t.Fatalf("ResolveProjectByName: %v", err)
+		t.Fatalf("ResolveProject: %v", err)
 	}
-	if id != testProject {
-		t.Errorf("expected %q, got %q", testProject, id)
+	if id != testProject || name != "test" {
+		t.Errorf("got id=%q name=%q, want id=%q name=%q", id, name, testProject, "test")
+	}
+}
+
+func TestStoreResolveProject_ByName(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	id, name, err := s.ResolveProject(ctx, "test")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != testProject || name != "test" {
+		t.Errorf("got id=%q name=%q, want id=%q name=%q", id, name, testProject, "test")
+	}
+}
+
+func TestStoreResolveProject_PathPrefix(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	if err := s.EnsureProject(ctx, "ghostid", "/home/wayne/git/ghost", "ghost"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
 	}
 
-	// Non-existent name returns empty string, no error.
-	id, err = s.ResolveProjectByName(ctx, "nonexistent")
+	id, name, err := s.ResolveProject(ctx, "/home/wayne/git/ghost/internal/memory")
 	if err != nil {
-		t.Fatalf("ResolveProjectByName nonexistent: %v", err)
+		t.Fatalf("ResolveProject: %v", err)
 	}
-	if id != "" {
-		t.Errorf("expected empty string for nonexistent, got %q", id)
+	if id != "ghostid" || name != "ghost" {
+		t.Errorf("got id=%q name=%q, want id=%q name=%q", id, name, "ghostid", "ghost")
+	}
+}
+
+func TestStoreResolveProject_LongestPathWins(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	if err := s.EnsureProject(ctx, "parent", "/home/wayne/git", "parent"); err != nil {
+		t.Fatalf("EnsureProject parent: %v", err)
+	}
+	if err := s.EnsureProject(ctx, "child", "/home/wayne/git/ghost", "ghost"); err != nil {
+		t.Fatalf("EnsureProject child: %v", err)
+	}
+
+	id, _, err := s.ResolveProject(ctx, "/home/wayne/git/ghost/cmd")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "child" {
+		t.Errorf("longest path should win, got %q, want %q", id, "child")
+	}
+}
+
+func TestStoreResolveProject_NoPrefixFalseMatch(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	if err := s.EnsureProject(ctx, "ghostid", "/home/wayne/git/ghost", "ghost"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+
+	id, name, err := s.ResolveProject(ctx, "/home/wayne/git/ghost-extra")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "" || name != "" {
+		t.Errorf("ghost-extra should NOT prefix-match ghost, got id=%q name=%q", id, name)
+	}
+}
+
+func TestStoreResolveProject_BasenameFallback(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	// Path shorter than the LENGTH(path) > 10 guard, so prefix matching can't fire —
+	// isolates the basename-of-input fallback (case 4).
+	if err := s.EnsureProject(ctx, "ghostid", "/x/ghost", "ghost"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+
+	id, name, err := s.ResolveProject(ctx, "/some/unrelated/path/ghost")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "ghostid" || name != "ghost" {
+		t.Errorf("basename fallback: got id=%q name=%q, want id=%q name=%q", id, name, "ghostid", "ghost")
+	}
+}
+
+func TestStoreResolveProject_NoMatch(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	id, name, err := s.ResolveProject(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "" || name != "" {
+		t.Errorf("expected empty on no match, got id=%q name=%q", id, name)
+	}
+}
+
+func TestStoreResolveProject_ClosedDB(t *testing.T) {
+	s := testStore(t)
+	s.Close() //nolint:errcheck
+	ctx := context.Background()
+
+	_, _, err := s.ResolveProject(ctx, "test")
+	if err == nil {
+		t.Fatal("expected error on closed DB, got nil")
+	}
+}
+
+func TestStoreListProjectNames(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	if err := s.EnsureProject(ctx, "ghostid", "/home/wayne/git/ghost", "ghost"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+
+	names, err := s.ListProjectNames(ctx)
+	if err != nil {
+		t.Fatalf("ListProjectNames: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("expected 2 names, got %d: %v", len(names), names)
+	}
+	// ListProjects orders by name ASC — "ghost" before "test".
+	if names[0] != "ghost" || names[1] != "test" {
+		t.Errorf("got %v, want [ghost test]", names)
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -70,7 +70,8 @@ type MemoryStore interface {
 	// Project management
 	ListProjects(ctx context.Context) ([]memory.Project, error)
 	EnsureProject(ctx context.Context, id, path, name string) error
-	ResolveProjectByName(ctx context.Context, name string) (string, error)
+	ResolveProject(ctx context.Context, input string) (id, name string, err error)
+	ListProjectNames(ctx context.Context) ([]string, error)
 	MergeProject(ctx context.Context, oldID, newID string) error
 
 	// Conversation persistence


### PR DESCRIPTION
## Summary
- Consolidates three independently-drifted project-identifier-resolution implementations (`Store.ResolveProjectByName`, `mcpserver.resolveProjectID`, `mcpinit.lookupProject`) into one canonical `Store.ResolveProject(ctx, input) (id, name string, err error)` — a 4-tier lookup: exact ID → exact name → path-prefix (longest wins) → basename fallback.
- Adds `Store.ListProjectNames` for CLI "known projects" listings on a resolution miss.
- Migrates every call site: `cmd/ghost/main.go` (reflect/resolve/supersede, via new `resolveProjectOrExit` helper), `internal/mcpserver/mcpserver.go` (16 sites; `ghost_memory_save` intentionally keeps raw input on a miss so auto-create-on-save still works), and `internal/mcpinit/{hook,stophook}.go`.
- Updates `provider.MemoryStore` interface to match.

Implements `docs/superpowers/specs/2026-07-28-project-resolution-unification-design.md` per `docs/superpowers/plans/2026-08-01-project-resolution-unification.md`. Executed task-by-task via subagent-driven development with spec-compliance + code-quality review after each task, plus a final whole-implementation review.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` all packages pass
- [x] `gofmt -l` clean on all touched files
- [x] Zero remaining references to the three deleted methods anywhere in the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Project references can now be resolved by ID, name, path, or directory name across CLI and MCP workflows.
  - Path matching selects the most specific project when multiple projects overlap.
  - Unknown project errors provide available project names to help correct input.
  - Project lists are now available consistently wherever project selection is supported.

- **Bug Fixes**
  - Improved handling of invalid project references, with clearer errors instead of silent fallbacks.
  - Saving memory with a new project name continues to support automatic project creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->