### PR TITLE
fix(eval): unset ANTHROPIC_API_KEY for claude -p actor subprocesses

### DIFF
--- a/docs/superpowers/eval/README.md
+++ b/docs/superpowers/eval/README.md
@@ -33,6 +33,14 @@ transcript) + N consolidation gradings + 4 storylines x 4-5 agents each +
 3 stress-test agents + 1 synthesis agent, plus the `resolve`/`supersede`
 Haiku calls inside the storyline grading steps. Budget accordingly.
 
+Only the `ghost reflect`/`resolve`/`supersede` CLI calls (Consolidation phase
++ storyline grading steps) spend real API credits — `internal/ai/client.go`
+is a direct Anthropic HTTP client and has no subscription option.
+`claude-eval-session.sh` unsets `ANTHROPIC_API_KEY` before launching each
+`claude -p` actor subprocess (replay/storyline/stress), so those ride your
+Claude Code subscription instead of API credits — do not remove that
+`env -u` or every actor session bills as pay-per-token API usage too.
+
 ## Isolation mechanism
 
 Every live-agent phase (replay, storyline, stress) does its actual work

--- a/docs/superpowers/eval/lib/claude-eval-session.sh
+++ b/docs/superpowers/eval/lib/claude-eval-session.sh
@@ -15,6 +15,15 @@
 # fire correctly instead of matching this repo's own cwd. This also keeps
 # the subprocess's session transcript out of the real
 # ~/.claude/projects/-home-wayne-git-ghost/ directory.
+#
+# ANTHROPIC_API_KEY is deliberately unset before invoking `claude -p` below.
+# If present, it overrides Claude Code's subscription/OAuth login and bills
+# this actor session as pay-per-token API usage instead of the subscription
+# — the opposite of what an eval "session replay" should cost. The Ghost
+# CLI calls this suite's Consolidation phase makes directly (ghost reflect/
+# resolve/supersede, in internal/ai/client.go) are a separate, unavoidable
+# direct HTTP client that always needs the key; only these `claude -p`
+# actor subprocesses can ride the subscription instead.
 set -euo pipefail
 
 UNIT_RUN_ID="${1:?usage: claude-eval-session.sh <unit-run-id> <prompt> <project-basename>}"
@@ -27,7 +36,7 @@ mkdir -p "${SESSION_CWD}"
 
 cd "${SESSION_CWD}"
 
-claude -p \
+env -u ANTHROPIC_API_KEY claude -p \
   --mcp-config "${CONFIG_DIR}/mcp.json" \
   --strict-mcp-config \
   --settings "${CONFIG_DIR}/settings.json" \


### PR DESCRIPTION
## Summary
- `claude-eval-session.sh` launched every replay/storyline/stress actor session with whatever environment the invoking process had, so an exported `ANTHROPIC_API_KEY` silently rerouted those `claude -p` subprocesses to pay-per-token API billing instead of the Claude Code subscription (Claude Code treats a present `ANTHROPIC_API_KEY` as taking precedence over subscription/OAuth login).
- Only `ghost reflect`/`resolve`/`supersede` (a direct Anthropic HTTP client in `internal/ai/client.go`, no subscription option) actually need the key — those still get it from the invoking shell for the Consolidation phase and storyline grading steps.
- Fix: `env -u ANTHROPIC_API_KEY` before the `claude -p` call in `claude-eval-session.sh`, so actor sessions ride the subscription. Updated the README's Cost section to document this so it doesn't regress.

## Test plan
- [ ] Re-run the eval suite (`docs/superpowers/eval/workflows/ghost-eval.workflow.js`) with `ANTHROPIC_API_KEY` exported only in the invoking shell, and confirm via `claude -p` behavior / lack of API credit spend that actor sessions authenticate via subscription while Consolidation/grading calls still succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which evaluation operations use API credits versus subscription-based authentication.
  * Documented that actor sessions use subscription/OAuth authentication and require the API key to remain unset.
  * Updated the evaluation script to enforce the documented authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->