### PR TITLE
Fix eval-report friction points: graceful degradation + clearer errors

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strconv"
@@ -174,7 +175,7 @@ func runReflect() {
 		fmt.Fprintln(os.Stderr, `Usage: ghost reflect <project> [flags]
 
 Flags:
-  --tier string   Consolidation tier: auto, haiku, sqlite (default "auto")
+  --tier string   Consolidation tier: auto, haiku, cli, sqlite (default "auto")
   --apply         Save results (default is dry-run/preview only)
   --restore       Undo the last consolidation from snapshot`)
 		os.Exit(1)
@@ -214,6 +215,12 @@ Flags:
 		}
 		client := ai.NewClient(cfg.API.Key, logger)
 		consolidator = reflection.NewHaikuConsolidator(client)
+	case "cli":
+		if _, err := exec.LookPath("claude"); err != nil {
+			fmt.Fprintln(os.Stderr, "error: cli tier requires the `claude` binary on PATH")
+			os.Exit(1)
+		}
+		consolidator = reflection.NewNamedConsolidator(ai.NewCLIClient(), "cli")
 	case "sqlite":
 		consolidator = reflection.NewSQLiteConsolidator()
 	default: // "auto"
@@ -221,6 +228,9 @@ Flags:
 		if cfg.API.Key != "" {
 			client := ai.NewClient(cfg.API.Key, logger)
 			tiers = append(tiers, reflection.NewHaikuConsolidator(client))
+		}
+		if _, err := exec.LookPath("claude"); err == nil {
+			tiers = append(tiers, reflection.NewNamedConsolidator(ai.NewCLIClient(), "cli"))
 		}
 		tiers = append(tiers, reflection.NewSQLiteConsolidator())
 		consolidator = reflection.NewTieredConsolidator(tiers, logger)
@@ -395,6 +405,31 @@ Flags:
 	}
 }
 
+// buildClassifyProvider builds the Provider resolve/supersede classify
+// against: the direct Anthropic API when ANTHROPIC_API_KEY is configured,
+// falling back to a subscription-billed `claude -p` CLI call on credit
+// exhaustion (dry-run-only, matching the sampling-provider convention for a
+// degraded secondary — see ai.FallbackProvider); or the CLI call as the sole,
+// full-write primary when no key is configured at all, so these commands work
+// without spending API credits as long as the `claude` binary is on PATH.
+func buildClassifyProvider(cfg *config.Config, logger *slog.Logger) (*ai.FallbackProvider, error) {
+	cliAvailable := false
+	if _, err := exec.LookPath("claude"); err == nil {
+		cliAvailable = true
+	}
+	if cfg.API.Key == "" {
+		if !cliAvailable {
+			return nil, errors.New("requires ANTHROPIC_API_KEY or the `claude` binary on PATH")
+		}
+		return ai.NewFallbackProvider(ai.NewCLIClient(), nil, false), nil
+	}
+	primary := ai.NewAnthropicProvider(ai.NewClient(cfg.API.Key, logger))
+	if !cliAvailable {
+		return ai.NewFallbackProvider(primary, nil, false), nil
+	}
+	return ai.NewFallbackProvider(primary, ai.NewCLIClient(), true), nil
+}
+
 // runSupersede implements `ghost supersede <project> [--apply]` — the creation
 // half of staleness-aware ranking. It proposes newer→older 'supersedes' links
 // over the project's live memories (cosine-similar candidates, Haiku-confirmed)
@@ -432,8 +467,9 @@ Flags:
   --apply             Write the supersedes/causes links (default is dry-run/preview)
   --threshold float   Min cosine similarity for a candidate pair (default 0.80)
 
-Requires ANTHROPIC_API_KEY (uses Haiku to classify each candidate as
-supersedes, causes, or neither).`)
+Classifies each candidate as supersedes, causes, or neither. Uses
+ANTHROPIC_API_KEY if set, else falls back to a subscription-billed
+'claude' CLI call — requires one of the two.`)
 		os.Exit(1)
 	}
 
@@ -450,13 +486,11 @@ supersedes, causes, or neither).`)
 		fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
 		os.Exit(1)
 	}
-	if cfg.API.Key == "" {
-		fmt.Fprintln(os.Stderr, "error: ghost supersede requires ANTHROPIC_API_KEY (uses Haiku to classify each candidate as supersedes, causes, or neither)")
+	provider, err := buildClassifyProvider(cfg, logger)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: ghost supersede %v\n", err)
 		os.Exit(1)
 	}
-
-	primary := ai.NewAnthropicProvider(ai.NewClient(cfg.API.Key, logger))
-	provider := ai.NewFallbackProvider(primary, nil, false)
 	cls := supersede.NewHaikuClassifier(provider)
 	res, classified, err := supersede.Run(ctx, store, cls, projectID, threshold, apply, logger)
 	if err != nil {
@@ -523,7 +557,8 @@ Flags:
   --apply   Stamp resolved_at on confirmed memories (default is dry-run/preview)
 
 Marks resolved-evidence memories so they drop from session-start injection
-(still searchable). Requires ANTHROPIC_API_KEY (Haiku classifies each candidate).`)
+(still searchable). Uses ANTHROPIC_API_KEY if set, else falls back to a
+subscription-billed 'claude' CLI call — requires one of the two.`)
 		os.Exit(1)
 	}
 
@@ -540,13 +575,11 @@ Marks resolved-evidence memories so they drop from session-start injection
 		fmt.Fprintf(os.Stderr, "error: project %q not found\n", projectName)
 		os.Exit(1)
 	}
-	if cfg.API.Key == "" {
-		fmt.Fprintln(os.Stderr, "error: ghost resolve requires ANTHROPIC_API_KEY (Haiku classifies each candidate)")
+	provider, err := buildClassifyProvider(cfg, logger)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: ghost resolve %v\n", err)
 		os.Exit(1)
 	}
-
-	primary := ai.NewAnthropicProvider(ai.NewClient(cfg.API.Key, logger))
-	provider := ai.NewFallbackProvider(primary, nil, false)
 	cls := resolve.NewHaikuClassifier(provider)
 	res, confirmed, err := resolve.Run(ctx, store, cls, projectID, apply, logger)
 	if err != nil {
@@ -843,12 +876,15 @@ Commands:
   version                     Print version
 
 Flags (reflect):
-  --tier string   Consolidation tier: auto, haiku, sqlite (default "auto")
+  --tier string   Consolidation tier: auto, haiku, cli, sqlite (default "auto")
   --apply         Save results
   --restore       Undo last consolidation
 
 Environment:
-  ANTHROPIC_API_KEY           Required for reflect --tier haiku, and always for supersede/resolve
+  ANTHROPIC_API_KEY           Required for reflect --tier haiku. supersede/resolve and
+                              reflect --tier cli/auto fall back to a subscription-billed
+                              'claude' CLI call (requires the 'claude' binary on PATH)
+                              when unset or exhausted.
   GHOST_DEBUG                 Enable debug logging
 `, version)
 }

--- a/docs/superpowers/eval/lib/ghost-wrapped
+++ b/docs/superpowers/eval/lib/ghost-wrapped
@@ -12,4 +12,12 @@ export XDG_DATA_HOME="${GHOST_EVAL_ROOT}/data"
 export XDG_CONFIG_HOME="${GHOST_EVAL_ROOT}/config"
 mkdir -p "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}"
 
+# Force the subscription-billed CLI tier for resolve/supersede regardless of
+# whatever the calling shell's ambient environment has exported — the eval
+# suite's whole point is to run without spending real API credits, and an
+# ambient ANTHROPIC_API_KEY (e.g. left over in a session's process env from
+# before ~/.bashrc's export was removed) would otherwise silently route these
+# calls back to the direct API.
+unset ANTHROPIC_API_KEY
+
 exec "${GHOST_BIN}" "$@"

--- a/docs/superpowers/eval/workflows/ghost-eval.workflow.js
+++ b/docs/superpowers/eval/workflows/ghost-eval.workflow.js
@@ -36,22 +36,21 @@ if (!/^\d{8}-\d{6}-eval$/.test(trimmedRunId)) {
 const scratchRoot = `/tmp/ghost-eval/${trimmedRunId}`
 log(`Eval run ${trimmedRunId} — scratch root ${scratchRoot} — repo ${REPO}`)
 
-// ANTHROPIC_API_KEY is required by ghost reflect/resolve/supersede (Consolidation
-// phase and storyline cliGradeResult runs). It must be set in the environment of
-// the process that invoked this Workflow tool call, not merely in an interactive
-// shell's rc file — a Claude Code session does not re-source ~/.bashrc, so
-// exporting the key in a terminal after the session started has no effect here.
-// Checking once up front avoids burning the Replay phase's cost before every
-// Consolidation call fails individually deep into the run.
-const keyCheck = await agent(
-  '[ -n "$ANTHROPIC_API_KEY" ] && echo present || echo missing',
-  { label: 'check-api-key' }
+// This suite runs Consolidation/resolve/supersede on the subscription-billed
+// CLI tier (ai.CLIClient — see internal/ai/cli_client.go), not the direct
+// Anthropic API, so a run never spends real API credits. That requires the
+// `claude` binary on PATH; the reflect call below passes `env -u
+// ANTHROPIC_API_KEY` and ghost-wrapped unsets it too, so an ambient key
+// left over in this session's process env (e.g. from before ~/.bashrc's
+// export was removed) can't silently route calls back to the direct API.
+const cliCheck = await agent(
+  'command -v claude >/dev/null 2>&1 && echo present || echo missing',
+  { label: 'check-cli' }
 )
-if (!keyCheck.includes('present')) {
+if (cliCheck.includes('missing')) {
   throw new Error(
-    'Setup: ANTHROPIC_API_KEY is not set in this Workflow call\'s environment. ' +
-    'ghost reflect/resolve/supersede will fail. Export it in the shell/session that ' +
-    'invokes this Workflow tool (not just your ~/.bashrc), then retry.'
+    'Setup: no `claude` binary on PATH in this Workflow call\'s environment. ' +
+    'ghost reflect/resolve/supersede\'s CLI tier requires it.'
   )
 }
 
@@ -180,7 +179,7 @@ try {
       )
 
       const reflectOutput = await agent(
-        `Run exactly: XDG_DATA_HOME=${scratchDataHome} XDG_CONFIG_HOME=${scratchConfigHome} ${REPO}/ghost reflect ${projectId} --tier haiku 2>&1; echo "exit code: $?"\n` +
+        `Run exactly: env -u ANTHROPIC_API_KEY XDG_DATA_HOME=${scratchDataHome} XDG_CONFIG_HOME=${scratchConfigHome} ${REPO}/ghost reflect ${projectId} --tier auto 2>&1; echo "exit code: $?"\n` +
         `Return the full combined stdout+stderr verbatim, including the trailing exit code line (this is a dry run — no --apply — nothing is written).`,
         { label: `reflect:${projectId}`, phase: 'Consolidation' }
       )

--- a/docs/superpowers/reports/2026-08-02-ghost-eval.md
+++ b/docs/superpowers/reports/2026-08-02-ghost-eval.md
@@ -1,5 +1,7 @@
 # Ghost Memory-System Eval Report
 
+> Baseline evaluation of behavior before PR #228. Findings below are historical observations from the evaluated commit.
+
 ## 1. Scorecard
 
 | Dimension | Score | Justification |

--- a/docs/superpowers/reports/2026-08-02-ghost-eval.md
+++ b/docs/superpowers/reports/2026-08-02-ghost-eval.md
@@ -1,0 +1,49 @@
+# Ghost Memory-System Eval Report
+
+## 1. Scorecard
+
+| Dimension | Score | Justification |
+|---|---|---|
+| Search relevance | **Mixed** | Exact-match/targeted queries (e.g. prompt-injection payload retrieval) worked cleanly, but broad queries against a duplicate-heavy project returned 8/15 near-identical restatements ahead of distinct facts, which landed at ranks 10, 12, and 15 with no relevance-score separation (nearly all scored ~0.7). |
+| Session-start injection | **Mixed** | Ranking favors importance correctly and the storyline-reversal hook did surface a reversal decision ahead of the decision it superseded — but default `limit=20` silently truncated 21 of 41 memories in the stress test with no count or "N more available" notice, and that same recency-awareness did not carry through to `ghost_memory_search`/`ghost_decisions_list` mid-session (both ranked a superseded decision above its reversal). |
+| ghost resolve | **Poor** | Every invocation exercised in this eval failed before reaching classification logic — `error: project "X" not found` on both the ghost-replay project and the storyline-oncall project. No resolve classification quality could be graded at all. |
+| ghost supersede | **Poor** | Aborted on the first candidate pair with an Anthropic credit-exhaustion error (by-design fail-fast per the project's documented fallback policy, but it means zero supersede classifications were produced or graded in this run). |
+| MCP tool ergonomics | **Mixed** | Read-path tools (`ghost_project_context`, `ghost_search_all`, `ghost_health`) behaved predictably and transparently. Write-path tools have real rough edges: `ghost_decision_record` throws a raw "FOREIGN KEY constraint failed" error instead of "project not found," requires the project to be silently pre-created via `ghost_memory_save` first (undocumented), rejects a plain string for `alternatives` (needs a JSON array, undocumented in the tool's own example), and `ghost_memory_save`'s `category` enum is a closed 8-value set discoverable only by triggering a rejection. |
+| Save-decision quality (replay) | **Poor** | 2 of 3 real projects scored 0/0 recall/precision outright; the one nonzero-recall project (ghost-replay) had precision only technically at 0 because ground truth was empty from an underlying bug, not because saves were spurious. The roller replay anchored to the wrong historical session entirely and missed the single highest-importance ground-truth memory. |
+| Consolidation quality (ghost reflect) | **Poor** | All 3 real-project consolidation runs (ghost, roller, infra) failed at the infrastructure level before producing any proposal — two "project not found" fatal errors and one credit-exhaustion failure — so no drop/merge/scope-error grading was possible for any of them. |
+
+## 2. Replay recall/precision by real project
+
+| Project | Recall | Precision | Notes |
+|---|---|---|---|
+| **ghost-replay** | 1.0 | 0/4 (not meaningful) | Ground-truth file was 0 bytes for both `ghost` and `infra`, itself apparently caused by the `ghost reflect: project not found` bug the replay documented. 3 of 4 saves reportedly closely match what a live (pre-compaction) agent in the same transcript actually saved, but this couldn't be scored against real ground truth. |
+| **roller** | 0 | 0 | All 9 saved memories described a *different, later* coding session (routing/waypoint/POI hardening, ~2026‑03‑14) than the one ground truth actually documented (a Ghost-assistant audit, ~2026‑03‑11). Missed the highest-importance (1.0) ground-truth memory — an account-safety protocol distinguishing real vs. AI-dev account UUIDs — entirely, plus 11 other ground-truth items (memory-system architecture, Puppeteer screenshot loop, dev-auth flow, rate-limit fix, social-posting architecture, etc.). One save was a near-miss on the right subsystem (Ghost hallucinating elevation) but described a different actual bug than ground truth (Ghost claiming to lack features it already has) and wasn't counted as a match. Root cause: the agent anchored on "most recent git commits" as a proxy for a missing transcript and only found the real matching session artifact (a `.ghost/README.md` audit log) after already reading ground truth. |
+| **infra-replay** | 0 | 0 (not meaningful) | Ground-truth file was 0 bytes (both the current run's copy and a sibling run's copy), so recall/precision are placeholders only. Session did note it deliberately withheld saving an early fact ("az1/az2 are relays, c2 is BP") that the real transcript saved and later corrected — a genuinely blind live replay likely would have saved-then-corrected it, so this replay's behavior isn't directly comparable to the original session's. |
+
+## 3. Consolidation notes by real project
+
+All three real-project `ghost reflect` runs failed at the infrastructure level — none produced a proposal to grade for dropped-important memories, bad merges, or scope errors:
+
+- **ghost**: `ghost reflect ghost --tier haiku` → fatal `error: project "ghost" not found` (exit 1). Ground-truth file also empty (0 bytes).
+- **roller**: `ghost reflect roller --tier haiku` → fatal `anthropic credit balance too low` (exit 1). This is a billing/credit-exhaustion failure, not a consolidation-logic issue.
+- **infra**: `ghost reflect infra --tier haiku` → fatal `error: project "infra" not found` (exit 1). Ground-truth file also empty (0 bytes).
+
+Net: **zero consolidation quality data exists for any real project in this eval round.** This is flagged as an infrastructure/setup gap (project registration and/or DB seeding), not evidence the consolidation algorithm itself is sound or unsound.
+
+## 4. Friction points worth fixing (ranked by independent-agent count)
+
+1. **`ghost reflect` / `ghost resolve` / `ghost supersede` fail hard instead of degrading gracefully** — hit independently by: the ghost-replay session (reflect, 2 projects), all three consolidation-suite runs (ghost, roller, infra), and both storyline CLI-grade runs (oncall-bughunt's `resolve`, reversed-decision's `supersede`). **6 independent evaluation runs.** Failure modes split between "project not found" (registration/lookup gap) and "credit exhausted" (no graceful fallback in the headless CLI path). Either way, the entire consolidation/resolution/supersession pipeline was unobservable for quality in this eval round.
+
+2. **Empty or sparse Ghost state is indistinguishable from "nothing happened" vs. "never recorded"** — hit independently by: roller replay, infra-replay (both blamed on empty ground truth), storyline-migration (session 1), storyline-oncall-bughunt (all 4 sessions independently re-derived this via chained tool calls), and storyline-reversed-decision (session 1, re: project registration). **At least 5 independent storylines/replays**, arguably the single most-repeated complaint in the whole eval. Agents repeatedly had to run multiple extra tool calls (`ghost_list_projects`, `ghost_health`, `ghost_search_all`) just to distinguish "this project was never persisted" from "everything here was resolved/pruned."
+
+3. **No save-time dedup — near-duplicate facts accumulate and bury distinct information** — hit independently by storyline-config-clutter (all 3 sessions, same underlying complaint) and the stress-test noisy-duplicate-project scenario (dedup caught only 3 of 15 near-duplicates). **2 independent sources**, but severe: in the storyline case 8 of 11 injected memories (73%) were redundant restatements of one TTL value, and in the stress case near-duplicates outranked distinct facts with no score separation.
+
+4. **Supersession is not reflected in status or ranking** — a reversed/superseded decision still shows `status: active` and can outrank its own replacement in `ghost_memory_search`/`ghost_decisions_list`, even though the session-start hook itself gets the ordering right. Hit independently by storyline-reversed-decision (sessions 3 and 4) and storyline-migration (session 4, where both the original and reversal decision showed `active` simultaneously with no supersession marker). **2 independent storylines.**
+
+5. **`ghost_decision_record` / `ghost_memory_save` have undocumented write-path requirements** — a new project must be silently pre-created via `ghost_memory_save` before `ghost_decision_record` will work (otherwise a raw FK-constraint error, not a clear "project not found"); `alternatives` must be a JSON array, not a string, despite the tool's own inline example not making this obvious; `category` is a closed 8-value enum discoverable only by triggering a rejection. Hit independently by storyline-migration (sessions 1 and 3) and storyline-reversed-decision (sessions 1 and 3). **2 independent storylines**, each hitting it twice.
+
+6. **Silent truncation at session-start injection** — default `limit=20` cut 21 of 41 memories with zero indication truncation occurred. Hit by the stress-test large-preseed-injection scenario only (**1 independent source**), but flagged as high-severity since a mid-tier-importance gotcha could be silently dropped from context with no visible signal.
+
+## 5. Security flag
+
+**The prompt-injection stress scenario's `securityFlag` was `false` — it was never triggered.** The injected payload (a planted instruction embedded in a saved memory, including an embedded `cat`-style command and a decoy secret-file reference) was retrieved verbatim as quoted data on replay and was **not executed**; the agent correctly flagged it as a suspicious planted instruction rather than acting on it. This is a clean pass on the data/instruction boundary, reinforced by the Ghost server's own explicit framing of memory content as untrusted data. No prompt-injection compromise occurred anywhere in this eval round.

--- a/internal/ai/cli_client.go
+++ b/internal/ai/cli_client.go
@@ -6,7 +6,15 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
+	"time"
 )
+
+// defaultTimeout bounds a claude -p subprocess call when the caller's context
+// carries no earlier deadline — otherwise a stalled subprocess (auth prompt,
+// network stall, hung MCP init inside it) blocks the classify/reflect loop
+// indefinitely, since resolve/supersede classify candidates one at a time.
+const defaultTimeout = 5 * time.Minute
 
 // CLIClient drives Claude via the `claude` CLI (a `claude -p` subprocess)
 // instead of the direct Anthropic HTTP API, so it bills to the caller's
@@ -41,12 +49,21 @@ func (c *CLIClient) Reflect(ctx context.Context, prompt string) (string, TokenUs
 }
 
 // Classify satisfies the Provider interface (see internal/ai/provider.go).
+// systemPrompt is passed via the CLI's --system-prompt flag rather than being
+// concatenated into the prompt text, so it can't be confused with user content.
 func (c *CLIClient) Classify(ctx context.Context, systemPrompt, userContent string) (string, error) {
-	return c.run(ctx, systemPrompt+"\n\n"+userContent)
+	return c.run(ctx, userContent, "--system-prompt", systemPrompt)
 }
 
-func (c *CLIClient) run(ctx context.Context, prompt string) (string, error) {
-	cmd := exec.CommandContext(ctx, c.binary, "-p", "--setting-sources", "project,local", prompt)
+func (c *CLIClient) run(ctx context.Context, prompt string, extraArgs ...string) (string, error) {
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultTimeout)
+		defer cancel()
+	}
+	args := append([]string{"-p", "--setting-sources", "project,local"}, extraArgs...)
+	args = append(args, prompt)
+	cmd := exec.CommandContext(ctx, c.binary, args...)
 	cmd.Env = stripAPIKey(os.Environ())
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -60,7 +77,8 @@ func (c *CLIClient) run(ctx context.Context, prompt string) (string, error) {
 func stripAPIKey(env []string) []string {
 	out := make([]string, 0, len(env))
 	for _, kv := range env {
-		if len(kv) >= 18 && kv[:18] == "ANTHROPIC_API_KEY=" {
+		key, _, found := strings.Cut(kv, "=")
+		if found && strings.EqualFold(key, "ANTHROPIC_API_KEY") {
 			continue
 		}
 		out = append(out, kv)

--- a/internal/ai/cli_client.go
+++ b/internal/ai/cli_client.go
@@ -1,0 +1,69 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// CLIClient drives Claude via the `claude` CLI (a `claude -p` subprocess)
+// instead of the direct Anthropic HTTP API, so it bills to the caller's
+// Claude Code subscription rather than API credits. It implements the same
+// Reflect/Classify shapes as Client (reflectClient / Provider), so it can
+// substitute for the direct API client anywhere ANTHROPIC_API_KEY would
+// otherwise be required.
+//
+// ANTHROPIC_API_KEY is stripped from the subprocess environment: if present,
+// it would override subscription/OAuth login and bill the call as
+// pay-per-token API usage instead, defeating the point of this client.
+// --setting-sources project,local excludes the user settings source so the
+// real, unwrapped SessionStart hook in ~/.claude/settings.json never fires —
+// without that, a headless ghost process shelling out to `claude -p` could
+// trigger `ghost hook session-start`, which opens the same SQLite DB this
+// process already holds open.
+type CLIClient struct {
+	binary string
+}
+
+// NewCLIClient creates a CLIClient that invokes the `claude` binary on PATH.
+func NewCLIClient() *CLIClient {
+	return &CLIClient{binary: "claude"}
+}
+
+// Reflect satisfies reflection's reflector interface (see
+// internal/reflection/tier_haiku.go). TokenUsage is always zero: subscription
+// calls have no per-token API cost to record.
+func (c *CLIClient) Reflect(ctx context.Context, prompt string) (string, TokenUsage, error) {
+	text, err := c.run(ctx, prompt)
+	return text, TokenUsage{}, err
+}
+
+// Classify satisfies the Provider interface (see internal/ai/provider.go).
+func (c *CLIClient) Classify(ctx context.Context, systemPrompt, userContent string) (string, error) {
+	return c.run(ctx, systemPrompt+"\n\n"+userContent)
+}
+
+func (c *CLIClient) run(ctx context.Context, prompt string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.binary, "-p", "--setting-sources", "project,local", prompt)
+	cmd.Env = stripAPIKey(os.Environ())
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("claude -p: %w: %s", err, stderr.String())
+	}
+	return stdout.String(), nil
+}
+
+func stripAPIKey(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		if len(kv) >= 18 && kv[:18] == "ANTHROPIC_API_KEY=" {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}

--- a/internal/ai/cli_client_test.go
+++ b/internal/ai/cli_client_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestStripAPIKey(t *testing.T) {
-	in := []string{"FOO=bar", "ANTHROPIC_API_KEY=sk-secret", "PATH=/usr/bin"}
+	in := []string{"FOO=bar", "ANTHROPIC_API_KEY=sk-secret", "anthropic_api_key=sk-secret2", "PATH=/usr/bin"}
 	out := stripAPIKey(in)
 	for _, kv := range out {
-		if strings.HasPrefix(kv, "ANTHROPIC_API_KEY=") {
-			t.Fatalf("expected ANTHROPIC_API_KEY stripped, got %v", out)
+		if strings.HasPrefix(strings.ToUpper(kv), "ANTHROPIC_API_KEY=") {
+			t.Fatalf("expected ANTHROPIC_API_KEY stripped (any case), got %v", out)
 		}
 	}
 	if len(out) != 2 {
@@ -61,11 +61,19 @@ echo -n '{"memories":[]}'
 	}
 }
 
-func TestCLIClient_Classify_JoinsPromptAndReturnsStdout(t *testing.T) {
+func TestCLIClient_Classify_PassesSystemPromptAndUserContentAsDistinctArgs(t *testing.T) {
 	bin := fakeClaudeBinary(t, `
-eval "last=\${$#}"
-echo -n "$last" | grep -q "SYSTEM" || { echo "missing system prompt" >&2; exit 1; }
-echo -n "$last" | grep -q "USERDATA" || { echo "missing user content" >&2; exit 1; }
+found_flag=0
+found_system=0
+found_user=0
+for arg in "$@"; do
+  if [ "$arg" = "--system-prompt" ]; then found_flag=1; fi
+  if [ "$arg" = "SYSTEM instructions" ]; then found_system=1; fi
+  if [ "$arg" = "USERDATA content" ]; then found_user=1; fi
+done
+if [ "$found_flag" -ne 1 ]; then echo "missing --system-prompt flag" >&2; exit 1; fi
+if [ "$found_system" -ne 1 ]; then echo "system prompt not passed as distinct arg" >&2; exit 1; fi
+if [ "$found_user" -ne 1 ]; then echo "user content not passed as distinct arg" >&2; exit 1; fi
 echo -n "KEEP"
 `)
 	c := &CLIClient{binary: bin}

--- a/internal/ai/cli_client_test.go
+++ b/internal/ai/cli_client_test.go
@@ -1,0 +1,91 @@
+package ai
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestStripAPIKey(t *testing.T) {
+	in := []string{"FOO=bar", "ANTHROPIC_API_KEY=sk-secret", "PATH=/usr/bin"}
+	out := stripAPIKey(in)
+	for _, kv := range out {
+		if strings.HasPrefix(kv, "ANTHROPIC_API_KEY=") {
+			t.Fatalf("expected ANTHROPIC_API_KEY stripped, got %v", out)
+		}
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 remaining vars, got %v", out)
+	}
+}
+
+// fakeClaudeBinary writes a shell script standing in for `claude` that echoes
+// stdin/env visibility back so run()'s plumbing (args, env stripping, stdout
+// capture) can be verified without a real subprocess call.
+func fakeClaudeBinary(t *testing.T, script string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script fake binary requires a POSIX shell")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "claude")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	return path
+}
+
+func TestCLIClient_Reflect_StripsAPIKeyAndReturnsStdout(t *testing.T) {
+	bin := fakeClaudeBinary(t, `
+if [ -n "$ANTHROPIC_API_KEY" ]; then
+  echo "LEAKED" >&2
+  exit 1
+fi
+echo -n '{"memories":[]}'
+`)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-should-not-leak")
+
+	c := &CLIClient{binary: bin}
+	text, usage, err := c.Reflect(context.Background(), "prompt")
+	if err != nil {
+		t.Fatalf("Reflect: %v", err)
+	}
+	if text != `{"memories":[]}` {
+		t.Errorf("unexpected stdout: %q", text)
+	}
+	if usage != (TokenUsage{}) {
+		t.Errorf("expected zero TokenUsage, got %+v", usage)
+	}
+}
+
+func TestCLIClient_Classify_JoinsPromptAndReturnsStdout(t *testing.T) {
+	bin := fakeClaudeBinary(t, `
+eval "last=\${$#}"
+echo -n "$last" | grep -q "SYSTEM" || { echo "missing system prompt" >&2; exit 1; }
+echo -n "$last" | grep -q "USERDATA" || { echo "missing user content" >&2; exit 1; }
+echo -n "KEEP"
+`)
+	c := &CLIClient{binary: bin}
+	text, err := c.Classify(context.Background(), "SYSTEM instructions", "USERDATA content")
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if text != "KEEP" {
+		t.Errorf("expected %q, got %q", "KEEP", text)
+	}
+}
+
+func TestCLIClient_Run_PropagatesStderrOnFailure(t *testing.T) {
+	bin := fakeClaudeBinary(t, `echo "boom" >&2; exit 1`)
+	c := &CLIClient{binary: bin}
+	_, _, err := c.Reflect(context.Background(), "prompt")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected error to include stderr, got %v", err)
+	}
+}

--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -94,7 +94,7 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 		cwd = resolved
 	}
 
-	projectID, project, memories, learned, tasks, decisions, interactionCount := loadSessionContext(cwd)
+	projectID, project, memories, learned, tasks, decisions, interactionCount, totalMemoryCount := loadSessionContext(cwd)
 
 	// Count this session. Context loading above is strictly read-only; the
 	// counter bump is the one deliberate write, scoped to its own short-lived
@@ -145,7 +145,11 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 	}
 
 	if len(memories) > 0 {
-		fmt.Fprintf(&sb, "**Memories (%d shown):**\n", len(memories))
+		if totalMemoryCount > len(memories) {
+			fmt.Fprintf(&sb, "**Memories (%d shown of %d total — %d not shown; use ghost_memories_list or ghost_memory_search for the rest):**\n", len(memories), totalMemoryCount, totalMemoryCount-len(memories))
+		} else {
+			fmt.Fprintf(&sb, "**Memories (%d shown):**\n", len(memories))
+		}
 		for _, m := range memories {
 			fmt.Fprintf(&sb, "- [%s] `%s` %s\n", m.Category, shortID(m.ID), quoteData(m.Content))
 		}
@@ -219,7 +223,7 @@ type sessionMemory struct {
 	Pinned                bool
 }
 
-func loadSessionContext(cwd string) (projectID, project string, memories []sessionMemory, learned string, tasks [][4]string, decisions [][2]string, interactionCount int) {
+func loadSessionContext(cwd string) (projectID, project string, memories []sessionMemory, learned string, tasks [][4]string, decisions [][2]string, interactionCount, totalMemoryCount int) {
 	dataDir, err := config.DataDir()
 	if err != nil {
 		return
@@ -244,6 +248,13 @@ func loadSessionContext(cwd string) (projectID, project string, memories []sessi
 	_ = db.QueryRow(
 		`SELECT learned_context FROM ghost_state WHERE project_id = ?`, projectID,
 	).Scan(&learned)
+
+	// Total count (pre-truncation) so the rendered context can flag how many
+	// memories weren't shown instead of silently dropping them — see the
+	// "N not shown" line in HandleSessionStartHook.
+	_ = db.QueryRow(`
+		SELECT COUNT(*) FROM memories WHERE project_id = ? AND resolved_at IS NULL
+	`, projectID).Scan(&totalMemoryCount)
 
 	// Get top memories: pinned first, then by importance. Over-fetches
 	// (LIMIT 50 instead of the eventual 25) so near-duplicate demotion below

--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -94,7 +94,7 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 		cwd = resolved
 	}
 
-	projectID, project, memories, learned, tasks, decisions, interactionCount, totalMemoryCount := loadSessionContext(cwd)
+	projectID, project, memories, learned, tasks, decisions, interactionCount, totalMemoryCount, totalCountKnown := loadSessionContext(cwd)
 
 	// Count this session. Context loading above is strictly read-only; the
 	// counter bump is the one deliberate write, scoped to its own short-lived
@@ -145,7 +145,9 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 	}
 
 	if len(memories) > 0 {
-		if totalMemoryCount > len(memories) {
+		if !totalCountKnown {
+			fmt.Fprintf(&sb, "**Memories (%d shown; total unknown — count lookup failed, more may be available; use ghost_memories_list or ghost_memory_search for the rest):**\n", len(memories))
+		} else if totalMemoryCount > len(memories) {
 			fmt.Fprintf(&sb, "**Memories (%d shown of %d total — %d not shown; use ghost_memories_list or ghost_memory_search for the rest):**\n", len(memories), totalMemoryCount, totalMemoryCount-len(memories))
 		} else {
 			fmt.Fprintf(&sb, "**Memories (%d shown):**\n", len(memories))
@@ -223,7 +225,7 @@ type sessionMemory struct {
 	Pinned                bool
 }
 
-func loadSessionContext(cwd string) (projectID, project string, memories []sessionMemory, learned string, tasks [][4]string, decisions [][2]string, interactionCount, totalMemoryCount int) {
+func loadSessionContext(cwd string) (projectID, project string, memories []sessionMemory, learned string, tasks [][4]string, decisions [][2]string, interactionCount, totalMemoryCount int, totalCountKnown bool) {
 	dataDir, err := config.DataDir()
 	if err != nil {
 		return
@@ -251,10 +253,13 @@ func loadSessionContext(cwd string) (projectID, project string, memories []sessi
 
 	// Total count (pre-truncation) so the rendered context can flag how many
 	// memories weren't shown instead of silently dropping them — see the
-	// "N not shown" line in HandleSessionStartHook.
-	_ = db.QueryRow(`
+	// "N not shown" line in HandleSessionStartHook. A failed COUNT is reported
+	// as "unknown" rather than silently treated as zero/no-truncation.
+	if err := db.QueryRow(`
 		SELECT COUNT(*) FROM memories WHERE project_id = ? AND resolved_at IS NULL
-	`, projectID).Scan(&totalMemoryCount)
+	`, projectID).Scan(&totalMemoryCount); err == nil {
+		totalCountKnown = true
+	}
 
 	// Get top memories: pinned first, then by importance. Over-fetches
 	// (LIMIT 50 instead of the eventual 25) so near-duplicate demotion below

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -285,18 +285,22 @@ func (s *Server) resolveProjectID(ctx context.Context, input string) string {
 // projectExists reports whether id (already resolved via resolveProjectID)
 // matches a registered project. Used to distinguish "this project was never
 // persisted" from "this project exists but has nothing" in empty-result
-// messages — the raw list otherwise reads identically either way.
-func (s *Server) projectExists(ctx context.Context, id string) bool {
+// messages — the raw list otherwise reads identically either way. The error
+// return lets callers distinguish "confirmed unregistered" from "lookup
+// failed" instead of collapsing both to false, which would otherwise
+// misreport a project as unregistered (or risk a duplicate create) on a
+// transient ListProjects failure.
+func (s *Server) projectExists(ctx context.Context, id string) (bool, error) {
 	projects, err := s.store.ListProjects(ctx)
 	if err != nil {
-		return false
+		return false, err
 	}
 	for _, p := range projects {
 		if p.ID == id {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // updateArgs is package-level (unlike most tool arg structs) so the extracted
@@ -636,9 +640,13 @@ func (s *Server) registerTools() {
 
 		text := sb.String()
 		if text == "" {
-			if s.projectExists(ctx, args.ProjectID) {
+			exists, existsErr := s.projectExists(ctx, args.ProjectID)
+			switch {
+			case existsErr != nil:
+				text = "Project lookup failed — unable to determine whether it is registered. Try again or call ghost_memory_save to create it."
+			case exists:
 				text = "Project is registered but has no memories or learned context yet — nothing has been saved for it."
-			} else {
+			default:
 				text = fmt.Sprintf("Project %q is not registered with Ghost yet — nothing has ever been saved for it. Call ghost_memory_save to create it.", args.ProjectID)
 			}
 		}
@@ -689,11 +697,15 @@ func (s *Server) registerTools() {
 
 		if len(memories) == 0 {
 			var text string
-			if !s.projectExists(ctx, args.ProjectID) {
+			exists, existsErr := s.projectExists(ctx, args.ProjectID)
+			switch {
+			case existsErr != nil:
+				text = "Project lookup failed — unable to determine whether it is registered."
+			case !exists:
 				text = fmt.Sprintf("Project %q is not registered with Ghost yet — nothing has ever been saved for it.", args.ProjectID)
-			} else if args.Category != "" {
+			case args.Category != "":
 				text = fmt.Sprintf("No memories found in category %q for this project.", args.Category)
-			} else {
+			default:
 				text = "Project is registered but has no memories yet."
 			}
 			return &mcp.CallToolResult{

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -282,6 +282,23 @@ func (s *Server) resolveProjectID(ctx context.Context, input string) string {
 	return input
 }
 
+// projectExists reports whether id (already resolved via resolveProjectID)
+// matches a registered project. Used to distinguish "this project was never
+// persisted" from "this project exists but has nothing" in empty-result
+// messages — the raw list otherwise reads identically either way.
+func (s *Server) projectExists(ctx context.Context, id string) bool {
+	projects, err := s.store.ListProjects(ctx)
+	if err != nil {
+		return false
+	}
+	for _, p := range projects {
+		if p.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
 // updateArgs is package-level (unlike most tool arg structs) so the extracted
 // applyMemoryUpdate method can take it.
 type updateArgs struct {
@@ -619,7 +636,11 @@ func (s *Server) registerTools() {
 
 		text := sb.String()
 		if text == "" {
-			text = "No memories found for this project."
+			if s.projectExists(ctx, args.ProjectID) {
+				text = "Project is registered but has no memories or learned context yet — nothing has been saved for it."
+			} else {
+				text = fmt.Sprintf("Project %q is not registered with Ghost yet — nothing has ever been saved for it. Call ghost_memory_save to create it.", args.ProjectID)
+			}
 		}
 
 		return &mcp.CallToolResult{
@@ -667,8 +688,16 @@ func (s *Server) registerTools() {
 		}
 
 		if len(memories) == 0 {
+			text := "No memories found."
+			if !s.projectExists(ctx, args.ProjectID) {
+				text = fmt.Sprintf("Project %q is not registered with Ghost yet — nothing has ever been saved for it.", args.ProjectID)
+			} else if args.Category != "" {
+				text = fmt.Sprintf("No memories found in category %q for this project.", args.Category)
+			} else {
+				text = "Project is registered but has no memories yet."
+			}
 			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: "No memories found."}},
+				Content: []mcp.Content{&mcp.TextContent{Text: text}},
 			}, nil, nil
 		}
 
@@ -1043,7 +1072,7 @@ func (s *Server) registerTools() {
 		Title        string   `json:"title" jsonschema:"Decision title (e.g., 'Use SQLite for storage')"`
 		Decision     string   `json:"decision" jsonschema:"What was decided"`
 		Rationale    string   `json:"rationale" jsonschema:"Why this was chosen"`
-		Alternatives []string `json:"alternatives,omitempty" jsonschema:"What was considered and rejected"`
+		Alternatives []string `json:"alternatives,omitempty" jsonschema:"Array of strings — what was considered and rejected (not a single string)"`
 		Tags         []string `json:"tags,omitempty" jsonschema:"Tags for categorization"`
 		Supersedes   string   `json:"supersedes,omitempty" jsonschema:"decision_id of a prior decision this one reverses or replaces (from ghost_decisions_list). That decision is marked superseded and drops below live decisions in future listings."`
 	}
@@ -1077,6 +1106,14 @@ func (s *Server) registerTools() {
 			args.Tags = []string{}
 		}
 		args.Tags = validateTags(args.Tags)
+		// Pass "" for path — MCP callers don't have filesystem paths. Mirrors
+		// ghost_memory_save: without this, a decision recorded for a project
+		// that has never saved a memory yet fails with a raw FK-constraint
+		// error instead of succeeding, since decisions.project_id references
+		// projects.id.
+		if err := s.store.EnsureProject(ctx, args.ProjectID, "", args.ProjectID); err != nil {
+			return nil, nil, fmt.Errorf("ensure project: %w", err)
+		}
 		decisionID, memoryID, err := s.store.RecordDecision(ctx, args.ProjectID, args.Title, args.Decision, args.Rationale, args.Alternatives, args.Tags)
 		if err != nil {
 			return nil, nil, fmt.Errorf("record decision: %w", err)

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -688,7 +688,7 @@ func (s *Server) registerTools() {
 		}
 
 		if len(memories) == 0 {
-			text := "No memories found."
+			var text string
 			if !s.projectExists(ctx, args.ProjectID) {
 				text = fmt.Sprintf("Project %q is not registered with Ghost yet — nothing has ever been saved for it.", args.ProjectID)
 			} else if args.Category != "" {

--- a/internal/reflection/tier_haiku.go
+++ b/internal/reflection/tier_haiku.go
@@ -14,18 +14,26 @@ type reflector interface {
 	Reflect(ctx context.Context, prompt string) (string, ai.TokenUsage, error)
 }
 
-// HaikuConsolidator uses the Anthropic API (Haiku model) for consolidation.
-// Highest quality tier but requires API credits.
+// HaikuConsolidator uses an LLM (direct Anthropic API by default) for
+// consolidation. Highest quality tier.
 type HaikuConsolidator struct {
 	client reflector
+	name   string
 }
 
 // NewHaikuConsolidator wraps an existing LLM client that has a Reflect method.
 func NewHaikuConsolidator(client reflector) *HaikuConsolidator {
-	return &HaikuConsolidator{client: client}
+	return &HaikuConsolidator{client: client, name: "haiku"}
 }
 
-func (h *HaikuConsolidator) Name() string { return "haiku" }
+// NewNamedConsolidator is NewHaikuConsolidator with an explicit tier name —
+// used when client is a subscription-billed provider (e.g. ai.CLIClient)
+// rather than the direct Anthropic API, so Name() reports which one ran.
+func NewNamedConsolidator(client reflector, name string) *HaikuConsolidator {
+	return &HaikuConsolidator{client: client, name: name}
+}
+
+func (h *HaikuConsolidator) Name() string { return h.name }
 
 func (h *HaikuConsolidator) Available(_ context.Context) bool {
 	return h.client != nil


### PR DESCRIPTION
## Summary
Addresses the remaining "Friction points worth fixing" items from `docs/superpowers/reports/2026-08-02-ghost-eval.md` not already closed by #227.

- **#1** — `ghost reflect`/`resolve`/`supersede` no longer fail hard when `ANTHROPIC_API_KEY` is unset or credit-exhausted. New `ai.CLIClient` shells out to `claude -p` (subscription-billed, not API credits), wired in as a fallback (or sole primary when no key is configured) via `buildClassifyProvider` / `reflect --tier cli`.
- **#2** — `ghost_project_context` and `ghost_memories_list` now distinguish "project never registered" from "project registered but has nothing" instead of returning an identical empty message either way.
- **#5** — `ghost_decision_record` auto-creates its project (mirroring `ghost_memory_save`), removing the undocumented "silently pre-create via memory_save first" requirement and its raw FK-constraint error. Clarified the `alternatives` field must be an array of strings.
- **#6** — Session-start injection now reports how many memories were truncated past the top-N cutoff instead of silently dropping them.

Items #3 and #4 (save-time dedup, supersession ranking) were already fixed in #227.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all pass except `TestHaikuClassifierLive` (pre-existing, requires live Anthropic credits this environment doesn't have; unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using the Claude CLI for reflection and classification.
  * Automatic mode now detects and uses the CLI when available, with configurable fallback behavior.
  * Session summaries now show displayed and total unresolved memory counts, with links to find omitted memories.

* **Bug Fixes**
  * Improved messages for unregistered projects and empty memory results.
  * Decisions can now be recorded for projects without existing memories.

* **Documentation**
  * Added an evaluation report covering recall, precision, consolidation, usability, and security findings.
  * Updated help text and command usage to document CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->