### PR TITLE
fix: close task-update race, missing ghost_resolve permission, LIKE wildcard bug

### DIFF
--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -361,9 +361,13 @@ func loadSessionContext(cwd string) (projectID, project string, memories []sessi
 // Returns ("", "") when no project matches.
 func lookupProject(db *sql.DB, cwd string) (id, name string) {
 	cwdBase := filepath.Base(cwd)
+	// path is escaped before use as a LIKE pattern so a literal '%' or '_' in
+	// a project's path (e.g. a directory named "foo_bar") can't act as an
+	// unintended wildcard and false-match an unrelated cwd.
 	row := db.QueryRow(`
 		SELECT id, name FROM projects
-		WHERE ((? = path OR ? LIKE path || '/%') AND LENGTH(path) > 10)
+		WHERE ((? = path OR ? LIKE REPLACE(REPLACE(REPLACE(path, '\', '\\'), '%', '\%'), '_', '\_') || '/%' ESCAPE '\')
+		       AND LENGTH(path) > 10)
 		   OR name = ?
 		ORDER BY LENGTH(path) DESC LIMIT 1
 	`, cwd, cwd, cwdBase)

--- a/internal/mcpinit/hook_test.go
+++ b/internal/mcpinit/hook_test.go
@@ -100,6 +100,27 @@ func TestLookupProject_NoMatch(t *testing.T) {
 	}
 }
 
+// TestLookupProject_PathWithLikeWildcards is the regression test for a project
+// path containing a literal '%' or '_': those must not act as unintended LIKE
+// wildcards and false-match an unrelated sibling directory.
+func TestLookupProject_PathWithLikeWildcards(t *testing.T) {
+	db := openTestDB(t)
+	insertProject(t, db, "abc123", "/home/wayne/git/foo_bar", "foo_bar")
+
+	// Without escaping, "foo_bar/%" as a LIKE pattern would also match
+	// "fooXbar/anything" since '_' matches any single character.
+	id, name := lookupProject(db, "/home/wayne/git/fooXbar/sub")
+	if id != "" || name != "" {
+		t.Errorf("unescaped underscore false match: got id=%q name=%q, want no match", id, name)
+	}
+
+	// The real subdirectory should still match correctly.
+	id, name = lookupProject(db, "/home/wayne/git/foo_bar/sub")
+	if id != "abc123" || name != "foo_bar" {
+		t.Errorf("exact underscore path: got id=%q name=%q, want abc123/foo_bar", id, name)
+	}
+}
+
 // openFileTestDB creates a real on-disk SQLite DB (needed for mode=ro callers like loadGlobalMemories).
 func openFileTestDB(t *testing.T) (db *sql.DB, path string) {
 	t.Helper()

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -287,8 +287,8 @@ func TestShellQuote(t *testing.T) {
 
 func TestGhostPermissions_Complete(t *testing.T) {
 	// Verify the canonical list has the expected count.
-	if len(ghostPermissions) != 18 {
-		t.Errorf("expected 18 ghost permissions, got %d", len(ghostPermissions))
+	if len(ghostPermissions) != 19 {
+		t.Errorf("expected 19 ghost permissions, got %d", len(ghostPermissions))
 	}
 
 	// All should start with the correct prefix.

--- a/internal/mcpinit/settings.go
+++ b/internal/mcpinit/settings.go
@@ -23,6 +23,7 @@ var ghostPermissions = []string{
 	"mcp__ghost__ghost_memory_search",
 	"mcp__ghost__ghost_memory_update",
 	"mcp__ghost__ghost_project_context",
+	"mcp__ghost__ghost_resolve",
 	"mcp__ghost__ghost_save_global",
 	"mcp__ghost__ghost_search_all",
 	"mcp__ghost__ghost_task_complete",

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -1298,14 +1298,7 @@ func (s *Server) registerTools() {
 			return nil, nil, fmt.Errorf("task_id is required")
 		}
 
-		// Fetch current task to fill in omitted fields (prevents zero-value clobber).
-		current, err := s.store.GetTask(ctx, args.TaskID)
-		if err != nil {
-			return nil, nil, fmt.Errorf("task not found: %w", err)
-		}
-
-		// status is optional — omitting it preserves the current value.
-		status := current.Status
+		var status *string
 		if args.Status != "" {
 			validStatuses := map[string]bool{
 				"pending": true, "active": true, "blocked": true, "done": true,
@@ -1313,27 +1306,26 @@ func (s *Server) registerTools() {
 			if !validStatuses[args.Status] {
 				return nil, nil, fmt.Errorf("invalid status %q — must be one of: pending, active, blocked, done", args.Status)
 			}
-			status = args.Status
+			status = &args.Status
 		}
 
-		priority := current.Priority
-		if args.Priority != nil {
-			priority = *args.Priority
-			if priority < 0 || priority > 4 {
-				priority = 2
-			}
+		if args.Priority != nil && (*args.Priority < 0 || *args.Priority > 4) {
+			normalized := 2
+			args.Priority = &normalized
 		}
-		description := current.Description
 		if args.Description != nil {
-			description = *args.Description
+			truncated := truncateUTF8(*args.Description, maxContentLen)
+			args.Description = &truncated
 		}
 
-		// Pass the resolved full ID, not the caller's (possibly prefix) input,
-		// so the fetch above and the write below can't hit different tasks.
-		if err := s.store.UpdateTask(ctx, current.ID, status, priority, description); err != nil {
+		// UpdateTask does its own read-merge-write under one lock, so a
+		// concurrent update between a separate read and this write can't be
+		// silently overwritten.
+		updated, err := s.store.UpdateTask(ctx, args.TaskID, status, args.Priority, args.Description)
+		if err != nil {
 			return nil, nil, fmt.Errorf("update task: %w", err)
 		}
-		s.notifyProjectResource(ctx, current.ProjectID, "tasks")
+		s.notifyProjectResource(ctx, updated.ProjectID, "tasks")
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "Task updated."}},
 		}, nil, nil

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -605,8 +605,8 @@ func TestTaskUpdate_EmptyStatusPreservesCurrentStatus(t *testing.T) {
 		t.Fatalf("CreateTask: %v", err)
 	}
 
-	// Default status is "pending". Update priority only (no status change).
-	// The fixed handler fetches current task and uses current.Status when args.Status == "".
+	// Default status is "pending". Update priority only (no status change) —
+	// UpdateTask preserves status/description internally when passed nil.
 	current, err := store.GetTask(ctx, id)
 	if err != nil {
 		t.Fatalf("GetTask: %v", err)
@@ -615,8 +615,8 @@ func TestTaskUpdate_EmptyStatusPreservesCurrentStatus(t *testing.T) {
 		t.Fatalf("expected initial status=pending, got %q", current.Status)
 	}
 
-	// Simulate what the fixed ghost_task_update handler does: use current status.
-	if err := store.UpdateTask(ctx, id, current.Status, 1, current.Description); err != nil {
+	priority := 1
+	if _, err := store.UpdateTask(ctx, id, nil, &priority, nil); err != nil {
 		t.Fatalf("UpdateTask: %v", err)
 	}
 

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1695,7 +1695,8 @@ func TestStoreTasks(t *testing.T) {
 	}
 
 	// Update a task.
-	if err := s.UpdateTask(ctx, id2, "active", 1, "Updated description"); err != nil {
+	updStatus, updPriority, updDesc := "active", 1, "Updated description"
+	if _, err := s.UpdateTask(ctx, id2, &updStatus, &updPriority, &updDesc); err != nil {
 		t.Fatalf("UpdateTask: %v", err)
 	}
 
@@ -1731,7 +1732,8 @@ func TestStoreTaskIDPrefix(t *testing.T) {
 	}
 
 	// UpdateTask and CompleteTask resolve prefixes too.
-	if err := s.UpdateTask(ctx, prefix, "active", 1, "updated via prefix"); err != nil {
+	prefixStatus, prefixPriority, prefixDesc := "active", 1, "updated via prefix"
+	if _, err := s.UpdateTask(ctx, prefix, &prefixStatus, &prefixPriority, &prefixDesc); err != nil {
 		t.Fatalf("UpdateTask by prefix: %v", err)
 	}
 	got, err = s.GetTask(ctx, fullID)
@@ -1783,7 +1785,8 @@ func TestStoreTaskIDPrefix(t *testing.T) {
 	if err := s.CompleteTask(ctx, "ZZZZ9999", ""); err == nil || !strings.Contains(err.Error(), "task not found") {
 		t.Errorf("CompleteTask unknown: want not-found error, got %v", err)
 	}
-	if err := s.UpdateTask(ctx, "ZZZZ9999", "active", 1, ""); err == nil || !strings.Contains(err.Error(), "task not found") {
+	unknownStatus, unknownPriority, unknownDesc := "active", 1, ""
+	if _, err := s.UpdateTask(ctx, "ZZZZ9999", &unknownStatus, &unknownPriority, &unknownDesc); err == nil || !strings.Contains(err.Error(), "task not found") {
 		t.Errorf("UpdateTask unknown: want not-found error, got %v", err)
 	}
 

--- a/internal/memory/tasks.go
+++ b/internal/memory/tasks.go
@@ -162,23 +162,53 @@ func (s *Store) GetTask(ctx context.Context, taskID string) (Task, error) {
 	return t, nil
 }
 
-// UpdateTask updates a task's status, priority, or description. Accepts a
-// full task ID or a unique prefix.
-func (s *Store) UpdateTask(ctx context.Context, taskID, status string, priority int, description string) error {
+// UpdateTask merges the caller's optional fields onto the current row and
+// writes the result under a single lock, closing the check-then-write race
+// where a separate get-then-update could clobber a concurrent update made
+// between the read and the write (see UpdateMemory for the same pattern).
+// status, priority, and description are nil to preserve the current value.
+// Accepts a full task ID or a unique prefix. Returns the task as it stood
+// after the merge, so callers don't need a separate read to get ProjectID
+// or the resolved field values.
+func (s *Store) UpdateTask(ctx context.Context, taskID string, status *string, priority *int, description *string) (Task, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	id, err := s.resolveTaskID(ctx, taskID)
 	if err != nil {
-		return err
+		return Task{}, err
 	}
 
-	_, err = s.db.ExecContext(ctx, `
+	var t Task
+	err = s.db.QueryRowContext(ctx, `
+		SELECT id, project_id, title, description, status, priority,
+		       COALESCE(blocked_by, ''), COALESCE(branch, ''), COALESCE(pr_number, 0),
+		       COALESCE(notes, ''), created_at, updated_at, COALESCE(completed_at, '')
+		FROM tasks WHERE id = ?
+	`, id).Scan(
+		&t.ID, &t.ProjectID, &t.Title, &t.Description, &t.Status,
+		&t.Priority, &t.BlockedBy, &t.Branch, &t.PRNumber, &t.Notes,
+		&t.CreatedAt, &t.UpdatedAt, &t.CompletedAt,
+	)
+	if err != nil {
+		return Task{}, fmt.Errorf("get task: %w", err)
+	}
+
+	if status != nil {
+		t.Status = *status
+	}
+	if priority != nil {
+		t.Priority = *priority
+	}
+	if description != nil {
+		t.Description = *description
+	}
+
+	if _, err := s.db.ExecContext(ctx, `
 		UPDATE tasks SET status = ?, priority = ?, description = ?, updated_at = datetime('now')
 		WHERE id = ?
-	`, status, priority, description, id)
-	if err != nil {
-		return fmt.Errorf("update task: %w", err)
+	`, t.Status, t.Priority, t.Description, id); err != nil {
+		return Task{}, fmt.Errorf("update task: %w", err)
 	}
-	return nil
+	return t, nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -60,7 +60,7 @@ type MemoryStore interface {
 	GetTask(ctx context.Context, taskID string) (memory.Task, error)
 	ListTasks(ctx context.Context, projectID, status string, limit int) ([]memory.Task, error)
 	CompleteTask(ctx context.Context, taskID, notes string) error
-	UpdateTask(ctx context.Context, taskID, status string, priority int, description string) error
+	UpdateTask(ctx context.Context, taskID string, status *string, priority *int, description *string) (memory.Task, error)
 
 	// Decisions
 	RecordDecision(ctx context.Context, projectID, title, decision, rationale string, alternatives, tags []string) (decisionID, memoryID string, err error)


### PR DESCRIPTION
## Summary
From this session's function audit (4 parallel background agents over mcpserver/mcpinit/memory/ai):

- **`ghost_task_update` lost-update race**: the handler did a separate `GetTask` read then `UpdateTask` write; a concurrent update landing between the two would be silently clobbered. `UpdateTask` now takes optional pointer fields and does the read-merge-write under a single lock, mirroring the pattern `UpdateMemory` already established for the same reason.
- **`ghost_task_update` didn't truncate `description`** the way `ghost_task_create` does — now consistent.
- **`ghost_resolve` was missing from the MCP permissions allowlist** — the tool exists and is callable but wasn't in the auto-approved list.
- **`lookupProject`'s SQL LIKE pattern wasn't escaped**: a project path containing a literal `%` or `_` (e.g. `foo_bar`) could wildcard-match an unrelated sibling directory (`foo1bar`). Now escaped with `ESCAPE '\'`.

Other audit findings (perf/scale items — N+1 queries, brute-force vector scans, TOCTOU in obsidian sync, etc.) were triaged but left for a separate follow-up since they're not correctness bugs.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all green except `TestHaikuClassifierLive`, a pre-existing live-API test that only runs with real credits configured (unrelated to this change)
- [x] Added `TestLookupProject_PathWithLikeWildcards` regression test
- [x] Updated existing `UpdateTask` callers/tests to the new pointer-based signature