### PR TITLE
feat(memory): make Upsert non-destructive on near-duplicate match

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -365,7 +365,7 @@ Flags:
 			fmt.Fprintf(os.Stderr, "warning: ensure _global project: %v\n", err)
 		}
 		for _, m := range globalMems {
-			if _, _, err := store.Upsert(ctx, "_global", m.Category, m.Content, "reflection", m.Importance, m.Tags); err != nil {
+			if _, _, _, err := store.Upsert(ctx, "_global", m.Category, m.Content, "reflection", m.Importance, m.Tags); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: upsert global memory: %v\n", err)
 			}
 		}

--- a/internal/claudeimport/import.go
+++ b/internal/claudeimport/import.go
@@ -218,11 +218,30 @@ func Import(ctx context.Context, store provider.MemoryStore, projectID, projectP
 }
 
 // importFromDir imports all Claude Code memories from a specific directory.
+//
+// Dedup guard: this is the ONLY caller in the codebase that needs re-runs to
+// be true no-ops (ghost mcp init documents itself as idempotent and safe to
+// re-run, and calls this unconditionally every time). Store.Upsert itself is
+// intentionally non-destructive — a duplicate save always creates a new,
+// linked row rather than silently merging, since ordinary ghost_memory_save
+// callers must never have content dropped. So the guard belongs here: before
+// importing a file's content, skip it if that exact content already exists
+// for this project. This keeps re-imports of previously-seen Claude Code
+// memory files from doubling the project's memory count on every init.
 func importFromDir(ctx context.Context, store provider.MemoryStore, projectID, dir string, logger *slog.Logger) (int, error) {
 	cleanDir := filepath.Clean(dir)
 	entries, err := os.ReadDir(cleanDir)
 	if err != nil {
 		return 0, fmt.Errorf("read claude memory dir: %w", err)
+	}
+
+	existing, err := store.GetAll(ctx, projectID, 100000)
+	if err != nil {
+		logger.Warn("claude import: could not load existing content for dedup guard", "error", err)
+	}
+	seen := make(map[string]bool, len(existing))
+	for _, m := range existing {
+		seen[m.Content] = true
 	}
 
 	var imported int
@@ -240,12 +259,16 @@ func importFromDir(ctx context.Context, store provider.MemoryStore, projectID, d
 		if skip {
 			continue
 		}
+		if seen[content] {
+			continue
+		}
 
 		_, _, _, err = store.Upsert(ctx, projectID, category, content, source, importance, importTags)
 		if err != nil {
 			logger.Warn("claude import: upsert failed", "file", entry.Name(), "error", err)
 			continue
 		}
+		seen[content] = true
 		imported++
 	}
 

--- a/internal/claudeimport/import.go
+++ b/internal/claudeimport/import.go
@@ -241,7 +241,7 @@ func importFromDir(ctx context.Context, store provider.MemoryStore, projectID, d
 			continue
 		}
 
-		_, _, err = store.Upsert(ctx, projectID, category, content, source, importance, importTags)
+		_, _, _, err = store.Upsert(ctx, projectID, category, content, source, importance, importTags)
 		if err != nil {
 			logger.Warn("claude import: upsert failed", "file", entry.Name(), "error", err)
 			continue

--- a/internal/claudeimport/import_test.go
+++ b/internal/claudeimport/import_test.go
@@ -320,23 +320,27 @@ Should be skipped.`)
 		t.Errorf("store count = %d, want >= 2", count)
 	}
 
-	// Re-importing is not idempotent by row count anymore: Upsert is
-	// non-destructive, so a re-imported duplicate gets its own row (linked
-	// to the original via a 'duplicate' relation) instead of merging into
-	// it. Both files still count as successfully imported.
+	// Test idempotency — importing again should not increase count.
+	//
+	// Store.Upsert itself is non-destructive (a duplicate save creates a new
+	// linked row rather than merging), so idempotency here relies on
+	// importFromDir's own dedup guard: it skips any file whose exact content
+	// already exists for the project, rather than calling Upsert at all.
+	// This matters because ghost mcp init calls Import unconditionally on
+	// every run and documents itself as safe to re-run.
 	imported2, err := importFromDir(ctx, store, projectID, memDir, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if imported2 != 2 {
-		t.Errorf("imported2 = %d, want 2 (re-import still succeeds for both files)", imported2)
+	if imported2 != 0 {
+		t.Errorf("imported2 = %d, want 0 (dedup guard skips already-imported content)", imported2)
 	}
 	count2, err := store.CountMemories(ctx, projectID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if count2 != count*2 {
-		t.Errorf("after re-import: count = %d, want %d (each duplicate gets its own linked row)", count2, count*2)
+	if count2 != count {
+		t.Errorf("after re-import: count = %d, want %d (idempotent)", count2, count)
 	}
 }
 

--- a/internal/claudeimport/import_test.go
+++ b/internal/claudeimport/import_test.go
@@ -320,20 +320,24 @@ Should be skipped.`)
 		t.Errorf("store count = %d, want >= 2", count)
 	}
 
-	// Test idempotency — importing again should not increase count.
+	// Re-importing is not idempotent by row count anymore: Upsert is
+	// non-destructive, so a re-imported duplicate gets its own row (linked
+	// to the original via a 'duplicate' relation) instead of merging into
+	// it. Both files still count as successfully imported.
 	imported2, err := importFromDir(ctx, store, projectID, memDir, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Upsert may merge, so imported2 could be non-zero but count should stay same.
+	if imported2 != 2 {
+		t.Errorf("imported2 = %d, want 2 (re-import still succeeds for both files)", imported2)
+	}
 	count2, err := store.CountMemories(ctx, projectID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if count2 != count {
-		t.Errorf("after re-import: count = %d, want %d (idempotent)", count2, count)
+	if count2 != count*2 {
+		t.Errorf("after re-import: count = %d, want %d (each duplicate gets its own linked row)", count2, count*2)
 	}
-	_ = imported2
 }
 
 func writeTempFile(t *testing.T, dir, name, content string) {

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -552,7 +552,7 @@ func (s *Server) registerTools() {
 			return nil, nil, fmt.Errorf("ensure project: %w", err)
 		}
 
-		id, merged, err := s.store.Upsert(ctx, args.ProjectID, args.Category, args.Content, "mcp", importance, args.Tags)
+		id, duplicateOf, score, err := s.store.Upsert(ctx, args.ProjectID, args.Category, args.Content, "mcp", importance, args.Tags)
 		if err != nil {
 			return nil, nil, fmt.Errorf("save failed: %w", err)
 		}
@@ -566,11 +566,10 @@ func (s *Server) registerTools() {
 			}
 		}
 
-		action := "saved"
-		if merged {
-			action = "merged with existing memory"
+		msg := fmt.Sprintf("Memory saved (id: %s)", id)
+		if duplicateOf != "" {
+			msg = fmt.Sprintf("Memory saved (id: %s), linked as a likely duplicate of %s (score %.2f)", id, duplicateOf, score)
 		}
-		msg := fmt.Sprintf("Memory %s (id: %s)", action, id)
 		if truncated {
 			msg += fmt.Sprintf(" (content truncated to %d chars)", maxContentLen)
 		}
@@ -891,16 +890,15 @@ func (s *Server) registerTools() {
 		if err := s.store.EnsureProject(ctx, "_global", "_global", "global"); err != nil {
 			return nil, nil, fmt.Errorf("ensure global project: %w", err)
 		}
-		id, merged, err := s.store.Upsert(ctx, "_global", args.Category, args.Content, "mcp", importance, args.Tags)
+		id, duplicateOf, score, err := s.store.Upsert(ctx, "_global", args.Category, args.Content, "mcp", importance, args.Tags)
 		if err != nil {
 			return nil, nil, fmt.Errorf("save failed: %w", err)
 		}
 		s.notifyResourceUpdated(ctx, "ghost://memories/global")
-		action := "saved"
-		if merged {
-			action = "merged with existing"
+		msg := fmt.Sprintf("Global memory saved (id: %s)", id)
+		if duplicateOf != "" {
+			msg = fmt.Sprintf("Global memory saved (id: %s), linked as a likely duplicate of %s (score %.2f)", id, duplicateOf, score)
 		}
-		msg := fmt.Sprintf("Global memory %s (id: %s)", action, id)
 		if globalTruncated {
 			msg += fmt.Sprintf(" (content truncated to %d chars)", maxContentLen)
 		}

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -183,7 +183,7 @@ func TestBuildProjectContext_WithMemories(t *testing.T) {
 
 	ctx := context.Background()
 	// Seed a memory for the test project (ID "abc123").
-	if _, _, err := store.Upsert(ctx, "abc123", "convention", "use nerdctl on node-2 for builds", "manual", 1.0, []string{"nerdctl"}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "abc123", "convention", "use nerdctl on node-2 for builds", "manual", 1.0, []string{"nerdctl"}); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 
@@ -224,7 +224,7 @@ func TestBuildProjectContext_IncludesGlobal(t *testing.T) {
 	if err := store.EnsureProject(ctx, "_global", "_global", "global"); err != nil {
 		t.Fatalf("EnsureProject _global: %v", err)
 	}
-	if _, _, err := store.Upsert(ctx, "_global", "preference", "always use nerdctl not docker", "manual", 1.0, []string{}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "_global", "preference", "always use nerdctl not docker", "manual", 1.0, []string{}); err != nil {
 		t.Fatalf("Upsert global: %v", err)
 	}
 
@@ -247,7 +247,7 @@ func TestBuildProjectContext_IncludesLearnedContext(t *testing.T) {
 	if err := store.UpdateLearnedContext(ctx, "abc123", "This is the learned summary.", ""); err != nil {
 		t.Fatalf("UpdateLearnedContext: %v", err)
 	}
-	if _, _, err := store.Upsert(ctx, "abc123", "fact", "seed memory", "manual", 0.5, []string{}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "abc123", "fact", "seed memory", "manual", 0.5, []string{}); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 
@@ -300,15 +300,15 @@ func TestSaveAndSearch_EndToEnd(t *testing.T) {
 	ctx := context.Background()
 
 	// Save a memory via store (simulating ghost_memory_save logic).
-	id, merged, err := store.Upsert(ctx, "abc123", "pattern", "use context.Background() in tests", "mcp", 0.7, []string{"testing"})
+	id, dupOf, _, err := store.Upsert(ctx, "abc123", "pattern", "use context.Background() in tests", "mcp", 0.7, []string{"testing"})
 	if err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 	if id == "" {
 		t.Error("expected non-empty ID")
 	}
-	if merged {
-		t.Error("first save should not be merged")
+	if dupOf != "" {
+		t.Error("first save should not report a duplicate")
 	}
 
 	// Search via FTS (simulating ghost_memory_search without embedder).
@@ -332,7 +332,7 @@ func TestSaveAndSearch_WithEmbedder(t *testing.T) {
 	ctx := context.Background()
 
 	// Save memory.
-	_, _, err := store.Upsert(ctx, "abc123", "fact", "Ghost uses SQLite with FTS5", "mcp", 0.8, []string{})
+	_, _, _, err := store.Upsert(ctx, "abc123", "fact", "Ghost uses SQLite with FTS5", "mcp", 0.8, []string{})
 	if err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
@@ -357,13 +357,13 @@ func TestListMemories_ByCategoryAndAll(t *testing.T) {
 	ctx := context.Background()
 
 	// Save memories in different categories with distinct content to avoid merge.
-	if _, _, err := store.Upsert(ctx, "abc123", "fact", "Go compiles to static binaries with no runtime dependencies", "mcp", 0.5, []string{}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "abc123", "fact", "Go compiles to static binaries with no runtime dependencies", "mcp", 0.5, []string{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := store.Upsert(ctx, "abc123", "decision", "Chi was chosen as HTTP router for its stdlib compatibility", "mcp", 0.7, []string{}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "abc123", "decision", "Chi was chosen as HTTP router for its stdlib compatibility", "mcp", 0.7, []string{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := store.Upsert(ctx, "abc123", "fact", "Cardano uses Ouroboros Praos consensus protocol for block production", "mcp", 0.6, []string{}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "abc123", "fact", "Cardano uses Ouroboros Praos consensus protocol for block production", "mcp", 0.6, []string{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -390,7 +390,7 @@ func TestDeleteMemory_EndToEnd(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
 
-	id, _, err := store.Upsert(ctx, "abc123", "gotcha", "watch for nil pointers", "mcp", 0.5, []string{})
+	id, _, _, err := store.Upsert(ctx, "abc123", "gotcha", "watch for nil pointers", "mcp", 0.5, []string{})
 	if err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
@@ -429,10 +429,10 @@ func TestSearchAll_CrossProject(t *testing.T) {
 	if err := store.EnsureProject(ctx, "def456", "/tmp/other", "other-project"); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := store.Upsert(ctx, "abc123", "fact", "ghost uses SQLite", "mcp", 0.5, []string{}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "abc123", "fact", "ghost uses SQLite", "mcp", 0.5, []string{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := store.Upsert(ctx, "def456", "fact", "roller uses SQLite", "mcp", 0.5, []string{}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "def456", "fact", "roller uses SQLite", "mcp", 0.5, []string{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -455,7 +455,7 @@ func TestSaveGlobal_EndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id, _, err := store.Upsert(ctx, "_global", "preference", "always use nerdctl", "mcp", 0.8, []string{})
+	id, _, _, err := store.Upsert(ctx, "_global", "preference", "always use nerdctl", "mcp", 0.8, []string{})
 	if err != nil {
 		t.Fatalf("Upsert global: %v", err)
 	}
@@ -545,10 +545,10 @@ func TestHealthOutput(t *testing.T) {
 	ctx := context.Background()
 
 	// Seed memories with very distinct content to avoid Upsert merge.
-	if _, _, err := store.Upsert(ctx, "abc123", "fact", "Ghost uses SQLite with FTS5 for full-text search capabilities", "mcp", 0.5, []string{}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "abc123", "fact", "Ghost uses SQLite with FTS5 for full-text search capabilities", "mcp", 0.5, []string{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := store.Upsert(ctx, "abc123", "convention", "Kubernetes manifests use helmfile for declarative deployment management", "mcp", 0.6, []string{}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "abc123", "convention", "Kubernetes manifests use helmfile for declarative deployment management", "mcp", 0.6, []string{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -904,7 +904,7 @@ func TestPrompts_RecallProject(t *testing.T) {
 	srv := New(store, logger, "test")
 
 	ctx := context.Background()
-	if _, _, err := store.Upsert(ctx, "abc123", "fact", "seed memory for recall test", "manual", 0.5, []string{}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "abc123", "fact", "seed memory for recall test", "manual", 0.5, []string{}); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 
@@ -991,7 +991,7 @@ func TestResourceSubscription_NotifiesOnMemorySave(t *testing.T) {
 		t.Fatalf("Subscribe: %v", err)
 	}
 
-	if _, _, err := store.Upsert(ctx, "abc123", "fact", "triggers subscription notify", "manual", 0.5, []string{}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "abc123", "fact", "triggers subscription notify", "manual", 0.5, []string{}); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 	srv.notifyResourceUpdated(ctx, uri)
@@ -1134,7 +1134,7 @@ func TestGhostResolve_DryRunByDefault(t *testing.T) {
 
 	ctx := context.Background()
 	const content = "root cause: fixed in v2, no further action needed"
-	if _, _, err := store.Upsert(ctx, "abc123", "gotcha", content, "manual", 0.5, []string{}); err != nil {
+	if _, _, _, err := store.Upsert(ctx, "abc123", "gotcha", content, "manual", 0.5, []string{}); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 

--- a/internal/memory/migrate.go
+++ b/internal/memory/migrate.go
@@ -11,7 +11,7 @@ import (
 // Bump it and append to migrations whenever initSQL changes in a way that
 // CREATE TABLE IF NOT EXISTS cannot deliver to existing databases (new columns,
 // CHECK values, foreign keys, dropped tables).
-const schemaVersion = 2
+const schemaVersion = 3
 
 // migrations[i] upgrades a database from user_version i to i+1. Each step is
 // frozen in time — it must keep working against the schema as it existed when
@@ -21,6 +21,7 @@ const schemaVersion = 2
 var migrations = []func(*sql.Tx) error{
 	migrateV1,
 	migrateV2,
+	migrateV3,
 }
 
 // migrate brings an existing database up to schemaVersion. Fresh databases
@@ -123,6 +124,53 @@ func migrateV2(tx *sql.Tx) error {
 	}
 	if _, err := tx.Exec(`ALTER TABLE memories ADD COLUMN resolved_at TEXT`); err != nil {
 		return fmt.Errorf("add memories.resolved_at: %w", err)
+	}
+	return nil
+}
+
+// migrateV3 adds 'duplicate' to memory_links.relation's CHECK — Upsert no
+// longer destructively overwrites content on a near-duplicate match; it links
+// the new row to the existing one instead, and the CHECK must accept that
+// relation value. SQLite cannot ALTER a CHECK constraint, so this is a table
+// rebuild like migrateV1's, but simpler: memory_links carries no FTS index or
+// rowid dependency, so it's a straight copy under the new DDL. A database that
+// never had memory_links at all (pre-dates the link graph entirely) needs no
+// rebuild — initSQL's CREATE TABLE IF NOT EXISTS will have already created it
+// fresh with this CHECK, same as migrateV1's pattern for tables that don't
+// exist yet.
+func migrateV3(tx *sql.Tx) error {
+	stale, err := tableDDLLacks(tx, "memory_links", "'duplicate'")
+	if err != nil {
+		return err
+	}
+	if !stale {
+		return nil
+	}
+	stmts := []string{
+		`CREATE TABLE memory_links_v3_new (
+    source_id      TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    target_id      TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    relation       TEXT NOT NULL DEFAULT 'related'
+                   CHECK (relation IN ('related', 'supersedes', 'contradicts', 'elaborates', 'causes', 'duplicate')),
+    strength       REAL NOT NULL DEFAULT 0.5,
+    source         TEXT NOT NULL DEFAULT 'auto'
+                   CHECK (source IN ('auto', 'llm', 'manual')),
+    created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+    invalidated_at TEXT,
+    PRIMARY KEY (source_id, target_id, relation)
+)`,
+		`INSERT INTO memory_links_v3_new (source_id, target_id, relation, strength, source, created_at, invalidated_at)
+SELECT source_id, target_id, relation, strength, source, created_at, invalidated_at
+FROM memory_links`,
+		`DROP TABLE memory_links`,
+		`ALTER TABLE memory_links_v3_new RENAME TO memory_links`,
+		`CREATE INDEX IF NOT EXISTS idx_links_source ON memory_links(source_id) WHERE invalidated_at IS NULL`,
+		`CREATE INDEX IF NOT EXISTS idx_links_target ON memory_links(target_id) WHERE invalidated_at IS NULL`,
+	}
+	for _, s := range stmts {
+		if _, err := tx.Exec(s); err != nil {
+			return fmt.Errorf("%q: %w", s[:min(40, len(s))], err)
+		}
 	}
 	return nil
 }

--- a/internal/memory/migrate_test.go
+++ b/internal/memory/migrate_test.go
@@ -331,3 +331,122 @@ func TestMigrateAddsResolvedAt(t *testing.T) {
 		t.Errorf("fts match after add-column migration: n=%d err=%v, want 1", nFts, err)
 	}
 }
+
+// v2WithLinksSQL is a schemaVersion-2 database: memories, memory_links (old
+// CHECK — no 'duplicate'), and the surrounding tables current initSQL creates.
+// Distinct from legacySQL, which predates memory_links entirely.
+const v2WithLinksSQL = `
+CREATE TABLE projects (
+    id          TEXT PRIMARY KEY,
+    path        TEXT NOT NULL UNIQUE,
+    name        TEXT NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE memories (
+    id            TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    category      TEXT NOT NULL DEFAULT 'fact',
+    content       TEXT NOT NULL,
+    importance    REAL NOT NULL DEFAULT 0.5,
+    access_count  INTEGER NOT NULL DEFAULT 0,
+    last_accessed TEXT,
+    source        TEXT NOT NULL DEFAULT 'reflection',
+    tags          TEXT DEFAULT '[]',
+    pinned        INTEGER NOT NULL DEFAULT 0,
+    resolved_at   TEXT,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE VIRTUAL TABLE memories_fts USING fts5(
+    content,
+    content=memories,
+    content_rowid=rowid,
+    tokenize='porter unicode61'
+);
+
+CREATE TRIGGER memories_ai AFTER INSERT ON memories BEGIN
+    INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+CREATE TABLE memory_links (
+    source_id      TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    target_id      TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    relation       TEXT NOT NULL DEFAULT 'related'
+                   CHECK (relation IN ('related', 'supersedes', 'contradicts', 'elaborates', 'causes')),
+    strength       REAL NOT NULL DEFAULT 0.5,
+    source         TEXT NOT NULL DEFAULT 'auto'
+                   CHECK (source IN ('auto', 'llm', 'manual')),
+    created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+    invalidated_at TEXT,
+    PRIMARY KEY (source_id, target_id, relation)
+);
+`
+
+// newV2WithLinksDB writes a schemaVersion-2 database with two memories and a
+// 'related' link between them, stamped at user_version=2, and returns its path.
+func newV2WithLinksDB(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "ghost.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open v2 db: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+	if _, err := db.Exec(v2WithLinksSQL); err != nil {
+		t.Fatalf("create v2 schema: %v", err)
+	}
+	seed := []string{
+		`INSERT INTO projects (id, path, name) VALUES ('p1', '/tmp/v2-p1', 'p1')`,
+		`INSERT INTO memories (id, project_id, category, content, source) VALUES
+			('m1', 'p1', 'fact', 'existing memory one', 'mcp'),
+			('m2', 'p1', 'fact', 'existing memory two', 'mcp')`,
+		`INSERT INTO memory_links (source_id, target_id, relation, strength, source)
+			VALUES ('m1', 'm2', 'related', 0.6, 'auto')`,
+		`PRAGMA user_version = 2`,
+	}
+	for _, s := range seed {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("seed v2 db: %v", err)
+		}
+	}
+	return dbPath
+}
+
+// TestMigrateV3AddsDuplicateRelation: a schemaVersion-2 database with an
+// existing memory_links row must upgrade to schemaVersion 3, keep the
+// existing link intact, and accept a 'duplicate' relation afterward.
+func TestMigrateV3AddsDuplicateRelation(t *testing.T) {
+	dbPath := newV2WithLinksDB(t)
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB on v2-with-links db: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	if v := schemaVersionOf(t, db); v != schemaVersion {
+		t.Errorf("user_version = %d, want %d", v, schemaVersion)
+	}
+
+	// The existing 'related' link survived the rebuild.
+	var strength float64
+	err = db.QueryRow(
+		`SELECT strength FROM memory_links WHERE source_id = 'm1' AND target_id = 'm2' AND relation = 'related'`,
+	).Scan(&strength)
+	if err != nil {
+		t.Fatalf("existing link missing after migration: %v", err)
+	}
+	if strength != 0.6 {
+		t.Errorf("existing link strength = %f, want 0.6", strength)
+	}
+
+	// The widened CHECK now accepts 'duplicate'.
+	if _, err := db.Exec(
+		`INSERT INTO memory_links (source_id, target_id, relation, strength, source) VALUES ('m2', 'm1', 'duplicate', 0.8, 'auto')`,
+	); err != nil {
+		t.Errorf("insert with relation='duplicate' still fails: %v", err)
+	}
+}

--- a/internal/memory/schema.go
+++ b/internal/memory/schema.go
@@ -187,7 +187,7 @@ CREATE TABLE IF NOT EXISTS memory_links (
     source_id      TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
     target_id      TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
     relation       TEXT NOT NULL DEFAULT 'related'
-                   CHECK (relation IN ('related', 'supersedes', 'contradicts', 'elaborates', 'causes')),
+                   CHECK (relation IN ('related', 'supersedes', 'contradicts', 'elaborates', 'causes', 'duplicate')),
     strength       REAL NOT NULL DEFAULT 0.5,
     source         TEXT NOT NULL DEFAULT 'auto'
                    CHECK (source IN ('auto', 'llm', 'manual')),

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -410,7 +410,18 @@ func (s *Store) Upsert(ctx context.Context, projectID, category, content, source
 		if newImportance > 1.0 {
 			newImportance = 1.0
 		}
-		if _, err = s.db.ExecContext(ctx, `
+
+		// The UPDATE (strengthen), INSERT (new row), and INSERT (link) must
+		// all succeed or none should — otherwise a failure partway through
+		// leaves the new memory row orphaned: unlinked, un-embedded (onSave
+		// never fires), and invisible. Same tx pattern as mergeProjectLocked.
+		tx, txErr := s.db.BeginTx(ctx, nil)
+		if txErr != nil {
+			return "", "", 0, fmt.Errorf("begin upsert tx: %w", txErr)
+		}
+		defer tx.Rollback() //nolint:errcheck
+
+		if _, err = tx.ExecContext(ctx, `
 			UPDATE memories
 			SET importance = ?, access_count = access_count + 1, updated_at = datetime('now'),
 			    resolved_at = NULL
@@ -419,7 +430,7 @@ func (s *Store) Upsert(ctx context.Context, projectID, category, content, source
 			return "", "", 0, fmt.Errorf("strengthen memory: %w", err)
 		}
 
-		if err = s.db.QueryRowContext(ctx, `
+		if err = tx.QueryRowContext(ctx, `
 			INSERT INTO memories (project_id, category, content, source, importance, tags)
 			VALUES (?, ?, ?, ?, ?, ?)
 			RETURNING id
@@ -431,7 +442,7 @@ func (s *Store) Upsert(ctx context.Context, projectID, category, content, source
 		// Upsert already holds the lock for its entire body. Inline the same
 		// upsert-link SQL directly instead. Direction is fixed (source_id=new,
 		// target_id=existing), not normalized like symmetric relations.
-		if _, err = s.db.ExecContext(ctx, `
+		if _, err = tx.ExecContext(ctx, `
 			INSERT INTO memory_links (source_id, target_id, relation, strength, source)
 			VALUES (?, ?, 'duplicate', ?, 'auto')
 			ON CONFLICT(source_id, target_id, relation) DO UPDATE SET
@@ -439,6 +450,10 @@ func (s *Store) Upsert(ctx context.Context, projectID, category, content, source
 				invalidated_at = NULL
 		`, id, existingID, score); err != nil {
 			return "", "", 0, fmt.Errorf("link duplicate: %w", err)
+		}
+
+		if err = tx.Commit(); err != nil {
+			return "", "", 0, fmt.Errorf("commit upsert tx: %w", err)
 		}
 
 		if s.onSave != nil {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -345,21 +345,24 @@ func (s *Store) Create(ctx context.Context, projectID string, m Memory) (string,
 }
 
 // Upsert checks for an existing similar memory (same category, FTS overlap).
-// If found, it strengthens the existing memory. If not, creates a new one.
-func (s *Store) Upsert(ctx context.Context, projectID, category, content, source string, importance float32, tags []string) (id string, merged bool, err error) {
+// If found, it strengthens the existing memory's importance/access_count and
+// links the new content to it as a 'duplicate' — it never overwrites the
+// existing row's content, so a genuinely different follow-up save under a
+// manual-sourced target (or any target) is never silently discarded. If no
+// candidate scores above threshold, it creates a new, unlinked row.
+func (s *Store) Upsert(ctx context.Context, projectID, category, content, source string, importance float32, tags []string) (id string, duplicateOf string, score float64, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	var existingID string
 	var existingImportance float32
-	var existingContent string
 
 	// Two-stage duplicate detection. Stage 1 (recall): the FTS OR-probe over
-	// the first 10 words retrieves merge candidates cheaply. Stage 2
+	// the first 30 words retrieves merge candidates cheaply. Stage 2
 	// (precision): mergeScore over the full token sets confirms a true
 	// duplicate — the OR-probe alone treats a single shared word as a match,
 	// which silently swallowed unrelated saves.
-	ftsQuery := sanitizeFTS(content)
+	ftsQuery := sanitizeFTSN(content, 30)
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT m.id, m.importance, m.content
 		FROM memories m
@@ -368,7 +371,7 @@ func (s *Store) Upsert(ctx context.Context, projectID, category, content, source
 		  AND m.category = ?
 		  AND memories_fts MATCH ?
 		ORDER BY rank, m.importance DESC
-		LIMIT 5
+		LIMIT 15
 	`, projectID, category, ftsQuery)
 	if err == nil {
 		// Token-free content (punctuation/single-char words only) can still
@@ -387,57 +390,76 @@ func (s *Store) Upsert(ctx context.Context, projectID, category, content, source
 				bestSim = sim
 				existingID = candID
 				existingImportance = candImportance
-				existingContent = candContent
 			}
 		}
 		if rowsErr := rows.Err(); rowsErr != nil {
 			existingID = "" // treat a broken candidate scan as no match
 		}
 		_ = rows.Close()
+		score = bestSim
 	}
 
+	tagsJSON, _ := json.Marshal(tags)
+
 	if existingID != "" {
-		// Found a match — strengthen it.
+		// Found a match — strengthen the existing row, then insert the new
+		// content as its own row and link it back as a 'duplicate'. Never
+		// overwrite existingContent: that silently discarded content for
+		// source='manual' targets while still reporting a merge.
 		newImportance := existingImportance + (importance * 0.2)
 		if newImportance > 1.0 {
 			newImportance = 1.0
 		}
-		finalContent := existingContent
-		if len(content) > len(existingContent) {
-			finalContent = content
-		}
-
-		_, err = s.db.ExecContext(ctx, `
+		if _, err = s.db.ExecContext(ctx, `
 			UPDATE memories
-			SET content = CASE WHEN source = 'manual' THEN content ELSE ? END,
-			    importance = ?, access_count = access_count + 1, updated_at = datetime('now'),
+			SET importance = ?, access_count = access_count + 1, updated_at = datetime('now'),
 			    resolved_at = NULL
 			WHERE id = ? AND project_id = ?
-		`, finalContent, newImportance, existingID, projectID)
-		if err != nil {
-			return "", false, fmt.Errorf("strengthen memory: %w", err)
+		`, newImportance, existingID, projectID); err != nil {
+			return "", "", 0, fmt.Errorf("strengthen memory: %w", err)
 		}
+
+		if err = s.db.QueryRowContext(ctx, `
+			INSERT INTO memories (project_id, category, content, source, importance, tags)
+			VALUES (?, ?, ?, ?, ?, ?)
+			RETURNING id
+		`, projectID, category, content, source, importance, string(tagsJSON)).Scan(&id); err != nil {
+			return "", "", 0, fmt.Errorf("create memory: %w", err)
+		}
+
+		// CreateLink takes s.mu itself — calling it here would deadlock, since
+		// Upsert already holds the lock for its entire body. Inline the same
+		// upsert-link SQL directly instead. Direction is fixed (source_id=new,
+		// target_id=existing), not normalized like symmetric relations.
+		if _, err = s.db.ExecContext(ctx, `
+			INSERT INTO memory_links (source_id, target_id, relation, strength, source)
+			VALUES (?, ?, 'duplicate', ?, 'auto')
+			ON CONFLICT(source_id, target_id, relation) DO UPDATE SET
+				strength = MAX(strength, excluded.strength),
+				invalidated_at = NULL
+		`, id, existingID, score); err != nil {
+			return "", "", 0, fmt.Errorf("link duplicate: %w", err)
+		}
+
 		if s.onSave != nil {
 			s.onSave(projectID)
 		}
-		return existingID, true, nil
+		return id, existingID, score, nil
 	}
 
 	// No match — create new.
-	tagsJSON, _ := json.Marshal(tags)
-
 	err = s.db.QueryRowContext(ctx, `
 		INSERT INTO memories (project_id, category, content, source, importance, tags)
 		VALUES (?, ?, ?, ?, ?, ?)
 		RETURNING id
 	`, projectID, category, content, source, importance, string(tagsJSON)).Scan(&id)
 	if err != nil {
-		return "", false, fmt.Errorf("create memory: %w", err)
+		return "", "", 0, fmt.Errorf("create memory: %w", err)
 	}
 	if s.onSave != nil {
 		s.onSave(projectID)
 	}
-	return id, false, nil
+	return id, "", 0, nil
 }
 
 // GetTopMemories returns the top N memories ranked by composite score
@@ -1436,7 +1458,19 @@ func mergeScore(a, b map[string]bool) float64 {
 	return 0
 }
 
+// sanitizeFTS sanitizes text into an FTS5 OR-query, capped at 10 words. Used
+// on the search path (SearchFTS, SearchFTSAll) — kept at the original cap so
+// retrieval-quality behavior (see TestBenchRegressionFloors) is unaffected.
 func sanitizeFTS(text string) string {
+	return sanitizeFTSN(text, 10)
+}
+
+// sanitizeFTSN sanitizes text into an FTS5 OR-query, capped at maxWords.
+// Upsert's duplicate-recall probe uses a wider cap than plain search
+// (see sanitizeFTS) because a broader OR-probe over more of the content
+// improves candidate recall for the precision pass (mergeScore) that follows;
+// widening the cap globally would instead perturb ranked search results.
+func sanitizeFTSN(text string, maxWords int) string {
 	// Remove FTS5 operators and punctuation, keep only words.
 	var words []string
 	for _, word := range strings.Fields(text) {
@@ -1458,12 +1492,12 @@ func sanitizeFTS(text string) string {
 	if len(words) == 0 {
 		return `""`
 	}
-	// Limit to first 10 words to keep the query reasonable.
-	if len(words) > 10 {
+	// Limit to first maxWords words to keep the query reasonable.
+	if len(words) > maxWords {
 		slog.Warn("fts query truncated",
 			"original_terms", len(words),
-			"limit", 10)
-		words = words[:10]
+			"limit", maxWords)
+		words = words[:maxWords]
 	}
 	return strings.Join(words, " OR ")
 }

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -81,40 +81,67 @@ func TestStoreUpsert(t *testing.T) {
 	ctx := context.Background()
 
 	// First insert via Upsert — should create new.
-	id1, merged, err := s.Upsert(ctx, testProject, "fact", "SQLite supports full-text search via FTS5", "reflection", 0.6, []string{"sqlite"})
+	id1, dupOf, _, err := s.Upsert(ctx, testProject, "fact", "SQLite supports full-text search via FTS5", "reflection", 0.6, []string{"sqlite"})
 	if err != nil {
 		t.Fatalf("Upsert (new): %v", err)
 	}
-	if merged {
-		t.Error("first Upsert should not merge")
+	if dupOf != "" {
+		t.Error("first Upsert should not report a duplicate")
 	}
 	if id1 == "" {
 		t.Fatal("first Upsert returned empty ID")
 	}
 
-	// Second Upsert with overlapping content — should merge.
-	id2, merged, err := s.Upsert(ctx, testProject, "fact", "SQLite FTS5 provides full-text search capabilities", "reflection", 0.5, []string{"sqlite", "fts"})
+	// Second Upsert with overlapping content — should link as a duplicate of id1.
+	id2, dupOf, _, err := s.Upsert(ctx, testProject, "fact", "SQLite FTS5 provides full-text search capabilities", "reflection", 0.5, []string{"sqlite", "fts"})
 	if err != nil {
 		t.Fatalf("Upsert (merge): %v", err)
 	}
-	if !merged {
-		t.Error("second Upsert should have merged")
+	if dupOf != id1 {
+		t.Errorf("second Upsert should report duplicateOf %s, got %q", id1, dupOf)
 	}
-	if id2 != id1 {
-		t.Errorf("merged ID should match original: got %s, want %s", id2, id1)
+	if id2 == id1 {
+		t.Error("second Upsert should have created its own row, not reused id1")
 	}
 
-	// Verify importance was strengthened: 0.6 + (0.5 * 0.2) = 0.7
+	// Both rows exist, with their original content untouched.
 	all, err := s.GetAll(ctx, testProject, 100)
 	if err != nil {
 		t.Fatalf("GetAll: %v", err)
 	}
-	if len(all) != 1 {
-		t.Fatalf("expected 1 memory after merge, got %d", len(all))
+	if len(all) != 2 {
+		t.Fatalf("expected 2 memories after duplicate-link, got %d", len(all))
 	}
+	byID := map[string]Memory{}
+	for _, m := range all {
+		byID[m.ID] = m
+	}
+	if byID[id1].Content != "SQLite supports full-text search via FTS5" {
+		t.Errorf("existing row content was overwritten: %q", byID[id1].Content)
+	}
+	if byID[id2].Content != "SQLite FTS5 provides full-text search capabilities" {
+		t.Errorf("new row content wrong: %q", byID[id2].Content)
+	}
+
+	// Existing row's importance was strengthened: 0.6 + (0.5 * 0.2) = 0.7
 	expected := float32(0.6 + 0.5*0.2)
-	if diff := all[0].Importance - expected; diff > 0.01 || diff < -0.01 {
-		t.Errorf("expected importance ~%f, got %f", expected, all[0].Importance)
+	if diff := byID[id1].Importance - expected; diff > 0.01 || diff < -0.01 {
+		t.Errorf("expected existing-row importance ~%f, got %f", expected, byID[id1].Importance)
+	}
+
+	// A 'duplicate' link connects the two rows in the right direction.
+	links, err := s.GetLinks(ctx, id1)
+	if err != nil {
+		t.Fatalf("GetLinks: %v", err)
+	}
+	found := false
+	for _, l := range links {
+		if l.Relation == "duplicate" && l.SourceID == id2 && l.TargetID == id1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a 'duplicate' link source_id=%s target_id=%s, links: %+v", id2, id1, links)
 	}
 }
 
@@ -126,24 +153,24 @@ func TestStoreUpsertNoMergeOnSharedWord(t *testing.T) {
 	// ("Phase"). Reproduces the 2026-07-19 live bug: the FTS OR-probe alone
 	// treated any one-word overlap as a duplicate and silently swallowed
 	// the second save.
-	id1, merged, err := s.Upsert(ctx, testProject, "decision",
+	id1, dupOf, _, err := s.Upsert(ctx, testProject, "decision",
 		"Benchmark strategy decided: Phase one is LongMemEval retrieval eval with ablations",
 		"mcp", 0.8, nil)
 	if err != nil {
 		t.Fatalf("Upsert (first): %v", err)
 	}
-	if merged {
-		t.Error("first Upsert should not merge")
+	if dupOf != "" {
+		t.Error("first Upsert should not report a duplicate")
 	}
 
-	id2, merged, err := s.Upsert(ctx, testProject, "decision",
+	id2, dupOf, _, err := s.Upsert(ctx, testProject, "decision",
 		"MCP Phase two design approved: memory update tool, stop hook, promote to global",
 		"mcp", 0.8, nil)
 	if err != nil {
 		t.Fatalf("Upsert (second): %v", err)
 	}
-	if merged {
-		t.Error("unrelated content sharing one word must not merge")
+	if dupOf != "" {
+		t.Error("unrelated content sharing one word must not report a duplicate")
 	}
 	if id2 == id1 {
 		t.Error("second Upsert should have created a distinct memory")
@@ -164,21 +191,21 @@ func TestStoreUpsertNoMergeBelowThreshold(t *testing.T) {
 
 	// Same topic vocabulary but genuinely different facts: token overlap is
 	// real yet below the 0.5 Jaccard gate, so both must survive.
-	_, _, err := s.Upsert(ctx, testProject, "gotcha",
+	_, _, _, err := s.Upsert(ctx, testProject, "gotcha",
 		"SQLite busy timeout must be set on the read-only hook connection",
 		"mcp", 0.7, nil)
 	if err != nil {
 		t.Fatalf("Upsert (first): %v", err)
 	}
 
-	_, merged, err := s.Upsert(ctx, testProject, "gotcha",
+	_, dupOf, _, err := s.Upsert(ctx, testProject, "gotcha",
 		"SQLite FTS5 rank ordering is unstable across identical RRF scores in hybrid search",
 		"mcp", 0.7, nil)
 	if err != nil {
 		t.Fatalf("Upsert (second): %v", err)
 	}
-	if merged {
-		t.Error("below-threshold overlap must not merge")
+	if dupOf != "" {
+		t.Error("below-threshold overlap must not report a duplicate")
 	}
 
 	all, err := s.GetAll(ctx, testProject, 100)
@@ -198,17 +225,17 @@ func TestStoreUpsertNoMergeOnTokenFreeContent(t *testing.T) {
 	// sets (tokenizeContent keeps len>1 only) while still FTS-matching each
 	// other (sanitizeFTS keeps single-char words). jaccard(∅,∅) = 1.0, so
 	// without a guard these unrelated saves would spuriously merge.
-	_, _, err := s.Upsert(ctx, testProject, "fact", "a b c", "mcp", 0.5, nil)
+	_, _, _, err := s.Upsert(ctx, testProject, "fact", "a b c", "mcp", 0.5, nil)
 	if err != nil {
 		t.Fatalf("Upsert (first): %v", err)
 	}
 
-	_, merged, err := s.Upsert(ctx, testProject, "fact", "a x y", "mcp", 0.5, nil)
+	_, dupOf, _, err := s.Upsert(ctx, testProject, "fact", "a x y", "mcp", 0.5, nil)
 	if err != nil {
 		t.Fatalf("Upsert (second): %v", err)
 	}
-	if merged {
-		t.Error("token-free contents must never merge")
+	if dupOf != "" {
+		t.Error("token-free contents must never report a duplicate")
 	}
 
 	all, err := s.GetAll(ctx, testProject, 100)
@@ -220,45 +247,45 @@ func TestStoreUpsertNoMergeOnTokenFreeContent(t *testing.T) {
 	}
 }
 
-func TestStoreUpsertMergesBestCandidate(t *testing.T) {
+func TestStoreUpsertDuplicateLinksBestCandidate(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()
 
 	// Two existing memories; the new content shares one word with A but is a
-	// near-duplicate of B. It must merge into B, not the first FTS hit.
-	_, _, err := s.Upsert(ctx, testProject, "fact",
+	// near-duplicate of B. It must link to B, not the first FTS hit.
+	_, _, _, err := s.Upsert(ctx, testProject, "fact",
 		"Deployment pipeline uses GitHub Actions runners on the cluster",
 		"mcp", 0.7, nil)
 	if err != nil {
 		t.Fatalf("Upsert (A): %v", err)
 	}
 
-	idB, _, err := s.Upsert(ctx, testProject, "fact",
+	idB, _, _, err := s.Upsert(ctx, testProject, "fact",
 		"Ollama embedding worker sweeps unembedded memories every two minutes",
 		"mcp", 0.7, nil)
 	if err != nil {
 		t.Fatalf("Upsert (B): %v", err)
 	}
 
-	idNew, merged, err := s.Upsert(ctx, testProject, "fact",
+	idNew, dupOf, _, err := s.Upsert(ctx, testProject, "fact",
 		"Ollama embedding worker sweeps the unembedded memories every two minutes for cluster projects",
 		"mcp", 0.7, nil)
 	if err != nil {
 		t.Fatalf("Upsert (near-dup of B): %v", err)
 	}
-	if !merged {
-		t.Fatal("near-duplicate of B should merge")
+	if dupOf != idB {
+		t.Fatalf("should link to B (%s), linked to %q", idB, dupOf)
 	}
-	if idNew != idB {
-		t.Errorf("should merge into B (%s), merged into %s", idB, idNew)
+	if idNew == idB {
+		t.Errorf("near-duplicate should get its own row distinct from B (%s)", idB)
 	}
 }
 
-// TestStoreUpsertMergesLengthAsymmetricParaphrases covers the failure the eval
-// surfaced: the same fact restated at a different length accumulated as
-// separate memories because Jaccard punishes the wordier side's filler tokens
-// (these pairs score 0.2–0.45). The overlap-coefficient leg catches them.
-func TestStoreUpsertMergesLengthAsymmetricParaphrases(t *testing.T) {
+// TestStoreUpsertDuplicateLinksLengthAsymmetricParaphrases covers the failure
+// the eval surfaced: the same fact restated at a different length. Each
+// restatement must get its own row and link back to a previously-seen row —
+// not accumulate as unrelated memories, and not silently overwrite one another.
+func TestStoreUpsertDuplicateLinksLengthAsymmetricParaphrases(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()
 
@@ -269,25 +296,28 @@ func TestStoreUpsertMergesLengthAsymmetricParaphrases(t *testing.T) {
 		"the session cache TTL value is 300 seconds and it is not currently tunable",
 	}
 
-	if _, _, err := s.Upsert(ctx, testProject, "fact", base, "mcp", 0.7, nil); err != nil {
+	baseID, _, _, err := s.Upsert(ctx, testProject, "fact", base, "mcp", 0.7, nil)
+	if err != nil {
 		t.Fatalf("Upsert (base): %v", err)
 	}
+	seenIDs := map[string]bool{baseID: true}
 	for i, r := range restatements {
-		_, merged, err := s.Upsert(ctx, testProject, "fact", r, "mcp", 0.7, nil)
+		id, dupOf, _, err := s.Upsert(ctx, testProject, "fact", r, "mcp", 0.7, nil)
 		if err != nil {
 			t.Fatalf("Upsert (restatement %d): %v", i, err)
 		}
-		if !merged {
-			t.Errorf("restatement %d must merge, did not: %q", i, r)
+		if dupOf == "" || !seenIDs[dupOf] {
+			t.Errorf("restatement %d must link to a previously-seen row, got dupOf=%q: %q", i, dupOf, r)
 		}
+		seenIDs[id] = true
 	}
 
 	all, err := s.GetAll(ctx, testProject, 100)
 	if err != nil {
 		t.Fatalf("GetAll: %v", err)
 	}
-	if len(all) != 1 {
-		t.Errorf("expected 1 memory after 4 restatements of one fact, got %d", len(all))
+	if len(all) != 4 {
+		t.Errorf("expected 4 rows (base + 3 restatements), got %d", len(all))
 		for _, m := range all {
 			t.Logf("  %s", m.Content)
 		}
@@ -305,7 +335,7 @@ func TestStoreUpsertOverlapLegDoesNotOverMerge(t *testing.T) {
 	// below, but states a different fact from each of them.
 	long := "the embedding worker retries the Ollama request twice before giving " +
 		"up and leaves the memory unembedded until the next sweep"
-	if _, _, err := s.Upsert(ctx, testProject, "gotcha", long, "mcp", 0.7, nil); err != nil {
+	if _, _, _, err := s.Upsert(ctx, testProject, "gotcha", long, "mcp", 0.7, nil); err != nil {
 		t.Fatalf("Upsert (long): %v", err)
 	}
 
@@ -315,12 +345,12 @@ func TestStoreUpsertOverlapLegDoesNotOverMerge(t *testing.T) {
 		"the memory unembedded",
 	}
 	for i, sh := range shorts {
-		_, merged, err := s.Upsert(ctx, testProject, "gotcha", sh, "mcp", 0.7, nil)
+		_, dupOf, _, err := s.Upsert(ctx, testProject, "gotcha", sh, "mcp", 0.7, nil)
 		if err != nil {
 			t.Fatalf("Upsert (short %d): %v", i, err)
 		}
-		if merged {
-			t.Errorf("short contained save %d must not merge into a longer unrelated memory: %q", i, sh)
+		if dupOf != "" {
+			t.Errorf("short contained save %d must not report a duplicate for a longer unrelated memory: %q", i, sh)
 		}
 	}
 
@@ -332,12 +362,12 @@ func TestStoreUpsertOverlapLegDoesNotOverMerge(t *testing.T) {
 		"the embedding worker writes vectors into the memory embeddings table",
 	}
 	for i, d := range distinct {
-		_, merged, err := s.Upsert(ctx, testProject, "gotcha", d, "mcp", 0.7, nil)
+		_, dupOf, _, err := s.Upsert(ctx, testProject, "gotcha", d, "mcp", 0.7, nil)
 		if err != nil {
 			t.Fatalf("Upsert (distinct %d): %v", i, err)
 		}
-		if merged {
-			t.Errorf("distinct fact %d sharing topic vocabulary must not merge: %q", i, d)
+		if dupOf != "" {
+			t.Errorf("distinct fact %d sharing topic vocabulary must not report a duplicate: %q", i, d)
 		}
 	}
 }
@@ -376,29 +406,26 @@ func TestStoreUpsertImportanceCap(t *testing.T) {
 	ctx := context.Background()
 
 	// Create with high importance.
-	_, _, err := s.Upsert(ctx, testProject, "fact", "Critical architecture pattern for the system", "reflection", 0.95, nil)
+	firstID, _, _, err := s.Upsert(ctx, testProject, "fact", "Critical architecture pattern for the system", "reflection", 0.95, nil)
 	if err != nil {
 		t.Fatalf("Upsert (new): %v", err)
 	}
 
-	// Upsert again — should be capped at 1.0.
-	_, merged, err := s.Upsert(ctx, testProject, "fact", "Critical architecture pattern for the entire system design", "reflection", 0.9, nil)
+	// Upsert a near-duplicate — existing row's importance should be capped at 1.0.
+	_, dupOf, _, err := s.Upsert(ctx, testProject, "fact", "Critical architecture pattern for the entire system design", "reflection", 0.9, nil)
 	if err != nil {
 		t.Fatalf("Upsert (cap): %v", err)
 	}
-	if !merged {
-		t.Error("expected merge")
+	if dupOf != firstID {
+		t.Fatalf("expected duplicate link to %s, got %q", firstID, dupOf)
 	}
 
-	all, err := s.GetAll(ctx, testProject, 100)
-	if err != nil {
-		t.Fatalf("GetAll: %v", err)
+	var importance float32
+	if err := s.db.QueryRowContext(ctx, `SELECT importance FROM memories WHERE id = ?`, firstID).Scan(&importance); err != nil {
+		t.Fatalf("query importance: %v", err)
 	}
-	if len(all) != 1 {
-		t.Fatalf("expected 1 memory, got %d", len(all))
-	}
-	if all[0].Importance > 1.0 {
-		t.Errorf("importance should be capped at 1.0, got %f", all[0].Importance)
+	if importance > 1.0 {
+		t.Errorf("importance should be capped at 1.0, got %f", importance)
 	}
 }
 
@@ -706,6 +733,19 @@ func TestSanitizeFTS(t *testing.T) {
 				t.Errorf("sanitizeFTS(%q)\n  got:  %s\n  want: %s", tc.input, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestSanitizeFTSNWiderCap verifies Upsert's duplicate-recall probe (which
+// calls sanitizeFTSN(content, 30)) gets a wider word cap than plain search
+// (sanitizeFTS, capped at 10) — see sanitizeFTSN's doc comment for why the
+// caps must differ.
+func TestSanitizeFTSNWiderCap(t *testing.T) {
+	input := "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo"
+	want := `"one" OR "two" OR "three" OR "four" OR "five" OR "six" OR "seven" OR "eight" OR "nine" OR "ten" OR "eleven" OR "twelve" OR "thirteen" OR "fourteen" OR "fifteen" OR "sixteen" OR "seventeen" OR "eighteen" OR "nineteen" OR "twenty" OR "twentyone" OR "twentytwo" OR "twentythree" OR "twentyfour" OR "twentyfive" OR "twentysix" OR "twentyseven" OR "twentyeight" OR "twentynine" OR "thirty"`
+	got := sanitizeFTSN(input, 30)
+	if got != want {
+		t.Errorf("sanitizeFTSN(%q, 30)\n  got:  %s\n  want: %s", input, got, want)
 	}
 }
 
@@ -1819,7 +1859,7 @@ func TestMergeProject(t *testing.T) {
 	}
 
 	// Seed data under the duplicate project.
-	memID, _, err := s.Upsert(ctx, "test", "fact", "MCP-created memory about deployment", "mcp", 0.7, []string{})
+	memID, _, _, err := s.Upsert(ctx, "test", "fact", "MCP-created memory about deployment", "mcp", 0.7, []string{})
 	if err != nil {
 		t.Fatalf("Upsert under dup: %v", err)
 	}
@@ -2265,7 +2305,7 @@ func TestEnsureProject_AutoMerge(t *testing.T) {
 	}
 
 	// Save a memory under the MCP project.
-	_, _, err := s.Upsert(ctx, "myproject", "fact", "deployed on k8s cluster alpha-7", "mcp", 0.8, []string{})
+	_, _, _, err := s.Upsert(ctx, "myproject", "fact", "deployed on k8s cluster alpha-7", "mcp", 0.8, []string{})
 	if err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
@@ -2492,19 +2532,19 @@ func TestUnresolveOnWrite(t *testing.T) {
 	assertActive(t, s, testProject, id)
 
 	// Upsert of a near-duplicate (strengthen branch) clears resolved_at.
-	uid, _, err := s.Upsert(ctx, testProject, "gotcha", "duplicate detection strengthen path here", "manual", 0.5, nil)
+	uid, _, _, err := s.Upsert(ctx, testProject, "gotcha", "duplicate detection strengthen path here", "manual", 0.5, nil)
 	if err != nil {
 		t.Fatalf("upsert create: %v", err)
 	}
 	if _, err := s.SetResolved(ctx, []string{uid}); err != nil {
 		t.Fatalf("SetResolved upsert row: %v", err)
 	}
-	gotID, merged, err := s.Upsert(ctx, testProject, "gotcha", "duplicate detection strengthen path here", "manual", 0.5, nil)
+	_, dupOf, _, err := s.Upsert(ctx, testProject, "gotcha", "duplicate detection strengthen path here", "manual", 0.5, nil)
 	if err != nil {
 		t.Fatalf("upsert dup: %v", err)
 	}
-	if !merged || gotID != uid {
-		t.Fatalf("upsert dup did not strengthen existing row: merged=%v id=%s want %s", merged, gotID, uid)
+	if dupOf != uid {
+		t.Fatalf("upsert dup did not link to existing row: dupOf=%s want %s", dupOf, uid)
 	}
 	assertActive(t, s, testProject, uid)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -20,7 +20,7 @@ type LLMProvider interface {
 type MemoryStore interface {
 	// Core CRUD
 	Create(ctx context.Context, projectID string, m memory.Memory) (string, error)
-	Upsert(ctx context.Context, projectID, category, content, source string, importance float32, tags []string) (string, bool, error)
+	Upsert(ctx context.Context, projectID, category, content, source string, importance float32, tags []string) (string, string, float64, error)
 	Delete(ctx context.Context, id string) error
 	UpdateMemory(ctx context.Context, projectID, id string, content, category *string, importance *float32, tags []string) error
 	PromoteToGlobal(ctx context.Context, projectID, id string) error


### PR DESCRIPTION
## Summary
- `Store.Upsert` no longer overwrites existing memory content when a near-duplicate is detected. Every save is its own row, linked to any matched existing row via a `'duplicate'` relation in `memory_links` (with match score), and the existing row's importance/access_count is strengthened instead of clobbered.
- Broadened the duplicate-detection recall probe (new `sanitizeFTSN` helper, 30-word cap / LIMIT 15) while leaving the shared `sanitizeFTS` used by search ranking at its original 10-word cap, to avoid regressing `TestBenchRegressionFloors`.
- `ghost_memory_save` / `ghost_save_global` now surface duplicate-link outcomes in their result message.
- Restored `ghost mcp init` idempotency (broken by the non-destructive Upsert change) with a dedup guard in `internal/claudeimport`.
- `provider.MemoryStore.Upsert` signature updated to `(id, duplicateOf, score, error)`; all call sites and tests updated accordingly.
- Adds `memory_links` schema migration for the new `'duplicate'` relation kind.

Addresses Area 1 ("Duplicate-merge data loss") of `docs/superpowers/specs/2026-08-02-eval-findings-remediation-design.md`.

## Test Plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` passing (pre-existing unrelated failure: `TestHaikuClassifierLive` due to Anthropic API credit exhaustion, not caused by this change)
- [x] New/updated tests cover: non-destructive row creation, duplicate link creation with score, importance strengthening/capping, `ghost mcp init` re-run no-op, wider FTS cap behavior
- [x] Two-stage review (spec compliance + code quality) passed per task; final whole-branch review verdict: Ready to merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Duplicate memories are now preserved as separate entries and linked to the existing memory.
  * Save confirmations identify likely duplicates, including the related memory and similarity score.
  * Duplicate detection is more accurate for paraphrased content.

* **Bug Fixes**
  * Repeated imports now skip memories already stored or encountered during the same import.
  * Database upgrades preserve existing links while enabling duplicate relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->