### PR TITLE
fix(mcpinit): surface database open failures in ghost mcp status

### DIFF
--- a/internal/mcpinit/status.go
+++ b/internal/mcpinit/status.go
@@ -95,7 +95,9 @@ func Status(w io.Writer) error {
 		dbPath := filepath.Join(dataDir, "ghost.db")
 		if _, err := os.Stat(dbPath); err == nil {
 			db, err := memory.OpenDB(dbPath)
-			if err == nil {
+			if err != nil {
+				check(false, "", fmt.Sprintf("database: %v", err))
+			} else {
 				defer db.Close() //nolint:errcheck
 				logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 				store := memory.NewStore(db, logger)

--- a/internal/mcpinit/status_test.go
+++ b/internal/mcpinit/status_test.go
@@ -25,6 +25,10 @@ func TestStatus_ReportsOpenDBFailure(t *testing.T) {
 		t.Fatalf("write fake db: %v", err)
 	}
 
+	// Isolate PATH so Status can't shell out to a host-installed `claude`
+	// binary — this test only exercises the database-open-failure check.
+	t.Setenv("PATH", t.TempDir())
+
 	var out bytes.Buffer
 	if err := Status(&out); err != nil {
 		t.Fatalf("Status: %v", err)

--- a/internal/mcpinit/status_test.go
+++ b/internal/mcpinit/status_test.go
@@ -1,0 +1,40 @@
+package mcpinit
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStatus_ReportsOpenDBFailure verifies that a database which exists but
+// fails to open (e.g. mid-migration foreign-key corruption) is surfaced as a
+// failed check, not silently skipped. Before this fix, Status only inspected
+// the database when memory.OpenDB succeeded, so a broken database looked
+// identical to "All checks passed."
+func TestStatus_ReportsOpenDBFailure(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataDir)
+	ghostDir := filepath.Join(dataDir, "ghost")
+	if err := os.MkdirAll(ghostDir, 0o700); err != nil {
+		t.Fatalf("mkdir ghost dir: %v", err)
+	}
+	dbPath := filepath.Join(ghostDir, "ghost.db")
+	if err := os.WriteFile(dbPath, []byte("not a sqlite database"), 0o600); err != nil {
+		t.Fatalf("write fake db: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := Status(&out); err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "✗ database:") {
+		t.Errorf("expected a failed database check, got:\n%s", output)
+	}
+	if strings.Contains(output, "All checks passed.") {
+		t.Errorf("a broken database must not report \"All checks passed.\", got:\n%s", output)
+	}
+}


### PR DESCRIPTION
## Summary
- `Status` only inspected the database when `memory.OpenDB` succeeded, so a broken/corrupt database (e.g. mid-migration foreign-key corruption) was silently skipped and reported as "All checks passed."
- Now a failed `OpenDB` call is surfaced as a failed check via the existing `check(false, ...)` path.

## Test plan
- [x] `go test ./internal/mcpinit/... -run TestStatus -v -count=1` — new regression test passes
- [x] `go build ./...`, `go vet ./...` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Database opening failures are now correctly reported as failed health checks.
  - Invalid existing databases no longer produce an incorrect “all checks passed” result.

- **Tests**
  - Added regression coverage for invalid database health-check reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->