### PR TITLE
chore(config): remove dead ReflectionConfig.Backend field

### DIFF
--- a/internal/config/config.example.yaml
+++ b/internal/config/config.example.yaml
@@ -37,10 +37,9 @@
 #                              # "related" isn't the same bar as "redundant"
 
 # --- Memory Consolidation ---
-# Controls the default tier for ghost reflect.
-# auto: tries haiku (if ANTHROPIC_API_KEY set) → sqlite (free, always available)
+# ghost reflect's tier is chosen via the --tier CLI flag, not config.
 # reflection:
-#   backend: "auto"                  # "auto", "haiku", "sqlite"
+#   auto_resolve: false               # run ghost resolve automatically after reflect
 
 # --- Obsidian Vault Mirror ---
 # One-way Markdown mirror of memories, decisions, and tasks

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,8 +40,7 @@ type APIConfig struct {
 
 // ReflectionConfig holds memory consolidation settings.
 type ReflectionConfig struct {
-	Backend     string `koanf:"backend"` // "auto", "haiku", "sqlite", "disabled"
-	AutoResolve bool   `koanf:"auto_resolve"`
+	AutoResolve bool `koanf:"auto_resolve"`
 }
 
 // EmbeddingConfig holds local embedding settings.
@@ -73,7 +72,6 @@ var defaults = map[string]interface{}{
 	"embedding.ollama_url":       "http://localhost:11434",
 	"embedding.model":            "nomic-embed-text:v1.5",
 	"embedding.dimensions":       768,
-	"reflection.backend":         "auto",
 	"reflection.auto_resolve":    false,
 	"linking.enabled":            true,
 	"linking.threshold":          0.70,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -90,11 +90,11 @@ func TestLoad_GhostEnvOverrides(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	// Clear any interfering env vars.
-	unsetEnvVars(t, []string{"GHOST_API_KEY", "GHOST_REFLECTION_BACKEND", "ANTHROPIC_API_KEY"})
+	unsetEnvVars(t, []string{"GHOST_API_KEY", "GHOST_EMBEDDING_MODEL", "ANTHROPIC_API_KEY"})
 
 	// Set GHOST_* overrides.
 	t.Setenv("GHOST_API_KEY", "sk-ghost-override")
-	t.Setenv("GHOST_REFLECTION_BACKEND", "sqlite")
+	t.Setenv("GHOST_EMBEDDING_MODEL", "custom-embed-model")
 
 	cfg, err := Load()
 	if err != nil {
@@ -104,8 +104,8 @@ func TestLoad_GhostEnvOverrides(t *testing.T) {
 	if cfg.API.Key != "sk-ghost-override" {
 		t.Errorf("expected api.key from GHOST_API_KEY, got %q", cfg.API.Key)
 	}
-	if cfg.Reflection.Backend != "sqlite" {
-		t.Errorf("expected reflection.backend=sqlite from env, got %q", cfg.Reflection.Backend)
+	if cfg.Embedding.Model != "custom-embed-model" {
+		t.Errorf("expected embedding.model=custom-embed-model from env, got %q", cfg.Embedding.Model)
 	}
 }
 
@@ -157,7 +157,7 @@ func TestLoad_YAMLFileOverride(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	// Clear interfering env vars.
-	unsetEnvVars(t, []string{"GHOST_API_KEY", "GHOST_REFLECTION_BACKEND", "ANTHROPIC_API_KEY"})
+	unsetEnvVars(t, []string{"GHOST_API_KEY", "GHOST_EMBEDDING_MODEL", "ANTHROPIC_API_KEY"})
 
 	// Create a config file in the user config dir.
 	configDir := filepath.Join(tmpDir, "ghost")
@@ -174,7 +174,7 @@ linking:
   threshold: 0.85
   demotion_threshold: 0.95
 reflection:
-  backend: "sqlite"
+  auto_resolve: true
 `
 	if err := os.WriteFile(configFile, []byte(yamlContent), 0o600); err != nil {
 		t.Fatal(err)
@@ -197,8 +197,8 @@ reflection:
 	if cfg.Linking.DemotionThreshold != 0.95 {
 		t.Errorf("linking.demotion_threshold = %f, want 0.95", cfg.Linking.DemotionThreshold)
 	}
-	if cfg.Reflection.Backend != "sqlite" {
-		t.Errorf("reflection.backend = %q, want %q", cfg.Reflection.Backend, "sqlite")
+	if !cfg.Reflection.AutoResolve {
+		t.Errorf("reflection.auto_resolve = %v, want true", cfg.Reflection.AutoResolve)
 	}
 
 	// Unaffected defaults should remain.
@@ -213,19 +213,19 @@ func TestLoad_EnvOverridesYAML(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	// Clear interfering env vars.
-	unsetEnvVars(t, []string{"GHOST_API_KEY", "GHOST_REFLECTION_BACKEND", "ANTHROPIC_API_KEY"})
+	unsetEnvVars(t, []string{"GHOST_API_KEY", "GHOST_EMBEDDING_MODEL", "ANTHROPIC_API_KEY"})
 
-	// YAML file sets backend to "haiku".
+	// YAML file sets embedding.model to "yaml-model".
 	configDir := filepath.Join(tmpDir, "ghost")
 	if err := os.MkdirAll(configDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte("reflection:\n  backend: haiku\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte("embedding:\n  model: yaml-model\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	// Env var overrides to "sqlite".
-	t.Setenv("GHOST_REFLECTION_BACKEND", "sqlite")
+	// Env var overrides to "env-model".
+	t.Setenv("GHOST_EMBEDDING_MODEL", "env-model")
 
 	cfg, err := Load()
 	if err != nil {
@@ -233,8 +233,8 @@ func TestLoad_EnvOverridesYAML(t *testing.T) {
 	}
 
 	// Env should take precedence over YAML.
-	if cfg.Reflection.Backend != "sqlite" {
-		t.Errorf("backend = %q, want %q (env should override yaml)", cfg.Reflection.Backend, "sqlite")
+	if cfg.Embedding.Model != "env-model" {
+		t.Errorf("embedding.model = %q, want %q (env should override yaml)", cfg.Embedding.Model, "env-model")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `ReflectionConfig.Backend` (`reflection.backend` config key) was never read by any production code path — `ghost reflect`'s tier is chosen via the `--tier` CLI flag instead.
- Removed the field, its default map entry, and the stale `config.example.yaml` comment; rewrote the three config_test.go cases that used it as an env/YAML override vehicle to use `embedding.model` instead (the override mechanism under test is unrelated to which key carries it).

## Test plan
- [x] `go test ./internal/config/... -v -count=1` — all pass
- [x] `go test ./... -count=1` — full suite green
- [x] `go build ./...`, `go vet ./...` clean