### PR TITLE
fix(mcpinit): explain truncation ranking in both globals and memories not-shown lines

### DIFF
--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -146,7 +146,7 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 			var gsb strings.Builder
 			fmt.Fprintf(&gsb, "\n**Global (applies to all projects):** the user's own saved cross-project preferences.\n")
 			if totalGlobalCountKnown && totalGlobalCount > len(globals) {
-				fmt.Fprintf(&gsb, "(%d shown of %d total — %d not shown; use ghost_search_all for the rest)\n", len(globals), totalGlobalCount, totalGlobalCount-len(globals))
+				fmt.Fprintf(&gsb, "(%d shown of %d total — %d not shown, ranked by pinned status, then importance, then most-recently-updated; use ghost_search_all for the rest)\n", len(globals), totalGlobalCount, totalGlobalCount-len(globals))
 			}
 			for _, m := range globals {
 				fmt.Fprintf(&gsb, "- [%s] %s\n", m.Category, quoteData(m.Content))
@@ -179,7 +179,7 @@ func HandleSessionStartHook(stdin io.Reader, stdout io.Writer) {
 		if !totalCountKnown {
 			fmt.Fprintf(&sb, "**Memories (%d shown; total unknown — count lookup failed, more may be available; use ghost_memories_list or ghost_memory_search for the rest):**\n", len(memories))
 		} else if totalMemoryCount > len(memories) {
-			fmt.Fprintf(&sb, "**Memories (%d shown of %d total — %d not shown; use ghost_memories_list or ghost_memory_search for the rest):**\n", len(memories), totalMemoryCount, totalMemoryCount-len(memories))
+			fmt.Fprintf(&sb, "**Memories (%d shown of %d total — %d not shown, ranked by a composite score of importance, pinned status, and category-aware recency decay; use ghost_memories_list or ghost_memory_search for the rest):**\n", len(memories), totalMemoryCount, totalMemoryCount-len(memories))
 		} else {
 			fmt.Fprintf(&sb, "**Memories (%d shown):**\n", len(memories))
 		}

--- a/internal/mcpinit/hook_test.go
+++ b/internal/mcpinit/hook_test.go
@@ -724,6 +724,9 @@ func TestSessionInjectionRespectsNewCap(t *testing.T) {
 	if !strings.Contains(result, "15 shown of 20 total — 5 not shown") {
 		t.Errorf("expected cap of 15 with not-shown count, got:\n%s", result)
 	}
+	if !strings.Contains(result, "ranked by a composite score of importance, pinned status, and category-aware recency decay") {
+		t.Errorf("memories not-shown line must explain the ranking factors; got:\n%s", result)
+	}
 }
 
 // TestSessionInjectionUsesDecayRanking: ranking must follow the category-aware

--- a/internal/mcpinit/hook_test.go
+++ b/internal/mcpinit/hook_test.go
@@ -329,6 +329,9 @@ func TestHandleSessionStartHook_GlobalsCapAndNotShownLine(t *testing.T) {
 	if !strings.Contains(result, "not shown") {
 		t.Errorf("globals section must surface a not-shown count when capped; got:\n%s", result)
 	}
+	if !strings.Contains(result, "ranked by pinned status, then importance, then most-recently-updated") {
+		t.Errorf("globals truncation message must describe the actual pinned/importance/updated_at ordering; got:\n%s", result)
+	}
 }
 
 func TestHandleSessionStartHook_GlobalsOnNoMatch(t *testing.T) {


### PR DESCRIPTION
## Summary
- The SessionStart hook's globals section already explained how truncated items are ranked when capped ("ranked by pinned status, then importance, then most-recently-updated").
- The project-memories section's equivalent "N shown of M total" line stayed silent about its ranking, which was actively misleading since it uses a different mechanism than the globals section: `DecayRankingSQL`'s single composite score (importance × category-aware time-decay × pinned-boost), not a simple three-key sort.
- Added the same style of explanation to the memories-section line, worded accurately for its actual ranking formula.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass, including `internal/mcpinit`)
- [x] Added an assertion to `TestHandleSessionStartHook_GlobalsCapAndNotShownLine`-adjacent memories test verifying the new explanatory text appears in the truncated memories line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Memory limit messages now explain how omitted global and project memories are ranked, including importance, pinned status, and recency.
  * Project memory messages clarify that recency may vary by category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->