### PR TITLE
fix tests: honor XDG_CONFIG_HOME and use portable printf in CLI fakes

### DIFF
--- a/internal/ai/cli_client_test.go
+++ b/internal/ai/cli_client_test.go
@@ -44,7 +44,7 @@ if [ -n "$ANTHROPIC_API_KEY" ]; then
   echo "LEAKED" >&2
   exit 1
 fi
-echo -n '{"memories":[]}'
+printf '%s' '{"memories":[]}'
 `)
 	t.Setenv("ANTHROPIC_API_KEY", "sk-should-not-leak")
 
@@ -74,7 +74,7 @@ done
 if [ "$found_flag" -ne 1 ]; then echo "missing --system-prompt flag" >&2; exit 1; fi
 if [ "$found_system" -ne 1 ]; then echo "system prompt not passed as distinct arg" >&2; exit 1; fi
 if [ "$found_user" -ne 1 ]; then echo "user content not passed as distinct arg" >&2; exit 1; fi
-echo -n "KEEP"
+printf '%s' "KEEP"
 `)
 	c := &CLIClient{binary: bin}
 	text, err := c.Classify(context.Background(), "SYSTEM instructions", "USERDATA content")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,7 +100,7 @@ func Load() (*Config, error) {
 	loadFileIfExists(k, "/etc/ghost/config.yaml", parser)
 
 	// Layer 3: ~/.config/ghost/config.yaml (user-global).
-	if configDir, err := os.UserConfigDir(); err == nil {
+	if configDir, err := userConfigDir(); err == nil {
 		loadFileIfExists(k, filepath.Join(configDir, "ghost", "config.yaml"), parser)
 	}
 
@@ -161,7 +161,7 @@ func DataDir() (string, error) {
 // EnsureConfigFile creates ~/.config/ghost/config.yaml from the embedded example
 // if it doesn't already exist. Returns the path and whether a new file was created.
 func EnsureConfigFile() (path string, created bool, err error) {
-	configDir, err := os.UserConfigDir()
+	configDir, err := userConfigDir()
 	if err != nil {
 		return "", false, err
 	}
@@ -186,4 +186,15 @@ func loadFileIfExists(k *koanf.Koanf, path string, parser koanf.Parser) {
 	if _, err := os.Stat(path); err == nil {
 		_ = k.Load(file.Provider(path), parser)
 	}
+}
+
+// userConfigDir returns the base user config directory, honoring XDG_CONFIG_HOME
+// when set. Unlike os.UserConfigDir — which ignores XDG_CONFIG_HOME on macOS —
+// this keeps the config path consistent with DataDir's XDG_DATA_HOME handling
+// and lets tests point XDG_CONFIG_HOME at a temp dir on every platform.
+func userConfigDir() (string, error) {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return dir, nil
+	}
+	return os.UserConfigDir()
 }


### PR DESCRIPTION
Fixes two macOS-only test failures that were also present on main:

- **internal/config**: `config.Load`/`EnsureConfigFile` used `os.UserConfigDir()`, which on macOS ignores `XDG_CONFIG_HOME` (returns `~/Library/Application Support`). Tests writing `$XDG_CONFIG_HOME/ghost/config.yaml` read nothing. Added `userConfigDir()` honoring `XDG_CONFIG_HOME` first, mirroring `DataDir`'s `XDG_DATA_HOME` handling. Linux behavior unchanged (Go already honors it there).
- **internal/ai**: fake `claude` scripts used `echo -n`, which macOS `/bin/sh` (bash POSIX mode) prints literally as `-n ...`. Switched to portable `printf '%s'`.