### PR TITLE
fix(mcpinit): fix Windows compatibility bugs in mcp init

### DIFF
--- a/internal/claudeimport/import.go
+++ b/internal/claudeimport/import.go
@@ -45,7 +45,12 @@ const defaultImportance float32 = 0.7
 
 // EncodeProjectPath converts an absolute path to Claude's directory name format.
 // E.g., "/home/wayne/git/ghost" → "-home-wayne-git-ghost".
+// Windows paths also carry backslashes and a drive-letter colon (e.g.
+// "C:\Users\me\repo"); both are folded into "-" the same as "/" so the
+// encoded name never embeds a literal ":" or "\", which would otherwise
+// break directory creation and the path-traversal check in ClaudeMemoryDir.
 func EncodeProjectPath(projectPath string) string {
+	projectPath = strings.NewReplacer(`\`, "-", ":", "-").Replace(projectPath)
 	return strings.ReplaceAll(projectPath, "/", "-")
 }
 

--- a/internal/claudeimport/import_test.go
+++ b/internal/claudeimport/import_test.go
@@ -20,6 +20,14 @@ func TestClaudeMemoryDir(t *testing.T) {
 		}
 	})
 
+	t.Run("encoding_windows", func(t *testing.T) {
+		got := EncodeProjectPath(`C:\Users\me\repo`)
+		want := "C--Users-me-repo"
+		if got != want {
+			t.Errorf("EncodeProjectPath = %q, want %q", got, want)
+		}
+	})
+
 	t.Run("returns_empty_for_missing_dir", func(t *testing.T) {
 		got := ClaudeMemoryDir("/nonexistent/project/path")
 		if got != "" {

--- a/internal/mcpinit/init.go
+++ b/internal/mcpinit/init.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/wcatz/ghost/internal/claudeimport"
@@ -194,8 +195,24 @@ func ensurePermissions(w io.Writer) (*settingsFile, error) {
 	return sf, nil
 }
 
-// shellQuote wraps s in POSIX single quotes, escaping any single quotes within.
+// shellQuote quotes s for safe embedding in a hook command line, matching
+// the shell Claude Code invokes hooks through: cmd.exe on Windows (which
+// does not treat ' as a quote character), POSIX shells elsewhere.
 func shellQuote(s string) string {
+	if runtime.GOOS == "windows" {
+		return shellQuoteWindows(s)
+	}
+	return shellQuotePOSIX(s)
+}
+
+// shellQuoteWindows quotes s for cmd.exe, which has no escape for embedded
+// double quotes other than doubling them.
+func shellQuoteWindows(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+// shellQuotePOSIX quotes s for POSIX shells using single quotes.
+func shellQuotePOSIX(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -277,9 +277,29 @@ func TestShellQuote(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := shellQuote(tt.input)
+			got := shellQuotePOSIX(tt.input)
 			if got != tt.want {
-				t.Errorf("shellQuote(%q) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("shellQuotePOSIX(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShellQuoteWindows(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"ghost", `"ghost"`},
+		{`C:\Users\me\ghost.exe`, `"C:\Users\me\ghost.exe"`},
+		{`C:\path with spaces\ghost.exe`, `"C:\path with spaces\ghost.exe"`},
+		{`C:\path\with"quote\ghost.exe`, `"C:\path\with""quote\ghost.exe"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := shellQuoteWindows(tt.input)
+			if got != tt.want {
+				t.Errorf("shellQuoteWindows(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -302,6 +303,17 @@ func TestShellQuoteWindows(t *testing.T) {
 				t.Errorf("shellQuoteWindows(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestShellQuoteDispatch(t *testing.T) {
+	input := `C:\path with spaces\ghost.exe`
+	want := shellQuotePOSIX(input)
+	if runtime.GOOS == "windows" {
+		want = shellQuoteWindows(input)
+	}
+	if got := shellQuote(input); got != want {
+		t.Errorf("shellQuote(%q) = %q, want %q", input, got, want)
 	}
 }
 

--- a/internal/mcpinit/obsidiansync.go
+++ b/internal/mcpinit/obsidiansync.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/wcatz/ghost/internal/config"
@@ -68,7 +67,9 @@ func ensureObsidianSyncRunning() {
 
 // isAlive reports whether pidPath names a PID file for a process that is
 // still running. It never treats a stale or missing PID file as an error —
-// the caller's only decision is "spawn a new one, or not".
+// the caller's only decision is "spawn a new one, or not". The liveness
+// check itself is platform-specific — see isProcessAlive in
+// obsidiansync_unix.go / obsidiansync_windows.go.
 func isAlive(pidPath string) bool {
 	data, err := os.ReadFile(pidPath)
 	if err != nil {
@@ -78,9 +79,5 @@ func isAlive(pidPath string) bool {
 	if err != nil || pid <= 0 {
 		return false
 	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return proc.Signal(syscall.Signal(0)) == nil
+	return isProcessAlive(pid)
 }

--- a/internal/mcpinit/obsidiansync_unix.go
+++ b/internal/mcpinit/obsidiansync_unix.go
@@ -3,6 +3,7 @@
 package mcpinit
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -12,4 +13,15 @@ import (
 // process group.
 func detachProcess(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+// isProcessAlive reports whether pid names a running process, by sending
+// it signal 0 — this checks existence and permission without actually
+// signaling the process.
+func isProcessAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
 }

--- a/internal/mcpinit/obsidiansync_windows.go
+++ b/internal/mcpinit/obsidiansync_windows.go
@@ -5,6 +5,8 @@ package mcpinit
 import (
 	"os/exec"
 	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
 // detachProcess starts cmd in a new process group so it survives this
@@ -13,4 +15,26 @@ import (
 // equivalent, so CREATE_NEW_PROCESS_GROUP is the closest analog.
 func detachProcess(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}
+
+// isProcessAlive reports whether pid names a running process. Unlike POSIX,
+// Windows aggressively recycles PIDs, so a PID that opens successfully but
+// has already exited (GetExitCodeProcess returns anything but
+// STILL_ACTIVE) is treated as not alive — otherwise a reused PID belonging
+// to an unrelated process would be mistaken for the one that owned the PID
+// file.
+func isProcessAlive(pid int) bool {
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(h) //nolint:errcheck
+
+	const stillActive = 259 // STILL_ACTIVE, per the Win32 GetExitCodeProcess docs
+
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(h, &exitCode); err != nil {
+		return false
+	}
+	return exitCode == stillActive
 }

--- a/internal/mcpinit/obsidiansync_windows.go
+++ b/internal/mcpinit/obsidiansync_windows.go
@@ -24,6 +24,9 @@ func detachProcess(cmd *exec.Cmd) {
 // to an unrelated process would be mistaken for the one that owned the PID
 // file.
 func isProcessAlive(pid int) bool {
+	if pid <= 0 || int64(pid) > 0xFFFFFFFF {
+		return false
+	}
 	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
 	if err != nil {
 		return false


### PR DESCRIPTION
## Summary
- `shellQuote` now emits `"..."` (doubling embedded quotes) on Windows instead of POSIX `'...'`, since cmd.exe (which Claude Code runs hooks through on Windows) doesn't treat `'` as a quote character — this was breaking the SessionStart/Stop hook commands.
- `EncodeProjectPath` now folds backslashes and drive-letter colons to `-` in addition to `/`, so Windows paths (e.g. `C:\Users\me\repo`) no longer produce an encoded directory name with an embedded `:` or `\`, which was silently breaking `writeRedirects` (`os.MkdirAll` failure) and Claude Code memory import (`ClaudeMemoryDir`'s path-traversal check).
- `isAlive`'s process-liveness check is now platform-specific: `obsidiansync_unix.go` keeps the existing signal-0 check, `obsidiansync_windows.go` adds one via `OpenProcess` + `GetExitCodeProcess` (checking for `STILL_ACTIVE`), since `proc.Signal(0)` is unsupported on Windows and always returned `false`, causing duplicate `obsidian.auto_sync` spawns and overlapping `reflection.auto_resolve`/`auto_supersede` passes.

Fixes #245.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `GOOS=windows GOARCH=amd64 go build ./...` (cross-compile check for the new Windows-only code path)
- [x] `go test ./...` — all packages pass
- [x] Added `TestShellQuoteWindows` covering cmd.exe quoting (plain, spaces, embedded `"`)
- [x] Added `encoding_windows` subtest to `TestClaudeMemoryDir` covering `C:\Users\me\repo` → `C--Users-me-repo`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path handling to prevent invalid encoded project directory names.
  * Added Windows-compatible command quoting for paths containing spaces or special characters.
  * Improved process detection across Windows and POSIX systems, including accurate handling of exited processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->