### PR TITLE
fix(obsidian): deterministic fault injection in TestSyncRetriesFailedExport

### DIFF
--- a/internal/obsidian/sync_test.go
+++ b/internal/obsidian/sync_test.go
@@ -108,11 +108,11 @@ func TestSyncRetriesFailedExport(t *testing.T) {
 		return len(m) == 1
 	})
 
-	// Break the vault: ensureVault's ReadDir fails on an unreadable root.
-	if err := os.Chmod(vault, 0o000); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(vault, 0o755) }) // let TempDir removal succeed on failure paths
+	// Break the vault: force ensureVault's ReadDir to fail. A permission-bit
+	// approach (os.Chmod(vault, 0o000)) is unreliable across CI privilege
+	// levels, so this swaps the package's ReadDir seam instead.
+	readDirFn.Store(func(string) ([]os.DirEntry, error) { return nil, errors.New("injected: unreadable vault") })
+	t.Cleanup(func() { readDirFn.Store(os.ReadDir) })
 
 	// A commit from the other connection triggers an export that fails.
 	if _, err := writeStore.Create(ctx, "p1", memory.Memory{Category: "fact", Content: "second memory", Importance: 0.7, Source: "mcp"}); err != nil {
@@ -121,9 +121,7 @@ func TestSyncRetriesFailedExport(t *testing.T) {
 	waitFor(t, func() bool { return strings.Contains(buf.String(), "export failed") })
 
 	// Fix the vault. NO further commits: only a retained baseline retries.
-	if err := os.Chmod(vault, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	readDirFn.Store(os.ReadDir)
 	waitFor(t, func() bool {
 		m, _ := filepath.Glob(filepath.Join(vault, "p1", "Memories", "*.md"))
 		return len(m) == 2

--- a/internal/obsidian/vault.go
+++ b/internal/obsidian/vault.go
@@ -5,15 +5,29 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 )
 
 const markerName = ".ghost-vault"
+
+// readDirFn is swappable so tests can force ensureVault's ReadDir call to
+// fail deterministically — os.Chmod-based fault injection is unreliable
+// across CI privilege levels (e.g. a process with CAP_DAC_READ_SEARCH can
+// bypass a directory's permission bits).
+var readDirFn atomic.Value // func(string) ([]os.DirEntry, error)
+
+func init() { readDirFn.Store(os.ReadDir) }
+
+func readDir(dir string) ([]os.DirEntry, error) {
+	fn, _ := readDirFn.Load().(func(string) ([]os.DirEntry, error))
+	return fn(dir)
+}
 
 // ensureVault prepares dir as a Ghost-managed mirror target. Fresh or empty
 // dirs are initialized with the marker; a non-empty dir without the marker is
 // refused — Ghost never adopts a folder it didn't create.
 func ensureVault(dir string) error {
-	entries, err := os.ReadDir(dir)
+	entries, err := readDir(dir)
 	if os.IsNotExist(err) {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("create vault dir: %w", err)


### PR DESCRIPTION
## Summary
- `TestSyncRetriesFailedExport` used `os.Chmod(vault, 0o000)` to force `ensureVault`'s `ReadDir` call to fail. This is unreliable across CI privilege levels — a process with `CAP_DAC_READ_SEARCH` (or running as root) can bypass directory permission bits, so the fault sometimes never triggers and the test hangs until its 30s deadline. Observed ~2/20 recent CI runs of `ci.yml`, always the same failure signature (timeout waiting for `"export failed"` in log output).
- Replaced the permission-based fault injection with an atomic, swappable `ReadDir` seam (`internal/obsidian/vault.go`) that the test overrides directly — deterministic regardless of environment/privilege.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test ./internal/obsidian/... -race -run TestSync -count=20 -v` — 20/20 pass (previously flaky test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for retry behavior when vault directory access fails.
  * Made failure scenarios more reliable and isolated during testing.

* **Refactor**
  * Improved the vault directory-reading implementation to support safer error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->