### PR TITLE
fix(mcpinit): migrate legacy hook quoting on Windows, warn on % in path

### DIFF
--- a/internal/mcpinit/init.go
+++ b/internal/mcpinit/init.go
@@ -249,50 +249,104 @@ func shellQuotePOSIX(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
-// ensureHook adds a SessionStart hook if not already present.
+// hookReconcileAction describes what reconcileHook did, for caller logging.
+type hookReconcileAction int
+
+const (
+	hookUnchanged hookReconcileAction = iota
+	hookAdded
+	hookMigrated
+)
+
+// needsQuoteMigration reports whether an existing hook command is the
+// single-quoted form ghost generated before #251. cmd.exe never treats ' as
+// a quote character, so that form is broken on Windows and not a string a
+// user would write by hand for this hook — safe to recognize and migrate.
+// On POSIX, a leading ' is the correct, current quoting, so callers must
+// only apply this check when targeting Windows.
+func needsQuoteMigration(existingCmd string) bool {
+	return strings.HasPrefix(existingCmd, "'")
+}
+
+// reconcileHook adds the hook if absent, migrates it in place if it's the
+// pre-#251 Windows-broken single-quoted form, and otherwise leaves it
+// untouched — including hand-edited commands that merely differ from
+// desiredCmd, since ghost mcp init must stay non-destructive on re-run.
+func reconcileHook(sf *settingsFile, event, cmdSubstr, desiredCmd string, isWindows bool) (hookReconcileAction, error) {
+	existing, ok := sf.findHookCommand(event, cmdSubstr)
+	if !ok {
+		entry := hookEntry{
+			Matcher: "",
+			Hooks: []hookAction{
+				{Type: "command", Command: desiredCmd},
+			},
+		}
+		if err := sf.addHook(event, entry); err != nil {
+			return hookUnchanged, fmt.Errorf("add hook: %w", err)
+		}
+		return hookAdded, nil
+	}
+
+	if isWindows && existing != desiredCmd && needsQuoteMigration(existing) {
+		if _, err := sf.replaceHookCommand(event, cmdSubstr, desiredCmd); err != nil {
+			return hookUnchanged, fmt.Errorf("migrate hook: %w", err)
+		}
+		return hookMigrated, nil
+	}
+
+	return hookUnchanged, nil
+}
+
+// ensureHook adds a SessionStart hook if not already present, or migrates it
+// off the pre-#251 quoting that's broken under cmd.exe.
 func ensureHook(w io.Writer, sf *settingsFile, ghostBin string) error {
 	hookCmd := shellQuote(ghostBin) + " hook session-start"
+	warnPercentPath(w, ghostBin)
 
-	if sf.hasHook("SessionStart", "hook session-start") {
+	action, err := reconcileHook(sf, "SessionStart", "hook session-start", hookCmd, runtime.GOOS == "windows")
+	if err != nil {
+		return err
+	}
+	switch action {
+	case hookAdded:
+		_, _ = fmt.Fprintf(w, "  + added SessionStart hook: %s\n", hookCmd)
+	case hookMigrated:
+		_, _ = fmt.Fprintf(w, "  + migrated SessionStart hook to cmd.exe-safe quoting: %s\n", hookCmd)
+	default:
 		_, _ = fmt.Fprintln(w, "  ✓ SessionStart hook already configured")
-		return nil
 	}
-
-	entry := hookEntry{
-		Matcher: "",
-		Hooks: []hookAction{
-			{Type: "command", Command: hookCmd},
-		},
-	}
-	if err := sf.addHook("SessionStart", entry); err != nil {
-		return fmt.Errorf("add hook: %w", err)
-	}
-
-	_, _ = fmt.Fprintf(w, "  + added SessionStart hook: %s\n", hookCmd)
 	return nil
 }
 
-// ensureStopHook adds a Stop hook if not already present.
+// ensureStopHook adds a Stop hook if not already present, or migrates it off
+// the pre-#251 quoting that's broken under cmd.exe.
 func ensureStopHook(w io.Writer, sf *settingsFile, ghostBin string) error {
 	hookCmd := shellQuote(ghostBin) + " hook stop"
 
-	if sf.hasHook("Stop", "hook stop") {
+	action, err := reconcileHook(sf, "Stop", "hook stop", hookCmd, runtime.GOOS == "windows")
+	if err != nil {
+		return err
+	}
+	switch action {
+	case hookAdded:
+		_, _ = fmt.Fprintf(w, "  + added Stop hook: %s\n", hookCmd)
+	case hookMigrated:
+		_, _ = fmt.Fprintf(w, "  + migrated Stop hook to cmd.exe-safe quoting: %s\n", hookCmd)
+	default:
 		_, _ = fmt.Fprintln(w, "  ✓ Stop hook already configured")
-		return nil
 	}
-
-	entry := hookEntry{
-		Matcher: "",
-		Hooks: []hookAction{
-			{Type: "command", Command: hookCmd},
-		},
-	}
-	if err := sf.addHook("Stop", entry); err != nil {
-		return fmt.Errorf("add stop hook: %w", err)
-	}
-
-	_, _ = fmt.Fprintf(w, "  + added Stop hook: %s\n", hookCmd)
 	return nil
+}
+
+// warnPercentPath flags ghost binary paths containing '%' on Windows: cmd.exe
+// may substitute %NAME% sequences when the hook command runs, silently
+// mangling the path. There's no escape that's safe to apply blindly — %%
+// only collapses inside batch-file parsing, not a plain `cmd /c "..."`
+// invocation — so this warns instead of guessing.
+func warnPercentPath(w io.Writer, ghostBin string) {
+	if runtime.GOOS == "windows" && strings.Contains(ghostBin, "%") {
+		_, _ = fmt.Fprintf(w, "  ! warning: ghost binary path %q contains '%%', which cmd.exe may substitute as an environment variable when the hook runs — consider installing ghost to a path without '%%'\n", ghostBin)
+	}
 }
 
 // ensureAutoMemoryDisabled sets "autoMemoryEnabled": false in settings.json so

--- a/internal/mcpinit/init.go
+++ b/internal/mcpinit/init.go
@@ -258,23 +258,18 @@ const (
 	hookMigrated
 )
 
-// needsQuoteMigration reports whether an existing hook command is the
-// single-quoted form ghost generated before #251. cmd.exe never treats ' as
-// a quote character, so that form is broken on Windows and not a string a
-// user would write by hand for this hook — safe to recognize and migrate.
-// On POSIX, a leading ' is the correct, current quoting, so callers must
-// only apply this check when targeting Windows.
-func needsQuoteMigration(existingCmd string) bool {
-	return strings.HasPrefix(existingCmd, "'")
-}
-
-// reconcileHook adds the hook if absent, migrates it in place if it's the
-// pre-#251 Windows-broken single-quoted form, and otherwise leaves it
-// untouched — including hand-edited commands that merely differ from
-// desiredCmd, since ghost mcp init must stay non-destructive on re-run.
-func reconcileHook(sf *settingsFile, event, cmdSubstr, desiredCmd string, isWindows bool) (hookReconcileAction, error) {
-	existing, ok := sf.findHookCommand(event, cmdSubstr)
-	if !ok {
+// reconcileHook adds the hook if absent, migrates it in place if it exactly
+// matches legacyCmd — the pre-#251 Windows-broken single-quoted form — and
+// otherwise leaves it untouched, including hand-edited commands that merely
+// differ from desiredCmd, since ghost mcp init must stay non-destructive on
+// re-run. The migration match is exact, not substring, so a hand-edited
+// wrapper that happens to also mention cmdSubstr is never rewritten.
+func reconcileHook(sf *settingsFile, event, cmdSubstr, desiredCmd, legacyCmd string, isWindows bool) (hookReconcileAction, error) {
+	_, exists, err := sf.findHookCommand(event, cmdSubstr)
+	if err != nil {
+		return hookUnchanged, fmt.Errorf("parse existing %s hooks: %w", event, err)
+	}
+	if !exists {
 		entry := hookEntry{
 			Matcher: "",
 			Hooks: []hookAction{
@@ -287,11 +282,17 @@ func reconcileHook(sf *settingsFile, event, cmdSubstr, desiredCmd string, isWind
 		return hookAdded, nil
 	}
 
-	if isWindows && existing != desiredCmd && needsQuoteMigration(existing) {
-		if _, err := sf.replaceHookCommand(event, cmdSubstr, desiredCmd); err != nil {
-			return hookUnchanged, fmt.Errorf("migrate hook: %w", err)
+	if isWindows && legacyCmd != desiredCmd {
+		isLegacy, err := sf.hasExactHookCommand(event, legacyCmd)
+		if err != nil {
+			return hookUnchanged, fmt.Errorf("parse existing %s hooks: %w", event, err)
 		}
-		return hookMigrated, nil
+		if isLegacy {
+			if _, err := sf.replaceHookCommand(event, legacyCmd, desiredCmd); err != nil {
+				return hookUnchanged, fmt.Errorf("migrate hook: %w", err)
+			}
+			return hookMigrated, nil
+		}
 	}
 
 	return hookUnchanged, nil
@@ -301,9 +302,10 @@ func reconcileHook(sf *settingsFile, event, cmdSubstr, desiredCmd string, isWind
 // off the pre-#251 quoting that's broken under cmd.exe.
 func ensureHook(w io.Writer, sf *settingsFile, ghostBin string) error {
 	hookCmd := shellQuote(ghostBin) + " hook session-start"
+	legacyCmd := shellQuotePOSIX(ghostBin) + " hook session-start"
 	warnPercentPath(w, ghostBin)
 
-	action, err := reconcileHook(sf, "SessionStart", "hook session-start", hookCmd, runtime.GOOS == "windows")
+	action, err := reconcileHook(sf, "SessionStart", "hook session-start", hookCmd, legacyCmd, runtime.GOOS == "windows")
 	if err != nil {
 		return err
 	}
@@ -322,8 +324,9 @@ func ensureHook(w io.Writer, sf *settingsFile, ghostBin string) error {
 // the pre-#251 quoting that's broken under cmd.exe.
 func ensureStopHook(w io.Writer, sf *settingsFile, ghostBin string) error {
 	hookCmd := shellQuote(ghostBin) + " hook stop"
+	legacyCmd := shellQuotePOSIX(ghostBin) + " hook stop"
 
-	action, err := reconcileHook(sf, "Stop", "hook stop", hookCmd, runtime.GOOS == "windows")
+	action, err := reconcileHook(sf, "Stop", "hook stop", hookCmd, legacyCmd, runtime.GOOS == "windows")
 	if err != nil {
 		return err
 	}

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -362,23 +362,10 @@ func TestEnsureStopHook(t *testing.T) {
 	}
 }
 
-func TestNeedsQuoteMigration(t *testing.T) {
-	tests := []struct {
-		name string
-		cmd  string
-		want bool
-	}{
-		{"legacy single-quoted", "'/usr/local/bin/ghost' hook session-start", true},
-		{"cmd.exe double-quoted", `"C:\ghost\ghost.exe" hook session-start`, false},
-		{"unquoted", "ghost hook session-start", false},
-		{"empty", "", false},
-	}
-	for _, tt := range tests {
-		if got := needsQuoteMigration(tt.cmd); got != tt.want {
-			t.Errorf("needsQuoteMigration(%q) = %v, want %v", tt.cmd, got, tt.want)
-		}
-	}
-}
+const (
+	testLegacyCmd  = `'C:\ghost\ghost.exe' hook session-start`
+	testDesiredCmd = `"C:\ghost\ghost.exe" hook session-start`
+)
 
 func TestReconcileHook_AddsWhenAbsent(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
@@ -387,7 +374,7 @@ func TestReconcileHook_AddsWhenAbsent(t *testing.T) {
 		t.Fatalf("loadSettings: %v", err)
 	}
 
-	action, err := reconcileHook(sf, "SessionStart", "hook session-start", `"C:\ghost\ghost.exe" hook session-start`, true)
+	action, err := reconcileHook(sf, "SessionStart", "hook session-start", testDesiredCmd, testLegacyCmd, true)
 	if err != nil {
 		t.Fatalf("reconcileHook: %v", err)
 	}
@@ -405,22 +392,20 @@ func TestReconcileHook_MigratesLegacyQuotingOnWindows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadSettings: %v", err)
 	}
-	legacy := `'C:\ghost\ghost.exe' hook session-start`
-	if err := sf.addHook("SessionStart", hookEntry{Hooks: []hookAction{{Type: "command", Command: legacy}}}); err != nil {
+	if err := sf.addHook("SessionStart", hookEntry{Hooks: []hookAction{{Type: "command", Command: testLegacyCmd}}}); err != nil {
 		t.Fatalf("addHook: %v", err)
 	}
 
-	desired := `"C:\ghost\ghost.exe" hook session-start`
-	action, err := reconcileHook(sf, "SessionStart", "hook session-start", desired, true)
+	action, err := reconcileHook(sf, "SessionStart", "hook session-start", testDesiredCmd, testLegacyCmd, true)
 	if err != nil {
 		t.Fatalf("reconcileHook: %v", err)
 	}
 	if action != hookMigrated {
 		t.Errorf("action = %v, want hookMigrated", action)
 	}
-	got, ok := sf.findHookCommand("SessionStart", "hook session-start")
-	if !ok || got != desired {
-		t.Errorf("findHookCommand = (%q, %v), want (%q, true)", got, ok, desired)
+	got, ok, _ := sf.findHookCommand("SessionStart", "hook session-start")
+	if !ok || got != testDesiredCmd {
+		t.Errorf("findHookCommand = (%q, %v), want (%q, true)", got, ok, testDesiredCmd)
 	}
 }
 
@@ -435,14 +420,14 @@ func TestReconcileHook_LeavesLegacyQuotingUntouchedOnPOSIX(t *testing.T) {
 		t.Fatalf("addHook: %v", err)
 	}
 
-	action, err := reconcileHook(sf, "SessionStart", "hook session-start", legacy, false)
+	action, err := reconcileHook(sf, "SessionStart", "hook session-start", legacy, legacy, false)
 	if err != nil {
 		t.Fatalf("reconcileHook: %v", err)
 	}
 	if action != hookUnchanged {
 		t.Errorf("action = %v, want hookUnchanged — single-quoted is the correct POSIX form", action)
 	}
-	got, _ := sf.findHookCommand("SessionStart", "hook session-start")
+	got, _, _ := sf.findHookCommand("SessionStart", "hook session-start")
 	if got != legacy {
 		t.Errorf("command changed to %q, want untouched %q", got, legacy)
 	}
@@ -459,16 +444,105 @@ func TestReconcileHook_LeavesCustomCommandUntouched(t *testing.T) {
 		t.Fatalf("addHook: %v", err)
 	}
 
-	action, err := reconcileHook(sf, "SessionStart", "hook session-start", `"C:\ghost\ghost.exe" hook session-start`, true)
+	action, err := reconcileHook(sf, "SessionStart", "hook session-start", testDesiredCmd, testLegacyCmd, true)
 	if err != nil {
 		t.Fatalf("reconcileHook: %v", err)
 	}
 	if action != hookUnchanged {
 		t.Errorf("action = %v, want hookUnchanged — a hand-edited command must never be clobbered", action)
 	}
-	got, _ := sf.findHookCommand("SessionStart", "hook session-start")
+	got, _, _ := sf.findHookCommand("SessionStart", "hook session-start")
 	if got != custom {
 		t.Errorf("command changed to %q, want untouched %q", got, custom)
+	}
+}
+
+// TestReconcileHook_MigratesExactLegacyCommandOnly covers the CodeRabbit
+// finding on PR #255: a hand-edited wrapper that starts with ' and mentions
+// "hook session-start" must never be mistaken for the legacy command, and the
+// exact legacy command must be found and migrated regardless of which entry
+// comes first in the hook list.
+func TestReconcileHook_MigratesExactLegacyCommandOnly(t *testing.T) {
+	wrapper := `'C:\tools\wrap.exe' --run 'hook session-start' --extra`
+
+	for _, order := range []string{"legacy-first", "wrapper-first"} {
+		t.Run(order, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			sf, err := loadSettings(path)
+			if err != nil {
+				t.Fatalf("loadSettings: %v", err)
+			}
+
+			first, second := testLegacyCmd, wrapper
+			if order == "wrapper-first" {
+				first, second = wrapper, testLegacyCmd
+			}
+			entry := hookEntry{Hooks: []hookAction{
+				{Type: "command", Command: first},
+				{Type: "command", Command: second},
+			}}
+			if err := sf.addHook("SessionStart", entry); err != nil {
+				t.Fatalf("addHook: %v", err)
+			}
+
+			action, err := reconcileHook(sf, "SessionStart", "hook session-start", testDesiredCmd, testLegacyCmd, true)
+			if err != nil {
+				t.Fatalf("reconcileHook: %v", err)
+			}
+			if action != hookMigrated {
+				t.Errorf("action = %v, want hookMigrated", action)
+			}
+
+			isLegacy, err := sf.hasExactHookCommand("SessionStart", testLegacyCmd)
+			if err != nil {
+				t.Fatalf("hasExactHookCommand: %v", err)
+			}
+			if isLegacy {
+				t.Error("legacy command was not migrated")
+			}
+			isDesired, err := sf.hasExactHookCommand("SessionStart", testDesiredCmd)
+			if err != nil {
+				t.Fatalf("hasExactHookCommand: %v", err)
+			}
+			if !isDesired {
+				t.Error("migrated command not found")
+			}
+			wrapperStillPresent, err := sf.hasExactHookCommand("SessionStart", wrapper)
+			if err != nil {
+				t.Fatalf("hasExactHookCommand: %v", err)
+			}
+			if !wrapperStillPresent {
+				t.Error("hand-edited wrapper was clobbered by the migration")
+			}
+		})
+	}
+}
+
+// TestReconcileHook_StopsOnMalformedHooks covers the CodeRabbit finding on
+// PR #255: a structurally invalid "hooks" value (valid JSON, wrong shape)
+// must halt reconciliation with an error rather than being silently
+// discarded by addHook's own parse-failure fallback.
+func TestReconcileHook_StopsOnMalformedHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(`{"hooks":[]}`), 0600); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatalf("loadSettings: %v", err)
+	}
+
+	if _, err := reconcileHook(sf, "SessionStart", "hook session-start", testDesiredCmd, testLegacyCmd, true); err == nil {
+		t.Fatal("expected reconcileHook to return an error for malformed hooks")
+	}
+
+	// The malformed value must survive untouched — no silent overwrite.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !strings.Contains(string(raw), `"hooks":[]`) {
+		t.Errorf("malformed hooks value was altered: %s", raw)
 	}
 }
 
@@ -488,7 +562,7 @@ func TestReconcileHook_PreservesOtherKeys(t *testing.T) {
 		t.Fatalf("loadSettings: %v", err)
 	}
 
-	if _, err := reconcileHook(sf, "SessionStart", "hook session-start", `"C:\ghost\ghost.exe" hook session-start`, true); err != nil {
+	if _, err := reconcileHook(sf, "SessionStart", "hook session-start", testDesiredCmd, testLegacyCmd, true); err != nil {
 		t.Fatalf("reconcileHook: %v", err)
 	}
 	if err := sf.save(); err != nil {

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -2,6 +2,7 @@ package mcpinit
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -358,5 +359,167 @@ func TestEnsureStopHook(t *testing.T) {
 	// SessionStart hooks are untouched.
 	if sf.hasHook("SessionStart", "hook stop") {
 		t.Error("Stop hook must not leak into SessionStart")
+	}
+}
+
+func TestNeedsQuoteMigration(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{"legacy single-quoted", "'/usr/local/bin/ghost' hook session-start", true},
+		{"cmd.exe double-quoted", `"C:\ghost\ghost.exe" hook session-start`, false},
+		{"unquoted", "ghost hook session-start", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		if got := needsQuoteMigration(tt.cmd); got != tt.want {
+			t.Errorf("needsQuoteMigration(%q) = %v, want %v", tt.cmd, got, tt.want)
+		}
+	}
+}
+
+func TestReconcileHook_AddsWhenAbsent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatalf("loadSettings: %v", err)
+	}
+
+	action, err := reconcileHook(sf, "SessionStart", "hook session-start", `"C:\ghost\ghost.exe" hook session-start`, true)
+	if err != nil {
+		t.Fatalf("reconcileHook: %v", err)
+	}
+	if action != hookAdded {
+		t.Errorf("action = %v, want hookAdded", action)
+	}
+	if !sf.hasHook("SessionStart", "hook session-start") {
+		t.Error("hook should be present")
+	}
+}
+
+func TestReconcileHook_MigratesLegacyQuotingOnWindows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatalf("loadSettings: %v", err)
+	}
+	legacy := `'C:\ghost\ghost.exe' hook session-start`
+	if err := sf.addHook("SessionStart", hookEntry{Hooks: []hookAction{{Type: "command", Command: legacy}}}); err != nil {
+		t.Fatalf("addHook: %v", err)
+	}
+
+	desired := `"C:\ghost\ghost.exe" hook session-start`
+	action, err := reconcileHook(sf, "SessionStart", "hook session-start", desired, true)
+	if err != nil {
+		t.Fatalf("reconcileHook: %v", err)
+	}
+	if action != hookMigrated {
+		t.Errorf("action = %v, want hookMigrated", action)
+	}
+	got, ok := sf.findHookCommand("SessionStart", "hook session-start")
+	if !ok || got != desired {
+		t.Errorf("findHookCommand = (%q, %v), want (%q, true)", got, ok, desired)
+	}
+}
+
+func TestReconcileHook_LeavesLegacyQuotingUntouchedOnPOSIX(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatalf("loadSettings: %v", err)
+	}
+	legacy := "'/usr/local/bin/ghost' hook session-start"
+	if err := sf.addHook("SessionStart", hookEntry{Hooks: []hookAction{{Type: "command", Command: legacy}}}); err != nil {
+		t.Fatalf("addHook: %v", err)
+	}
+
+	action, err := reconcileHook(sf, "SessionStart", "hook session-start", legacy, false)
+	if err != nil {
+		t.Fatalf("reconcileHook: %v", err)
+	}
+	if action != hookUnchanged {
+		t.Errorf("action = %v, want hookUnchanged — single-quoted is the correct POSIX form", action)
+	}
+	got, _ := sf.findHookCommand("SessionStart", "hook session-start")
+	if got != legacy {
+		t.Errorf("command changed to %q, want untouched %q", got, legacy)
+	}
+}
+
+func TestReconcileHook_LeavesCustomCommandUntouched(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatalf("loadSettings: %v", err)
+	}
+	custom := `"C:\tools\wrapper.exe" ghost hook session-start --verbose`
+	if err := sf.addHook("SessionStart", hookEntry{Hooks: []hookAction{{Type: "command", Command: custom}}}); err != nil {
+		t.Fatalf("addHook: %v", err)
+	}
+
+	action, err := reconcileHook(sf, "SessionStart", "hook session-start", `"C:\ghost\ghost.exe" hook session-start`, true)
+	if err != nil {
+		t.Fatalf("reconcileHook: %v", err)
+	}
+	if action != hookUnchanged {
+		t.Errorf("action = %v, want hookUnchanged — a hand-edited command must never be clobbered", action)
+	}
+	got, _ := sf.findHookCommand("SessionStart", "hook session-start")
+	if got != custom {
+		t.Errorf("command changed to %q, want untouched %q", got, custom)
+	}
+}
+
+func TestReconcileHook_PreservesOtherKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(`{
+		"otherTopLevelKey": "keep-me",
+		"hooks": {
+			"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "echo hi", "timeout": 30}]}],
+			"SessionStart": [{"matcher": "", "hooks": [{"type": "command", "command": "'C:\\ghost\\ghost.exe' hook session-start"}]}]
+		}
+	}`), 0600); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatalf("loadSettings: %v", err)
+	}
+
+	if _, err := reconcileHook(sf, "SessionStart", "hook session-start", `"C:\ghost\ghost.exe" hook session-start`, true); err != nil {
+		t.Fatalf("reconcileHook: %v", err)
+	}
+	if err := sf.save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out["otherTopLevelKey"] != "keep-me" {
+		t.Errorf("otherTopLevelKey was dropped: %v", out)
+	}
+	hooks, _ := out["hooks"].(map[string]any)
+	preToolUse, _ := json.Marshal(hooks["PreToolUse"])
+	if !strings.Contains(string(preToolUse), `"timeout":30`) {
+		t.Errorf("PreToolUse entry lost its timeout field: %s", preToolUse)
+	}
+}
+
+func TestWarnPercentPath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("warnPercentPath only warns on windows")
+	}
+	var out strings.Builder
+	warnPercentPath(&out, `C:\Users\%USERNAME%\ghost.exe`)
+	if !strings.Contains(out.String(), "warning") {
+		t.Errorf("expected a warning, got %q", out.String())
 	}
 }

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -546,6 +546,42 @@ func TestReconcileHook_StopsOnMalformedHooks(t *testing.T) {
 	}
 }
 
+// TestReconcileHook_StopsOnNullHooks covers the CodeRabbit Critical finding
+// on PR #255: {"hooks":null} must halt reconciliation with an error rather
+// than reaching addHook, which assigns into the "hooks" map unconditionally
+// and would panic on the nil map produced by unmarshaling a null root.
+func TestReconcileHook_StopsOnNullHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(`{"hooks":null}`), 0600); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatalf("loadSettings: %v", err)
+	}
+
+	if _, err := reconcileHook(sf, "SessionStart", "hook session-start", testDesiredCmd, testLegacyCmd, true); err == nil {
+		t.Fatal("expected reconcileHook to return an error for hooks:null")
+	}
+}
+
+// TestReconcileHook_StopsOnNullEventHooks covers the same finding for a null
+// value scoped to a single event rather than the whole "hooks" object.
+func TestReconcileHook_StopsOnNullEventHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(`{"hooks":{"SessionStart":null}}`), 0600); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatalf("loadSettings: %v", err)
+	}
+
+	if _, err := reconcileHook(sf, "SessionStart", "hook session-start", testDesiredCmd, testLegacyCmd, true); err == nil {
+		t.Fatal("expected reconcileHook to return an error for hooks.SessionStart:null")
+	}
+}
+
 func TestReconcileHook_PreservesOtherKeys(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	if err := os.WriteFile(path, []byte(`{

--- a/internal/mcpinit/settings.go
+++ b/internal/mcpinit/settings.go
@@ -249,6 +249,80 @@ func (s *settingsFile) hasHook(event, cmdSubstr string) bool {
 	return false
 }
 
+// findHookCommand returns the first hook command for event containing
+// cmdSubstr, and whether one was found.
+func (s *settingsFile) findHookCommand(event, cmdSubstr string) (string, bool) {
+	hooksRaw, ok := s.raw["hooks"]
+	if !ok {
+		return "", false
+	}
+
+	var hooks map[string][]hookEntry
+	if err := json.Unmarshal(hooksRaw, &hooks); err != nil {
+		return "", false
+	}
+
+	for _, entry := range hooks[event] {
+		for _, h := range entry.Hooks {
+			if strings.Contains(h.Command, cmdSubstr) {
+				return h.Command, true
+			}
+		}
+	}
+	return "", false
+}
+
+// replaceHookCommand rewrites every hook command for event containing
+// cmdSubstr to newCmd. Like addHook, it only unmarshals/re-marshals
+// hooks[event], so it does not disturb other events or unrelated top-level
+// keys. Returns false if no matching command was found.
+func (s *settingsFile) replaceHookCommand(event, cmdSubstr, newCmd string) (bool, error) {
+	raw, ok := s.raw["hooks"]
+	if !ok {
+		return false, nil
+	}
+
+	var hooks map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &hooks); err != nil {
+		return false, fmt.Errorf("parse hooks: %w", err)
+	}
+
+	eventRaw, ok := hooks[event]
+	if !ok {
+		return false, nil
+	}
+	var entries []hookEntry
+	if err := json.Unmarshal(eventRaw, &entries); err != nil {
+		return false, fmt.Errorf("parse %s hooks: %w", event, err)
+	}
+
+	found := false
+	for i := range entries {
+		for j := range entries[i].Hooks {
+			if strings.Contains(entries[i].Hooks[j].Command, cmdSubstr) {
+				entries[i].Hooks[j].Command = newCmd
+				found = true
+			}
+		}
+	}
+	if !found {
+		return false, nil
+	}
+
+	entriesJSON, err := json.Marshal(entries)
+	if err != nil {
+		return false, err
+	}
+	hooks[event] = entriesJSON
+
+	hooksJSON, err := json.Marshal(hooks)
+	if err != nil {
+		return false, err
+	}
+	s.raw["hooks"] = hooksJSON
+	return true, nil
+}
+
 // addHook adds a hook entry for the given event. Does not clobber existing hooks.
 func (s *settingsFile) addHook(event string, entry hookEntry) error {
 	var hooks map[string]json.RawMessage

--- a/internal/mcpinit/settings.go
+++ b/internal/mcpinit/settings.go
@@ -249,23 +249,51 @@ func (s *settingsFile) hasHook(event, cmdSubstr string) bool {
 	return false
 }
 
+// isJSONNull reports whether raw is the JSON literal null. json.Unmarshal
+// happily decodes null into a map or slice as nil with no error, which would
+// otherwise make an explicit null indistinguishable from "absent" — that
+// distinction matters here because "absent" is safe to fill in via addHook,
+// while an explicit null is structurally-invalid-but-present data that must
+// halt reconciliation instead.
+func isJSONNull(raw json.RawMessage) bool {
+	return strings.TrimSpace(string(raw)) == "null"
+}
+
 // findHookCommand returns the first hook command for event containing
-// cmdSubstr, and whether one was found. err is non-nil only when the
-// existing "hooks" value is present but structurally invalid — callers must
-// treat that as "stop", not "absent": proceeding to addHook would silently
-// discard the malformed value via its own parse-failure fallback.
+// cmdSubstr, and whether one was found. err is non-nil when the existing
+// "hooks" value (or the specific event's value within it) is present but
+// structurally invalid — including explicit JSON null, which unmarshals into
+// a nil map/slice with no error — so callers must treat that as "stop", not
+// "absent": proceeding to addHook on a nil "hooks" map panics, and on a nil
+// per-event value silently discards it.
 func (s *settingsFile) findHookCommand(event, cmdSubstr string) (cmd string, ok bool, err error) {
 	hooksRaw, present := s.raw["hooks"]
 	if !present {
 		return "", false, nil
 	}
+	if isJSONNull(hooksRaw) {
+		return "", false, fmt.Errorf("hooks is null")
+	}
 
-	var hooks map[string][]hookEntry
-	if uerr := json.Unmarshal(hooksRaw, &hooks); uerr != nil {
+	var hooksMap map[string]json.RawMessage
+	if uerr := json.Unmarshal(hooksRaw, &hooksMap); uerr != nil {
 		return "", false, fmt.Errorf("parse hooks: %w", uerr)
 	}
 
-	for _, entry := range hooks[event] {
+	eventRaw, present := hooksMap[event]
+	if !present {
+		return "", false, nil
+	}
+	if isJSONNull(eventRaw) {
+		return "", false, fmt.Errorf("hooks[%s] is null", event)
+	}
+
+	var entries []hookEntry
+	if uerr := json.Unmarshal(eventRaw, &entries); uerr != nil {
+		return "", false, fmt.Errorf("parse %s hooks: %w", event, uerr)
+	}
+
+	for _, entry := range entries {
 		for _, h := range entry.Hooks {
 			if strings.Contains(h.Command, cmdSubstr) {
 				return h.Command, true, nil
@@ -285,13 +313,29 @@ func (s *settingsFile) hasExactHookCommand(event, cmd string) (bool, error) {
 	if !present {
 		return false, nil
 	}
+	if isJSONNull(hooksRaw) {
+		return false, fmt.Errorf("hooks is null")
+	}
 
-	var hooks map[string][]hookEntry
-	if err := json.Unmarshal(hooksRaw, &hooks); err != nil {
+	var hooksMap map[string]json.RawMessage
+	if err := json.Unmarshal(hooksRaw, &hooksMap); err != nil {
 		return false, fmt.Errorf("parse hooks: %w", err)
 	}
 
-	for _, entry := range hooks[event] {
+	eventRaw, present := hooksMap[event]
+	if !present {
+		return false, nil
+	}
+	if isJSONNull(eventRaw) {
+		return false, fmt.Errorf("hooks[%s] is null", event)
+	}
+
+	var entries []hookEntry
+	if err := json.Unmarshal(eventRaw, &entries); err != nil {
+		return false, fmt.Errorf("parse %s hooks: %w", event, err)
+	}
+
+	for _, entry := range entries {
 		for _, h := range entry.Hooks {
 			if h.Command == cmd {
 				return true, nil
@@ -312,6 +356,9 @@ func (s *settingsFile) replaceHookCommand(event, oldCmd, newCmd string) (bool, e
 	if !ok {
 		return false, nil
 	}
+	if isJSONNull(raw) {
+		return false, fmt.Errorf("hooks is null")
+	}
 
 	var hooks map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &hooks); err != nil {
@@ -321,6 +368,9 @@ func (s *settingsFile) replaceHookCommand(event, oldCmd, newCmd string) (bool, e
 	eventRaw, ok := hooks[event]
 	if !ok {
 		return false, nil
+	}
+	if isJSONNull(eventRaw) {
+		return false, fmt.Errorf("hooks[%s] is null", event)
 	}
 	var entries []hookEntry
 	if err := json.Unmarshal(eventRaw, &entries); err != nil {
@@ -361,7 +411,8 @@ func (s *settingsFile) addHook(event string, entry hookEntry) error {
 		if err := json.Unmarshal(raw, &hooks); err != nil {
 			hooks = make(map[string]json.RawMessage)
 		}
-	} else {
+	}
+	if hooks == nil {
 		hooks = make(map[string]json.RawMessage)
 	}
 

--- a/internal/mcpinit/settings.go
+++ b/internal/mcpinit/settings.go
@@ -250,33 +250,64 @@ func (s *settingsFile) hasHook(event, cmdSubstr string) bool {
 }
 
 // findHookCommand returns the first hook command for event containing
-// cmdSubstr, and whether one was found.
-func (s *settingsFile) findHookCommand(event, cmdSubstr string) (string, bool) {
-	hooksRaw, ok := s.raw["hooks"]
-	if !ok {
-		return "", false
+// cmdSubstr, and whether one was found. err is non-nil only when the
+// existing "hooks" value is present but structurally invalid — callers must
+// treat that as "stop", not "absent": proceeding to addHook would silently
+// discard the malformed value via its own parse-failure fallback.
+func (s *settingsFile) findHookCommand(event, cmdSubstr string) (cmd string, ok bool, err error) {
+	hooksRaw, present := s.raw["hooks"]
+	if !present {
+		return "", false, nil
 	}
 
 	var hooks map[string][]hookEntry
-	if err := json.Unmarshal(hooksRaw, &hooks); err != nil {
-		return "", false
+	if uerr := json.Unmarshal(hooksRaw, &hooks); uerr != nil {
+		return "", false, fmt.Errorf("parse hooks: %w", uerr)
 	}
 
 	for _, entry := range hooks[event] {
 		for _, h := range entry.Hooks {
 			if strings.Contains(h.Command, cmdSubstr) {
-				return h.Command, true
+				return h.Command, true, nil
 			}
 		}
 	}
-	return "", false
+	return "", false, nil
 }
 
-// replaceHookCommand rewrites every hook command for event containing
-// cmdSubstr to newCmd. Like addHook, it only unmarshals/re-marshals
-// hooks[event], so it does not disturb other events or unrelated top-level
-// keys. Returns false if no matching command was found.
-func (s *settingsFile) replaceHookCommand(event, cmdSubstr, newCmd string) (bool, error) {
+// hasExactHookCommand reports whether any hook command for event exactly
+// equals cmd. Used to find the precise pre-#251 legacy command rather than
+// anything that merely contains the same substring — a hand-edited wrapper
+// can legitimately contain "hook session-start" too, and must never be
+// mistaken for the legacy command.
+func (s *settingsFile) hasExactHookCommand(event, cmd string) (bool, error) {
+	hooksRaw, present := s.raw["hooks"]
+	if !present {
+		return false, nil
+	}
+
+	var hooks map[string][]hookEntry
+	if err := json.Unmarshal(hooksRaw, &hooks); err != nil {
+		return false, fmt.Errorf("parse hooks: %w", err)
+	}
+
+	for _, entry := range hooks[event] {
+		for _, h := range entry.Hooks {
+			if h.Command == cmd {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// replaceHookCommand rewrites every hook command for event that exactly
+// equals oldCmd to newCmd — an exact match, not a substring one, so a
+// hand-edited command that merely contains the same text is never touched.
+// Like addHook, it only unmarshals/re-marshals hooks[event], so it does not
+// disturb other events or unrelated top-level keys. Returns false if no
+// exact match was found.
+func (s *settingsFile) replaceHookCommand(event, oldCmd, newCmd string) (bool, error) {
 	raw, ok := s.raw["hooks"]
 	if !ok {
 		return false, nil
@@ -299,7 +330,7 @@ func (s *settingsFile) replaceHookCommand(event, cmdSubstr, newCmd string) (bool
 	found := false
 	for i := range entries {
 		for j := range entries[i].Hooks {
-			if strings.Contains(entries[i].Hooks[j].Command, cmdSubstr) {
+			if entries[i].Hooks[j].Command == oldCmd {
 				entries[i].Hooks[j].Command = newCmd
 				found = true
 			}

--- a/internal/mcpinit/settings_test.go
+++ b/internal/mcpinit/settings_test.go
@@ -203,6 +203,48 @@ func TestFindHookCommand_MalformedHooksReturnsError(t *testing.T) {
 	}
 }
 
+func TestFindHookCommand_NullHooksReturnsError(t *testing.T) {
+	path := tempSettings(t, `{"hooks":null}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := sf.findHookCommand("SessionStart", "hook session-start"); err == nil {
+		t.Error("expected findHookCommand to return an error for hooks:null")
+	}
+}
+
+func TestFindHookCommand_NullEventReturnsError(t *testing.T) {
+	path := tempSettings(t, `{"hooks":{"SessionStart":null}}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := sf.findHookCommand("SessionStart", "hook session-start"); err == nil {
+		t.Error("expected findHookCommand to return an error for hooks.SessionStart:null")
+	}
+}
+
+// TestAddHook_NeverCalledWithNullHooks documents the invariant that prevents
+// the CodeRabbit-flagged panic: addHook assigns into the "hooks" map
+// unconditionally, so it must never be reached when "hooks" is null. In
+// production the only caller is reconcileHook, which is gated behind
+// findHookCommand's error return — this test proves addHook itself no
+// longer panics even if that gate is bypassed, since json.Unmarshal of a
+// null root leaves the local map nil and the assignment below would panic
+// without the nil-guard added alongside these findHookCommand changes.
+func TestAddHook_NullHooksDoesNotPanic(t *testing.T) {
+	path := tempSettings(t, `{"hooks":null}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := hookEntry{Hooks: []hookAction{{Type: "command", Command: "ghost hook session-start"}}}
+	if err := sf.addHook("SessionStart", entry); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestHasExactHookCommand(t *testing.T) {
 	path := tempSettings(t, `{}`)
 	sf, err := loadSettings(path)

--- a/internal/mcpinit/settings_test.go
+++ b/internal/mcpinit/settings_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -158,6 +159,81 @@ func TestAddHook_PreservesExisting(t *testing.T) {
 	}
 	if _, ok := hooks["SessionStart"]; !ok {
 		t.Error("SessionStart hook was not added")
+	}
+}
+
+func TestFindHookCommand_NotPresent(t *testing.T) {
+	path := tempSettings(t, `{}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := sf.findHookCommand("SessionStart", "hook session-start"); ok {
+		t.Error("expected findHookCommand to return false")
+	}
+}
+
+func TestFindHookCommand_Present(t *testing.T) {
+	path := tempSettings(t, `{}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := hookEntry{Hooks: []hookAction{{Type: "command", Command: "ghost hook session-start"}}}
+	if err := sf.addHook("SessionStart", entry); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := sf.findHookCommand("SessionStart", "hook session-start")
+	if !ok || got != "ghost hook session-start" {
+		t.Errorf("findHookCommand = (%q, %v), want (%q, true)", got, ok, "ghost hook session-start")
+	}
+}
+
+func TestReplaceHookCommand_NoMatchingEvent(t *testing.T) {
+	path := tempSettings(t, `{}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replaced, err := sf.replaceHookCommand("SessionStart", "hook session-start", "new command")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replaced {
+		t.Error("expected replaceHookCommand to return false when hooks are absent")
+	}
+}
+
+func TestReplaceHookCommand_PreservesOtherEventsAndFields(t *testing.T) {
+	existing := `{"hooks":{
+		"PreToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"check.sh","timeout":30}]}],
+		"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"'/usr/local/bin/ghost' hook session-start"}]}]
+	}}`
+	path := tempSettings(t, existing)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replaced, err := sf.replaceHookCommand("SessionStart", "hook session-start", `"C:\ghost\ghost.exe" hook session-start`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !replaced {
+		t.Fatal("expected replaceHookCommand to report a match")
+	}
+
+	got, ok := sf.findHookCommand("SessionStart", "hook session-start")
+	if !ok || got != `"C:\ghost\ghost.exe" hook session-start` {
+		t.Errorf("SessionStart command = (%q, %v), want the replaced command", got, ok)
+	}
+
+	var hooks map[string]json.RawMessage
+	if err := json.Unmarshal(sf.raw["hooks"], &hooks); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(hooks["PreToolUse"]), `"timeout":30`) {
+		t.Errorf("PreToolUse entry lost its timeout field: %s", hooks["PreToolUse"])
 	}
 }
 

--- a/internal/mcpinit/settings_test.go
+++ b/internal/mcpinit/settings_test.go
@@ -168,8 +168,8 @@ func TestFindHookCommand_NotPresent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := sf.findHookCommand("SessionStart", "hook session-start"); ok {
-		t.Error("expected findHookCommand to return false")
+	if _, ok, err := sf.findHookCommand("SessionStart", "hook session-start"); ok || err != nil {
+		t.Errorf("expected findHookCommand to return (_, false, nil), got (_, %v, %v)", ok, err)
 	}
 }
 
@@ -183,9 +183,51 @@ func TestFindHookCommand_Present(t *testing.T) {
 	if err := sf.addHook("SessionStart", entry); err != nil {
 		t.Fatal(err)
 	}
-	got, ok := sf.findHookCommand("SessionStart", "hook session-start")
+	got, ok, err := sf.findHookCommand("SessionStart", "hook session-start")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !ok || got != "ghost hook session-start" {
 		t.Errorf("findHookCommand = (%q, %v), want (%q, true)", got, ok, "ghost hook session-start")
+	}
+}
+
+func TestFindHookCommand_MalformedHooksReturnsError(t *testing.T) {
+	path := tempSettings(t, `{"hooks":[]}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := sf.findHookCommand("SessionStart", "hook session-start"); err == nil {
+		t.Error("expected findHookCommand to return an error for a malformed hooks value")
+	}
+}
+
+func TestHasExactHookCommand(t *testing.T) {
+	path := tempSettings(t, `{}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := hookEntry{Hooks: []hookAction{{Type: "command", Command: "'/usr/local/bin/ghost' hook session-start"}}}
+	if err := sf.addHook("SessionStart", entry); err != nil {
+		t.Fatal(err)
+	}
+
+	exact, err := sf.hasExactHookCommand("SessionStart", "'/usr/local/bin/ghost' hook session-start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exact {
+		t.Error("expected exact match to be found")
+	}
+
+	partial, err := sf.hasExactHookCommand("SessionStart", "hook session-start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if partial {
+		t.Error("expected substring-only match to NOT be treated as exact")
 	}
 }
 
@@ -205,9 +247,10 @@ func TestReplaceHookCommand_NoMatchingEvent(t *testing.T) {
 }
 
 func TestReplaceHookCommand_PreservesOtherEventsAndFields(t *testing.T) {
+	legacy := "'/usr/local/bin/ghost' hook session-start"
 	existing := `{"hooks":{
 		"PreToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"check.sh","timeout":30}]}],
-		"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"'/usr/local/bin/ghost' hook session-start"}]}]
+		"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"` + legacy + `"}]}]
 	}}`
 	path := tempSettings(t, existing)
 	sf, err := loadSettings(path)
@@ -215,7 +258,8 @@ func TestReplaceHookCommand_PreservesOtherEventsAndFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	replaced, err := sf.replaceHookCommand("SessionStart", "hook session-start", `"C:\ghost\ghost.exe" hook session-start`)
+	desired := `"C:\ghost\ghost.exe" hook session-start`
+	replaced, err := sf.replaceHookCommand("SessionStart", legacy, desired)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,8 +267,11 @@ func TestReplaceHookCommand_PreservesOtherEventsAndFields(t *testing.T) {
 		t.Fatal("expected replaceHookCommand to report a match")
 	}
 
-	got, ok := sf.findHookCommand("SessionStart", "hook session-start")
-	if !ok || got != `"C:\ghost\ghost.exe" hook session-start` {
+	got, ok, err := sf.findHookCommand("SessionStart", "hook session-start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || got != desired {
 		t.Errorf("SessionStart command = (%q, %v), want the replaced command", got, ok)
 	}
 
@@ -234,6 +281,35 @@ func TestReplaceHookCommand_PreservesOtherEventsAndFields(t *testing.T) {
 	}
 	if !strings.Contains(string(hooks["PreToolUse"]), `"timeout":30`) {
 		t.Errorf("PreToolUse entry lost its timeout field: %s", hooks["PreToolUse"])
+	}
+}
+
+func TestReplaceHookCommand_DoesNotTouchNonExactMatch(t *testing.T) {
+	wrapper := "'/opt/wrap.sh' --run 'hook session-start' --extra"
+	path := tempSettings(t, `{}`)
+	sf, err := loadSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := hookEntry{Hooks: []hookAction{{Type: "command", Command: wrapper}}}
+	if err := sf.addHook("SessionStart", entry); err != nil {
+		t.Fatal(err)
+	}
+
+	replaced, err := sf.replaceHookCommand("SessionStart", "'/usr/local/bin/ghost' hook session-start", "new command")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replaced {
+		t.Error("expected replaceHookCommand to report no match for a command that only contains the substring")
+	}
+
+	got, ok, err := sf.findHookCommand("SessionStart", "hook session-start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || got != wrapper {
+		t.Errorf("wrapper command was altered: got (%q, %v), want untouched %q", got, ok, wrapper)
 	}
 }
 


### PR DESCRIPTION
## Summary
Addresses items 1 and 2 of #252 (item 3 — Windows PID-reuse detection — is a separate, larger PID-file-format change spanning multiple writers and is being scoped as its own branch).

- `ensureHook`/`ensureStopHook` now migrate the pre-#251 single-quoted hook command to the correct cmd.exe-safe quoting, but only on Windows and only for that exact legacy signature — hand-edited or already-correct commands are left untouched (re-running `ghost mcp init` stays non-destructive).
- Warn (rather than guess an escape) when the resolved ghost binary path contains `%` on Windows, since cmd.exe may substitute `%VAR%` sequences and there's no `%%`-doubling escape that's verified safe outside batch-file parsing.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (all packages green)
- [x] `go test ./internal/mcpinit/... -race -count=1`
- [x] New tests cover: add-when-absent, migrate-on-Windows, leave-untouched-on-POSIX (single-quote is the correct POSIX form), leave-hand-edited-command-untouched, and preservation of unrelated settings.json keys/fields across the rewrite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SessionStart and Stop hook setup by adding missing hooks and safely migrating legacy Windows command quoting.
  * Preserved custom commands, unrelated settings, and nested hook configuration.
  * Added warnings for Windows paths containing `%`, which may be interpreted as environment variables.
  * Improved status reporting to indicate whether hooks were added, migrated, or already configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->