### PR TITLE
fix(mcpinit): detect PID reuse via process creation-time token

### DIFF
--- a/docs/superpowers/plans/2026-08-09-pid-reuse-creation-time.md
+++ b/docs/superpowers/plans/2026-08-09-pid-reuse-creation-time.md
@@ -1,0 +1,975 @@
+# PID-Reuse Detection via Process Creation Time — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `isAlive()` in `internal/mcpinit` detect PID reuse (a dead process's PID handed to an unrelated new process) across Linux, macOS, and Windows, closing item 3 of GitHub issue #252.
+
+**Architecture:** Record each spawned process's OS-assigned creation time as an opaque string token alongside its PID in the `.pid` file (`"<pid>:<token>"`). At liveness-check time, re-derive the current holder's token and require an exact match; mismatch means the PID was recycled. A bare PID with no colon is the legacy format and falls back to today's PID-only check. Every new syscall path fails open (treats unreadable/unsupported as "can't tell, don't break the caller").
+
+**Tech Stack:** Go 1.26, `golang.org/x/sys/unix` (darwin), `golang.org/x/sys/windows` (already a direct dependency), `/proc` on Linux. No new dependencies.
+
+**Design spec:** `docs/superpowers/specs/2026-08-09-pid-reuse-creation-time-design.md`
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `internal/mcpinit/obsidiansync_linux.go` | Create | `processStartTime` for Linux (boot_id + `/proc/<pid>/stat` starttime) |
+| `internal/mcpinit/obsidiansync_linux_test.go` | Create | Tests for the above |
+| `internal/mcpinit/obsidiansync_darwin.go` | Create | `processStartTime` for macOS (`SysctlKinfoProc` wall-clock `Timeval`) |
+| `internal/mcpinit/obsidiansync_darwin_test.go` | Create | Tests for the above |
+| `internal/mcpinit/obsidiansync_unix_other.go` | Create | `processStartTime` fallback (`"", false`) for any other Unix |
+| `internal/mcpinit/obsidiansync_windows.go` | Modify | Add `processStartTime`; change `isProcessAlive` to 3-arg token-aware form |
+| `internal/mcpinit/obsidiansync_unix.go` | Modify | Change `isProcessAlive` to 3-arg token-aware form (shared by linux+darwin+other unix) |
+| `internal/mcpinit/obsidiansync.go` | Modify | `isAlive` parses `"pid:token"`; `ensureObsidianSyncRunning` writes via token-aware `atomicWritePID` |
+| `internal/mcpinit/stophook.go` | Modify | `atomicWritePID` gains token params; `claimPidFile`'s placeholder write gets a token too; both spawn functions pass tokens |
+| `internal/mcpinit/obsidiansync_test.go` | Modify | New tests for token-format `isAlive` behavior |
+| `internal/mcpinit/stophook_test.go` | Modify | New test for `claimPidFile`'s placeholder-token fix |
+
+No new packages, no new files outside `internal/mcpinit`.
+
+---
+
+### Task 1: Linux `processStartTime`
+
+**Files:**
+- Create: `internal/mcpinit/obsidiansync_linux.go`
+- Test: `internal/mcpinit/obsidiansync_linux_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+//go:build linux
+
+package mcpinit
+
+import (
+	"os"
+	"testing"
+)
+
+func TestProcessStartTime_OwnPID(t *testing.T) {
+	token, ok := processStartTime(os.Getpid())
+	if !ok {
+		t.Fatal("processStartTime(own pid) ok = false, want true")
+	}
+	if token == "" {
+		t.Error("processStartTime(own pid) returned an empty token with ok=true")
+	}
+}
+
+func TestProcessStartTime_Stable(t *testing.T) {
+	a, okA := processStartTime(os.Getpid())
+	b, okB := processStartTime(os.Getpid())
+	if !okA || !okB {
+		t.Fatal("processStartTime(own pid) failed on a repeat call")
+	}
+	if a != b {
+		t.Errorf("processStartTime(own pid) not stable across calls: %q vs %q", a, b)
+	}
+}
+
+func TestProcessStartTime_ImplausiblePID(t *testing.T) {
+	if _, ok := processStartTime(999999999); ok {
+		t.Error("processStartTime(implausible pid) ok = true, want false")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/mcpinit/... -run TestProcessStartTime -v`
+Expected: FAIL with `undefined: processStartTime`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+//go:build linux
+
+package mcpinit
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// processStartTime returns an opaque token identifying pid's process
+// creation instant, or ("", false) if it can't be determined (process
+// gone, unreadable /proc entry, permission denied).
+//
+// The raw source — /proc/<pid>/stat field 22 ("starttime") — is clock
+// ticks since boot, not wall-clock, so it is NOT by itself reboot-safe:
+// .pid files persist in dataDir across reboots, and a freshly-started,
+// unrelated process after a reboot can coincidentally have the same
+// boot-relative tick count a stale file recorded before the reboot. The
+// machine's boot ID (a fresh UUID generated at every boot) is prefixed so
+// a pre-reboot token can never match a post-reboot one, regardless of tick
+// coincidence.
+func processStartTime(pid int) (string, bool) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return "", false
+	}
+	line := string(data)
+
+	// comm (field 2) is wrapped in parens and can itself contain spaces and
+	// parens, so split on the *last* ')' to find where it ends unambiguously.
+	idx := strings.LastIndexByte(line, ')')
+	if idx == -1 || idx+2 >= len(line) {
+		return "", false
+	}
+	// Fields after the split start at field 3 (state); field 22 (starttime)
+	// is therefore remainder-index 22-3 = 19.
+	fields := strings.Fields(line[idx+2:])
+	const starttimeIdx = 19
+	if starttimeIdx >= len(fields) {
+		return "", false
+	}
+	starttime := fields[starttimeIdx]
+
+	bootID, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(bootID)) + "-" + starttime, true
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/mcpinit/... -run TestProcessStartTime -v`
+Expected: PASS (all 3 subtests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcpinit/obsidiansync_linux.go internal/mcpinit/obsidiansync_linux_test.go
+git commit -m "feat(mcpinit): add Linux process creation-time token"
+```
+
+---
+
+### Task 2: Darwin `processStartTime`
+
+**Files:**
+- Create: `internal/mcpinit/obsidiansync_darwin.go`
+- Test: `internal/mcpinit/obsidiansync_darwin_test.go`
+
+This task cannot run on this Linux dev machine — verify with `GOOS=darwin GOARCH=arm64 go vet ./internal/mcpinit/...` and `GOOS=darwin GOARCH=amd64 go build ./internal/mcpinit/...` instead of executing the test. The test itself is still written now so it runs for real in a future macOS CI run or local macOS dev loop.
+
+- [ ] **Step 1: Write the test (cannot execute locally — write it first per TDD intent, verify by cross-compiling)**
+
+```go
+//go:build darwin
+
+package mcpinit
+
+import (
+	"os"
+	"testing"
+)
+
+func TestProcessStartTime_OwnPID(t *testing.T) {
+	token, ok := processStartTime(os.Getpid())
+	if !ok {
+		t.Fatal("processStartTime(own pid) ok = false, want true")
+	}
+	if token == "" {
+		t.Error("processStartTime(own pid) returned an empty token with ok=true")
+	}
+}
+
+func TestProcessStartTime_Stable(t *testing.T) {
+	a, okA := processStartTime(os.Getpid())
+	b, okB := processStartTime(os.Getpid())
+	if !okA || !okB {
+		t.Fatal("processStartTime(own pid) failed on a repeat call")
+	}
+	if a != b {
+		t.Errorf("processStartTime(own pid) not stable across calls: %q vs %q", a, b)
+	}
+}
+
+func TestProcessStartTime_ImplausiblePID(t *testing.T) {
+	if _, ok := processStartTime(999999999); ok {
+		t.Error("processStartTime(implausible pid) ok = true, want false")
+	}
+}
+```
+
+- [ ] **Step 2: Verify it fails to compile (proves the symbol doesn't exist yet)**
+
+Run: `GOOS=darwin GOARCH=arm64 go vet ./internal/mcpinit/...`
+Expected: FAIL with `undefined: processStartTime`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+//go:build darwin
+
+package mcpinit
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// processStartTime returns an opaque token identifying pid's process
+// creation instant, or ("", false) if it can't be determined. KinfoProc's
+// P_starttime is a wall-clock Timeval (seconds+microseconds since epoch),
+// so — unlike Linux's boot-relative ticks — it is already reboot-safe with
+// no extra prefixing needed.
+func processStartTime(pid int) (string, bool) {
+	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return "", false
+	}
+	tv := kp.Proc.P_starttime
+	return fmt.Sprintf("%d.%d", tv.Sec, tv.Usec), true
+}
+```
+
+- [ ] **Step 4: Verify it builds and vets clean**
+
+Run: `GOOS=darwin GOARCH=arm64 go vet ./internal/mcpinit/... && GOOS=darwin GOARCH=amd64 go build ./internal/mcpinit/...`
+Expected: no output, exit 0
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcpinit/obsidiansync_darwin.go internal/mcpinit/obsidiansync_darwin_test.go
+git commit -m "feat(mcpinit): add Darwin process creation-time token"
+```
+
+---
+
+### Task 3: Fallback `processStartTime` for other Unix
+
+**Files:**
+- Create: `internal/mcpinit/obsidiansync_unix_other.go`
+
+No test file — this is a one-line intentional no-op, and its only observable behavior (fail open to legacy PID-only liveness) is already covered by Task 5/6's `isProcessAlive` tests using `haveToken=false`.
+
+- [ ] **Step 1: Write the implementation**
+
+```go
+//go:build !windows && !linux && !darwin
+
+package mcpinit
+
+// processStartTime has no known implementation on this OS. Returning
+// ("", false) degrades callers to legacy PID-only liveness checking,
+// identical to today's behavior — no regression, just no reuse detection
+// on whatever unlisted Unix this is.
+func processStartTime(pid int) (string, bool) {
+	return "", false
+}
+```
+
+- [ ] **Step 2: Verify it compiles for a representative excluded OS**
+
+Run: `GOOS=freebsd GOARCH=amd64 go build ./internal/mcpinit/...`
+Expected: no output, exit 0 (this also proves the build-tag exclusion is correct: if it overlapped with linux/darwin/windows, those builds would now fail on a duplicate `processStartTime` definition — check that too)
+Run: `go build ./internal/mcpinit/... && GOOS=darwin GOARCH=arm64 go build ./internal/mcpinit/... && GOOS=windows GOARCH=amd64 go build ./internal/mcpinit/...`
+Expected: no output, exit 0 for all three
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/mcpinit/obsidiansync_unix_other.go
+git commit -m "feat(mcpinit): fall back to legacy liveness on unlisted Unix"
+```
+
+---
+
+### Task 4: Windows `processStartTime`
+
+**Files:**
+- Modify: `internal/mcpinit/obsidiansync_windows.go`
+- Create: `internal/mcpinit/obsidiansync_windows_test.go`
+
+Same cross-compile-only caveat as Task 2 — this cannot execute on this Linux machine.
+
+- [ ] **Step 1: Write the test**
+
+```go
+//go:build windows
+
+package mcpinit
+
+import (
+	"os"
+	"testing"
+)
+
+func TestProcessStartTime_OwnPID(t *testing.T) {
+	token, ok := processStartTime(os.Getpid())
+	if !ok {
+		t.Fatal("processStartTime(own pid) ok = false, want true")
+	}
+	if token == "" {
+		t.Error("processStartTime(own pid) returned an empty token with ok=true")
+	}
+}
+
+func TestProcessStartTime_Stable(t *testing.T) {
+	a, okA := processStartTime(os.Getpid())
+	b, okB := processStartTime(os.Getpid())
+	if !okA || !okB {
+		t.Fatal("processStartTime(own pid) failed on a repeat call")
+	}
+	if a != b {
+		t.Errorf("processStartTime(own pid) not stable across calls: %q vs %q", a, b)
+	}
+}
+
+func TestProcessStartTime_ImplausiblePID(t *testing.T) {
+	if _, ok := processStartTime(999999999); ok {
+		t.Error("processStartTime(implausible pid) ok = true, want false")
+	}
+}
+```
+
+- [ ] **Step 2: Verify it fails to compile**
+
+Run: `GOOS=windows GOARCH=amd64 go vet ./internal/mcpinit/...`
+Expected: FAIL with `undefined: processStartTime`
+
+- [ ] **Step 3: Add the implementation to `obsidiansync_windows.go`**
+
+Add `"strconv"` to the existing import block, then append below `isProcessAlive` (implementation unchanged for now — signature change is Task 6):
+
+```go
+// processStartTime returns an opaque token identifying pid's process
+// creation instant, or ("", false) if it can't be determined. The
+// creation Filetime is wall-clock (100ns intervals since 1601-01-01), so
+// it is already reboot-safe with no extra prefixing needed.
+func processStartTime(pid int) (string, bool) {
+	if pid <= 0 || int64(pid) > 0xFFFFFFFF {
+		return "", false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return "", false
+	}
+	defer windows.CloseHandle(h) //nolint:errcheck
+
+	var creationTime, exitTime, kernelTime, userTime windows.Filetime
+	if err := windows.GetProcessTimes(h, &creationTime, &exitTime, &kernelTime, &userTime); err != nil {
+		return "", false
+	}
+	value := uint64(creationTime.HighDateTime)<<32 | uint64(creationTime.LowDateTime)
+	return strconv.FormatUint(value, 10), true
+}
+```
+
+The full updated import block:
+
+```go
+import (
+	"os/exec"
+	"strconv"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+```
+
+- [ ] **Step 4: Verify it builds and vets clean**
+
+Run: `GOOS=windows GOARCH=amd64 go vet ./internal/mcpinit/... && GOOS=windows GOARCH=arm64 go build ./internal/mcpinit/...`
+Expected: no output, exit 0
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcpinit/obsidiansync_windows.go internal/mcpinit/obsidiansync_windows_test.go
+git commit -m "feat(mcpinit): add Windows process creation-time token"
+```
+
+---
+
+### Task 5: Token-aware `isProcessAlive` on POSIX
+
+**Files:**
+- Modify: `internal/mcpinit/obsidiansync_unix.go`
+- Modify: `internal/mcpinit/obsidiansync_test.go` (add tests; this file has no build tag, so it runs on every OS including Windows in CI... it doesn't today since it's Unix-focused, but check: existing `obsidiansync_test.go` has no build tag and calls `isAlive`, `ensureObsidianSyncRunning` — those are OS-agnostic entry points already, so this is fine. New tests added here must also be OS-agnostic; anything Unix-signal-specific goes in Task 5 only if it needs no build tag. Since `isAlive`/`isProcessAlive` behavior differs on Windows only in the underlying liveness primitive, not the token contract, token behavior tests belong in the OS-agnostic file (they exercise `isAlive`, not `isProcessAlive` directly) — see Task 7.)
+
+This task only touches the POSIX signal-0 file itself.
+
+- [ ] **Step 1: Write the failing test** (Linux-only, since it needs `processStartTime` from Task 1; darwin gets the same coverage for free via Task 2's build)
+
+```go
+//go:build linux
+
+package mcpinit
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsProcessAlive_TokenMatch(t *testing.T) {
+	token, ok := processStartTime(os.Getpid())
+	if !ok {
+		t.Fatal("processStartTime(own pid) failed; can't set up test")
+	}
+	if !isProcessAlive(os.Getpid(), token, true) {
+		t.Error("isProcessAlive(own pid, own true token) = false, want true")
+	}
+}
+
+func TestIsProcessAlive_TokenMismatch(t *testing.T) {
+	if isProcessAlive(os.Getpid(), "definitely-not-the-real-token", true) {
+		t.Error("isProcessAlive(own pid, wrong token) = true, want false (PID-reuse must be detected)")
+	}
+}
+
+func TestIsProcessAlive_NoToken(t *testing.T) {
+	if !isProcessAlive(os.Getpid(), "", false) {
+		t.Error("isProcessAlive(own pid, haveToken=false) = false, want true (legacy behavior preserved)")
+	}
+}
+
+func TestIsProcessAlive_DeadPIDIgnoresToken(t *testing.T) {
+	if isProcessAlive(999999999, "anything", true) {
+		t.Error("isProcessAlive(implausible pid, ...) = true, want false")
+	}
+}
+```
+
+Add this file as `internal/mcpinit/obsidiansync_linux_test.go`'s continuation — actually, append these functions into the *same* `obsidiansync_linux_test.go` created in Task 1 (same build tag, same file, avoids a near-duplicate file). Skip creating a new file for this step; edit the Task 1 file instead.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/mcpinit/... -run TestIsProcessAlive -v`
+Expected: FAIL — `isProcessAlive` still takes 1 argument, so this won't compile: `too many arguments in call to isProcessAlive`
+
+- [ ] **Step 3: Change `isProcessAlive`'s signature and implementation**
+
+In `internal/mcpinit/obsidiansync_unix.go`, replace:
+
+```go
+// isProcessAlive reports whether pid names a running process, by sending
+// it signal 0 — this checks existence and permission without actually
+// signaling the process.
+func isProcessAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+```
+
+with:
+
+```go
+// isProcessAlive reports whether pid names a running process, by sending
+// it signal 0 — this checks existence and permission without actually
+// signaling the process. If haveToken is true, a live PID is additionally
+// required to still carry wantToken as its creation-time token — a
+// mismatch means the OS recycled pid to an unrelated process after the
+// original one exited, which plain signal-0 can't distinguish from the
+// original still running. A transient failure to read the fresh token
+// fails open to "alive" rather than flapping a live process to "dead".
+func isProcessAlive(pid int, wantToken string, haveToken bool) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	if proc.Signal(syscall.Signal(0)) != nil {
+		return false
+	}
+	if !haveToken {
+		return true
+	}
+	token, ok := processStartTime(pid)
+	if !ok {
+		return true
+	}
+	return token == wantToken
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/mcpinit/... -run TestIsProcessAlive -v`
+Expected: PASS (all 4 subtests). Note: the full package won't compile yet — `obsidiansync.go`'s `isAlive` and `obsidiansync_windows.go`'s `isProcessAlive` still call/define the old 1-arg form. Run the narrower Linux-only test target instead if the full package fails to build:
+
+Run: `go vet ./internal/mcpinit/... 2>&1 | head -20`
+Expected at this point: errors from `obsidiansync.go` (`isAlive` calling `isProcessAlive(pid)` with 1 arg) and `obsidiansync_windows.go` (duplicate-signature mismatch is fine since it's build-tag excluded on Linux, but its own `isProcessAlive(pid int) bool` doesn't match this file if both were ever compiled together — they never are, different build tags, so no conflict). This is expected and resolved by Tasks 6–7; do not fix it here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcpinit/obsidiansync_unix.go internal/mcpinit/obsidiansync_linux_test.go
+git commit -m "feat(mcpinit): make POSIX isProcessAlive token-aware"
+```
+
+---
+
+### Task 6: Token-aware `isProcessAlive` on Windows
+
+**Files:**
+- Modify: `internal/mcpinit/obsidiansync_windows.go`
+- Modify: `internal/mcpinit/obsidiansync_windows_test.go`
+
+- [ ] **Step 1: Write the failing test** (append to the file created in Task 4)
+
+```go
+func TestIsProcessAlive_TokenMatch(t *testing.T) {
+	token, ok := processStartTime(os.Getpid())
+	if !ok {
+		t.Fatal("processStartTime(own pid) failed; can't set up test")
+	}
+	if !isProcessAlive(os.Getpid(), token, true) {
+		t.Error("isProcessAlive(own pid, own true token) = false, want true")
+	}
+}
+
+func TestIsProcessAlive_TokenMismatch(t *testing.T) {
+	if isProcessAlive(os.Getpid(), "definitely-not-the-real-token", true) {
+		t.Error("isProcessAlive(own pid, wrong token) = true, want false (PID-reuse must be detected)")
+	}
+}
+
+func TestIsProcessAlive_NoToken(t *testing.T) {
+	if !isProcessAlive(os.Getpid(), "", false) {
+		t.Error("isProcessAlive(own pid, haveToken=false) = false, want true (legacy behavior preserved)")
+	}
+}
+```
+
+- [ ] **Step 2: Verify it fails to compile**
+
+Run: `GOOS=windows GOARCH=amd64 go vet ./internal/mcpinit/...`
+Expected: FAIL — `too many arguments in call to isProcessAlive`
+
+- [ ] **Step 3: Change `isProcessAlive`'s signature and implementation**
+
+Replace:
+
+```go
+// isProcessAlive reports whether pid names a running process. Unlike POSIX,
+// Windows aggressively recycles PIDs, so a PID that opens successfully but
+// has already exited (GetExitCodeProcess returns anything but
+// STILL_ACTIVE) is treated as not alive — otherwise a reused PID belonging
+// to an unrelated process would be mistaken for the one that owned the PID
+// file.
+func isProcessAlive(pid int) bool {
+	if pid <= 0 || int64(pid) > 0xFFFFFFFF {
+		return false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(h) //nolint:errcheck
+
+	const stillActive = 259 // STILL_ACTIVE, per the Win32 GetExitCodeProcess docs
+
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(h, &exitCode); err != nil {
+		return false
+	}
+	return exitCode == stillActive
+}
+```
+
+with:
+
+```go
+// isProcessAlive reports whether pid names a running process. Unlike POSIX,
+// Windows aggressively recycles PIDs, so a PID that opens successfully but
+// has already exited (GetExitCodeProcess returns anything but
+// STILL_ACTIVE) is treated as not alive — otherwise a reused PID belonging
+// to an unrelated process would be mistaken for the one that owned the PID
+// file. If haveToken is true, a live PID is additionally required to still
+// carry wantToken as its creation-time token — a mismatch means the OS
+// recycled pid to an unrelated process after the original one exited,
+// which STILL_ACTIVE alone can't distinguish from the original still
+// running. A transient failure to read the fresh token fails open to
+// "alive" rather than flapping a live process to "dead".
+func isProcessAlive(pid int, wantToken string, haveToken bool) bool {
+	if pid <= 0 || int64(pid) > 0xFFFFFFFF {
+		return false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(h) //nolint:errcheck
+
+	const stillActive = 259 // STILL_ACTIVE, per the Win32 GetExitCodeProcess docs
+
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(h, &exitCode); err != nil {
+		return false
+	}
+	if exitCode != stillActive {
+		return false
+	}
+	if !haveToken {
+		return true
+	}
+	token, ok := processStartTime(pid)
+	if !ok {
+		return true
+	}
+	return token == wantToken
+}
+```
+
+- [ ] **Step 4: Verify it builds and vets clean**
+
+Run: `GOOS=windows GOARCH=amd64 go vet ./internal/mcpinit/... && GOOS=windows GOARCH=arm64 go build ./internal/mcpinit/...`
+Expected: no output, exit 0 (still fails until Task 7 fixes `obsidiansync.go`'s caller — expected, same as Task 5 Step 4)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcpinit/obsidiansync_windows.go internal/mcpinit/obsidiansync_windows_test.go
+git commit -m "feat(mcpinit): make Windows isProcessAlive token-aware"
+```
+
+---
+
+### Task 7: `atomicWritePID` and `claimPidFile` gain tokens (closes the placeholder-write gap)
+
+**Files:**
+- Modify: `internal/mcpinit/stophook.go`
+- Modify: `internal/mcpinit/stophook_test.go`
+
+This is Fable's Defect 3 fix: `claimPidFile`'s placeholder write (`os.Getpid()`, before `cmd.Start()`) currently has no creation-time guard, so if one of the three early-return paths after it fires, the placeholder is stuck on disk indistinguishable from a genuinely-stale PID once the short-lived hook process exits and its PID gets reused.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// TestClaimPidFile_PlaceholderCarriesToken proves the placeholder PID
+// claimPidFile writes (the caller's own PID, before it has spawned
+// anything) is written in the same "pid:token" format as a real spawn —
+// otherwise an abandoned placeholder (caller hits an early-return failure
+// path after claiming but before cmd.Start()) has no creation-time guard
+// and reproduces the exact PID-reuse bug this design fixes.
+func TestClaimPidFile_PlaceholderCarriesToken(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "resolve-test.pid")
+
+	if !claimPidFile(pidPath) {
+		t.Fatal("claimPidFile on an empty slot = false, want true")
+	}
+
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatalf("read pidPath: %v", err)
+	}
+	content := strings.TrimSpace(string(data))
+	pidStr, token, haveToken := strings.Cut(content, ":")
+	if _, err := strconv.Atoi(pidStr); err != nil {
+		t.Errorf("placeholder content has no valid leading PID: %q", content)
+	}
+	// processStartTime can legitimately return ok=false on some platforms
+	// (obsidiansync_unix_other.go, or a transient read failure) — when it
+	// does, the placeholder correctly falls back to the bare-PID legacy
+	// format instead of claiming a token it doesn't have.
+	if token, ok := processStartTime(os.Getpid()); ok && (!haveToken || token == "") {
+		t.Errorf("processStartTime succeeded (token=%q) but placeholder has no token: %q", token, content)
+	}
+	_ = token
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/mcpinit/... -run TestClaimPidFile_PlaceholderCarriesToken -v`
+Expected: FAIL — today's `claimPidFile` writes a bare PID with no colon, so on any platform where `processStartTime(os.Getpid())` succeeds, `haveToken` is false and the assertion trips.
+
+- [ ] **Step 3: Update `atomicWritePID` and `claimPidFile`**
+
+Replace:
+
+```go
+// atomicWritePID writes pid into path via write-temp-then-rename so a
+// concurrent reader (e.g. another caller's claimPidFile, which reads this
+// file under its own lock) never observes a truncated or partially-written
+// file — os.WriteFile's open+truncate+write is not atomic and this call site
+// runs outside any lock.
+func atomicWritePID(path string, pid int) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strconv.Itoa(pid)), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+```
+
+with:
+
+```go
+// atomicWritePID writes pid (and, when haveToken is true, its creation-time
+// token in "pid:token" form — see processStartTime) into path via
+// write-temp-then-rename so a concurrent reader (e.g. another caller's
+// claimPidFile, which reads this file under its own lock) never observes a
+// truncated or partially-written file — os.WriteFile's
+// open+truncate+write is not atomic and this call site runs outside any
+// lock. When haveToken is false, the bare-PID legacy format is written,
+// same as before this token support existed.
+func atomicWritePID(path string, pid int, token string, haveToken bool) error {
+	content := strconv.Itoa(pid)
+	if haveToken {
+		content += ":" + token
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+```
+
+Replace:
+
+```go
+	if isAlive(pidPath) {
+		return false
+	}
+	return atomicWritePID(pidPath, os.Getpid()) == nil
+}
+```
+
+with:
+
+```go
+	if isAlive(pidPath) {
+		return false
+	}
+	token, haveToken := processStartTime(os.Getpid())
+	return atomicWritePID(pidPath, os.Getpid(), token, haveToken) == nil
+}
+```
+
+(This is the end of `claimPidFile` — only its last 3 lines change; the lock-file setup above it is untouched.)
+
+Now fix the two remaining call sites in the same file — `spawnResolveIfConfigured` and `spawnSupersedeIfConfigured` — both currently end with:
+
+```go
+	_ = atomicWritePID(pidPath, cmd.Process.Pid)
+	_ = cmd.Process.Release()
+```
+
+Replace **both** occurrences with:
+
+```go
+	token, haveToken := processStartTime(cmd.Process.Pid)
+	_ = atomicWritePID(pidPath, cmd.Process.Pid, token, haveToken)
+	_ = cmd.Process.Release()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/mcpinit/... -run TestClaimPidFile -v`
+Expected: PASS, including the two pre-existing `TestClaimPidFile_ConcurrentCallersOnlyOneWins*` tests (unaffected — they only assert PID parses, which still holds with the new `"pid:token"` format).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcpinit/stophook.go internal/mcpinit/stophook_test.go
+git commit -m "fix(mcpinit): give claimPidFile's placeholder write a creation-time token"
+```
+
+---
+
+### Task 8: `isAlive` parses the token format; `ensureObsidianSyncRunning` writes one
+
+**Files:**
+- Modify: `internal/mcpinit/obsidiansync.go`
+- Modify: `internal/mcpinit/obsidiansync_test.go`
+
+This is the task that makes the whole package compile again (Tasks 5–6 changed `isProcessAlive`'s signature; `isAlive` is its only caller and still calls the old 1-arg form until now).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/mcpinit/obsidiansync_test.go`:
+
+```go
+func TestIsAlive_LegacyBarePIDStillWorks(t *testing.T) {
+	// A pre-upgrade pidfile (no colon) must keep working exactly as before —
+	// no migration step, no regression, just no reuse detection.
+	pidPath := filepath.Join(t.TempDir(), "obsidian-sync.pid")
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !isAlive(pidPath) {
+		t.Error("isAlive() = false for a legacy bare-PID file naming this process, want true")
+	}
+}
+
+func TestIsAlive_TokenFormatOwnPID(t *testing.T) {
+	token, ok := processStartTime(os.Getpid())
+	if !ok {
+		t.Skip("processStartTime unsupported on this platform; nothing to test here")
+	}
+	pidPath := filepath.Join(t.TempDir(), "obsidian-sync.pid")
+	content := strconv.Itoa(os.Getpid()) + ":" + token
+	if err := os.WriteFile(pidPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !isAlive(pidPath) {
+		t.Error("isAlive() = false for own pid:token, want true")
+	}
+}
+
+func TestIsAlive_TokenMismatchMeansReuse(t *testing.T) {
+	if _, ok := processStartTime(os.Getpid()); !ok {
+		t.Skip("processStartTime unsupported on this platform; nothing to test here")
+	}
+	pidPath := filepath.Join(t.TempDir(), "obsidian-sync.pid")
+	content := strconv.Itoa(os.Getpid()) + ":stale-token-from-a-different-process-instance"
+	if err := os.WriteFile(pidPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if isAlive(pidPath) {
+		t.Error("isAlive() = true for own pid with a mismatched token, want false (this is the PID-reuse regression test)")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go build ./internal/mcpinit/...`
+Expected: FAIL — `isAlive`'s call `isProcessAlive(pid)` now has too few arguments (`isProcessAlive` takes 3 as of Task 5/6)
+
+- [ ] **Step 3: Update `isAlive` and `ensureObsidianSyncRunning`**
+
+Replace:
+
+```go
+// isAlive reports whether pidPath names a PID file for a process that is
+// still running. It never treats a stale or missing PID file as an error —
+// the caller's only decision is "spawn a new one, or not". The liveness
+// check itself is platform-specific — see isProcessAlive in
+// obsidiansync_unix.go / obsidiansync_windows.go.
+func isAlive(pidPath string) bool {
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		return false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return false
+	}
+	return isProcessAlive(pid)
+}
+```
+
+with:
+
+```go
+// isAlive reports whether pidPath names a PID file for a process that is
+// still running. It never treats a stale or missing PID file as an error —
+// the caller's only decision is "spawn a new one, or not". The file holds
+// either a bare PID (legacy format, liveness-only) or "pid:token" (see
+// processStartTime), in which case a live PID additionally has to still
+// carry that token to be reported alive — see isProcessAlive in
+// obsidiansync_unix.go / obsidiansync_windows.go.
+func isAlive(pidPath string) bool {
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		return false
+	}
+	pidStr, token, haveToken := strings.Cut(strings.TrimSpace(string(data)), ":")
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil || pid <= 0 {
+		return false
+	}
+	return isProcessAlive(pid, token, haveToken)
+}
+```
+
+Then replace `ensureObsidianSyncRunning`'s write line:
+
+```go
+	_ = os.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), 0o600)
+	_ = cmd.Process.Release()
+```
+
+with:
+
+```go
+	token, haveToken := processStartTime(cmd.Process.Pid)
+	_ = atomicWritePID(pidPath, cmd.Process.Pid, token, haveToken)
+	_ = cmd.Process.Release()
+```
+
+This drops the direct `os.WriteFile` call in favor of the same atomic, token-aware helper the two stop-hook spawners use — one write path instead of two slightly different ones. `strconv` stays imported (still used by `isAlive`'s `strconv.Atoi`); no import list changes needed in this file.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go build ./... && go vet ./... && go test ./internal/mcpinit/... -v`
+Expected: builds clean; all tests pass, including every pre-existing test in `obsidiansync_test.go` and `stophook_test.go` (none of their assertions depended on the old bare-PID write format surviving — `TestIsAlive_LiveProcess` writes a bare PID directly via `os.WriteFile` and still hits the legacy fallback path, which is intentionally preserved).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcpinit/obsidiansync.go internal/mcpinit/obsidiansync_test.go
+git commit -m "feat(mcpinit): isAlive detects PID reuse via creation-time token"
+```
+
+---
+
+### Task 9: Full cross-platform verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full test suite and vet on the native platform**
+
+Run: `go vet ./... && go test ./...`
+Expected: all packages pass, no vet warnings
+
+- [ ] **Step 2: Cross-compile every goreleaser target**
+
+Run:
+```bash
+GOOS=linux   GOARCH=amd64 go build ./... && \
+GOOS=linux   GOARCH=arm64 go build ./... && \
+GOOS=darwin  GOARCH=amd64 go build ./... && \
+GOOS=darwin  GOARCH=arm64 go build ./... && \
+GOOS=windows GOARCH=amd64 go build ./... && \
+GOOS=windows GOARCH=arm64 go build ./... && \
+echo ALL_OK
+```
+Expected: `ALL_OK` printed, no build errors on any target — this is the only verification available for the darwin/windows code paths on this Linux dev machine, matching CI's own limitation (CI only runs `ubuntu-latest`).
+
+- [ ] **Step 3: Run `go vet` per cross-compiled target too (vet does more static checking than a bare build)**
+
+Run:
+```bash
+GOOS=darwin  GOARCH=arm64 go vet ./... && \
+GOOS=windows GOARCH=amd64 go vet ./... && \
+echo VET_OK
+```
+Expected: `VET_OK` printed
+
+- [ ] **Step 4: No commit needed** — this task is pure verification. If any step fails, fix the offending file from the earlier task that introduced it and re-run this task from Step 1.
+
+---
+
+## Spec Coverage Check
+
+- PID file format (bare = legacy, `pid:token` = new) → Tasks 7, 8. ✓
+- Per-platform `processStartTime` (linux/darwin/windows/other) → Tasks 1–4. ✓
+- Linux boot_id reboot-safety fix → Task 1. ✓
+- Darwin wall-clock `Timeval` string format → Task 2. ✓
+- Windows wall-clock `Filetime` string format → Task 4. ✓
+- `isProcessAlive` 3-arg token-aware signature (POSIX + Windows) → Tasks 5, 6. ✓
+- Fail-open on every new syscall path → Tasks 1–6 (every `processStartTime`/`isProcessAlive` implementation returns/treats failure as "alive"/"unsupported", never errors up). ✓
+- Write path: `ensureObsidianSyncRunning`, `spawnResolveIfConfigured`, `spawnSupersedeIfConfigured`, `atomicWritePID` → Tasks 7, 8. ✓
+- `claimPidFile` placeholder-write token fix (Defect 3) → Task 7. ✓
+- Cross-platform build/vet verification → Task 9. ✓
+
+No spec section is left uncovered.

--- a/docs/superpowers/plans/2026-08-09-pid-reuse-creation-time.md
+++ b/docs/superpowers/plans/2026-08-09-pid-reuse-creation-time.md
@@ -502,7 +502,7 @@ Run: `go test ./internal/mcpinit/... -run TestIsProcessAlive -v`
 Expected: PASS (all 4 subtests). Note: the full package won't compile yet — `obsidiansync.go`'s `isAlive` and `obsidiansync_windows.go`'s `isProcessAlive` still call/define the old 1-arg form. Run the narrower Linux-only test target instead if the full package fails to build:
 
 Run: `go vet ./internal/mcpinit/... 2>&1 | head -20`
-Expected at this point: errors from `obsidiansync.go` (`isAlive` calling `isProcessAlive(pid)` with 1 arg) and `obsidiansync_windows.go` (duplicate-signature mismatch is fine since it's build-tag excluded on Linux, but its own `isProcessAlive(pid int) bool` doesn't match this file if both were ever compiled together — they never are, different build tags, so no conflict). This is expected and resolved by Tasks 6–7; do not fix it here.
+Expected at this point: errors from `obsidiansync.go` (`isAlive` calling `isProcessAlive(pid)` with 1 arg) and `obsidiansync_windows.go` (duplicate-signature mismatch is fine since it's build-tag excluded on Linux, but its own `isProcessAlive(pid int) bool` doesn't match this file if both were ever compiled together — they never are, different build tags, so no conflict). This is expected and resolved by Task 8 (which updates `isAlive`'s caller); do not fix it here.
 
 - [ ] **Step 5: Commit**
 
@@ -628,7 +628,7 @@ func isProcessAlive(pid int, wantToken string, haveToken bool) bool {
 - [ ] **Step 4: Verify it builds and vets clean**
 
 Run: `GOOS=windows GOARCH=amd64 go vet ./internal/mcpinit/... && GOOS=windows GOARCH=arm64 go build ./internal/mcpinit/...`
-Expected: no output, exit 0 (still fails until Task 7 fixes `obsidiansync.go`'s caller — expected, same as Task 5 Step 4)
+Expected: this still fails until Task 8 fixes `obsidiansync.go`'s caller — expected, same as Task 5 Step 4; do not fix it here.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/specs/2026-08-09-pid-reuse-creation-time-design.md
+++ b/docs/superpowers/specs/2026-08-09-pid-reuse-creation-time-design.md
@@ -1,0 +1,139 @@
+# PID-Reuse Detection via Process Creation Time
+
+Closes item 3 of #252 (Windows PID-reuse detection), extended to cover the
+identical, previously-accepted gap on POSIX (Linux/macOS signal-0 checks).
+
+## Problem
+
+`isAlive()` in `internal/mcpinit/obsidiansync.go` decides whether a
+background process (obsidian-sync, resolve, supersede) is still running by
+reading a PID from a `.pid` file and calling platform-specific
+`isProcessAlive(pid)`:
+
+- POSIX (`obsidiansync_unix.go`): `os.FindProcess` + signal 0.
+- Windows (`obsidiansync_windows.go`): `OpenProcess` +
+  `GetExitCodeProcess` == `STILL_ACTIVE`.
+
+Both checks only prove *some* process currently holds that PID number — not
+that it's the *same* process instance that wrote the file. Once the original
+process exits, the OS is free to hand that PID to any new, unrelated
+process. If that reuse happens while a stale `.pid` file still names the old
+PID, `isAlive` wrongly reports "still running," and the caller (session-start
+hook for obsidian-sync, stop hook for resolve/supersede) skips spawning a
+real one — silently breaking the auto-sync/auto-resolve/auto-supersede
+features until the file is manually cleared.
+
+All three PID files (`obsidian-sync.pid`, `resolve-<project>.pid`,
+`supersede-<project>.pid`) go through this same code path, so fixing it here
+fixes all three call sites in `stophook.go` and `obsidiansync.go`.
+
+## Fix
+
+Record each process's OS-assigned creation time alongside its PID at write
+time. At read time, re-derive the creation time for whatever process
+currently holds that PID and require it to match. A reused PID will almost
+certainly have a different creation time, revealing the reuse.
+
+Creation time is never interpreted as wall-clock time or converted across
+platforms — it's an opaque per-platform integer, compared only for equality
+against a value obtained the same way on the same machine.
+
+## Components
+
+### 1. PID file format
+
+`"<pid>:<creationTime>"`, e.g. `"12345:412039182"`.
+
+A bare integer with no colon (today's on-disk format) parses as *legacy*:
+PID known, creation time unknown. Legacy files fall back to today's
+PID-only liveness check — no reuse detection, but no regression either. The
+next time that slot is claimed and rewritten, it upgrades to the new format
+automatically. No migration step or format-version bump is needed.
+
+### 2. Per-platform creation-time reader
+
+New function, one implementation per OS, returning `(0, false)` on any
+failure (unreadable proc entry, permission denied, unsupported OS):
+
+```go
+func processStartTime(pid int) (start uint64, ok bool)
+```
+
+- **`obsidiansync_linux.go`**: read `/proc/<pid>/stat`. The `comm` field
+  (2nd field) can itself contain spaces and parentheses, so split on the
+  *last* `)` in the line before tokenizing the remainder by spaces — field
+  22 overall is then remainder-field 20 (1-indexed after the split).
+  Field 22 is `starttime`: clock ticks since boot. Never converted to wall
+  time; compared as-is.
+- **`obsidiansync_darwin.go`**: `unix.SysctlKinfoProc("kern.proc.pid", pid)`
+  (`golang.org/x/sys/unix`, already an indirect dependency) →
+  `KinfoProc.Proc.P_starttime`, a `Timeval`. Compared as
+  `(Sec, Usec)` tuple equality.
+- **`obsidiansync_windows.go`** (extends the existing file): use the
+  process handle already opened by `isProcessAlive` to call
+  `windows.GetProcessTimes`, taking the creation `Filetime` as a `uint64`.
+- **`obsidiansync_unix_other.go`** (`//go:build !windows && !linux && !darwin`):
+  always returns `(0, false)`. Covers any other Unix goreleaser might target
+  in the future; degrades to PID-only liveness, matching today's behavior
+  exactly.
+
+### 3. `isProcessAlive` signature change (all platform files)
+
+```go
+func isProcessAlive(pid int, wantStart uint64, haveStart bool) bool
+```
+
+Existing liveness check runs first (unchanged). If it reports alive and
+`haveStart` is true, additionally calls `processStartTime(pid)` for a fresh
+reading and requires it to equal `wantStart` — mismatch means the PID was
+recycled, so report not-alive. If the fresh reading itself fails
+(`ok == false`), fail open to "alive" (today's behavior) rather than
+flapping a live process to "dead" because of a transient read error.
+
+### 4. Write path
+
+`ensureObsidianSyncRunning`, `spawnResolveIfConfigured`,
+`spawnSupersedeIfConfigured`, `atomicWritePID`, and `claimPidFile` all
+currently write a bare PID. After `cmd.Start()`, read the new child's start
+time via `processStartTime(cmd.Process.Pid)` and write `"pid:starttime"` (or
+bare `pid` when `ok` is false — same as today, and forward-compatible with
+the legacy-format fallback in `isAlive`).
+
+`isAlive(pidPath)` itself keeps its existing signature; internally it now
+splits on `:`, parses both parts when present, and calls the 3-arg
+`isProcessAlive`.
+
+## Error handling
+
+Every new syscall path fails open to today's PID-only behavior rather than
+erroring — consistent with this file's existing contract that PID-file
+logic must never block or fail the session-start/stop hooks. No new error
+returns propagate to callers; `isAlive` keeps returning a plain `bool`.
+
+## Testing
+
+- Platform-specific unit tests (build-tag gated, matching the existing
+  `obsidiansync_unix.go` / `obsidiansync_windows.go` test split) for each new
+  `processStartTime` implementation and for `isProcessAlive`'s 3-arg form:
+  - Own PID + own true start time → alive.
+  - Own PID + a deliberately wrong start time → not alive (this is the
+    regression test for PID-reuse; it doesn't require actually triggering
+    PID reuse, just asserting the mismatch path).
+  - Legacy bare-PID file (no colon) → behaves exactly as before
+    (liveness-only).
+  - Malformed file content → not alive (existing behavior, unchanged).
+- No changes needed to existing `obsidiansync_test.go` / `stophook_test.go`
+  tests that exercise the public `isAlive(pidPath)` surface, since that
+  signature is unchanged.
+- `go vet ./...`, `go build ./...` for all three GOOS targets
+  (`GOOS=linux`, `GOOS=darwin`, `GOOS=windows`) since CI only runs
+  `ubuntu-latest` and cross-compiles the others — this is the only
+  verification available for the darwin/windows paths short of manual
+  testing on those OSes.
+
+## Scope check
+
+This is a self-contained change to `internal/mcpinit`: 3-4 new small
+platform-specific files plus signature changes to 3 existing call sites
+(`obsidiansync.go`, `stophook.go` write paths) and no new dependencies. Fits
+a single implementation plan.

--- a/docs/superpowers/specs/2026-08-09-pid-reuse-creation-time-design.md
+++ b/docs/superpowers/specs/2026-08-09-pid-reuse-creation-time-design.md
@@ -35,69 +35,123 @@ currently holds that PID and require it to match. A reused PID will almost
 certainly have a different creation time, revealing the reuse.
 
 Creation time is never interpreted as wall-clock time or converted across
-platforms — it's an opaque per-platform integer, compared only for equality
-against a value obtained the same way on the same machine.
+platforms or arithmetically compared — it's an **opaque per-platform
+string token**, compared only for exact equality against a token obtained
+the same way on the same machine. A string (not an integer) is required
+because the per-platform sources aren't uniformly representable as one
+numeric type (see Component 2), and because Linux's raw source value is not
+by itself reboot-safe (see below).
 
 ## Components
 
 ### 1. PID file format
 
-`"<pid>:<creationTime>"`, e.g. `"12345:412039182"`.
+`"<pid>:<creationToken>"`, e.g. `"12345:a1b2c3d4-412039182"`.
 
 A bare integer with no colon (today's on-disk format) parses as *legacy*:
-PID known, creation time unknown. Legacy files fall back to today's
+PID known, creation token unknown. Legacy files fall back to today's
 PID-only liveness check — no reuse detection, but no regression either. The
 next time that slot is claimed and rewritten, it upgrades to the new format
 automatically. No migration step or format-version bump is needed.
 
-### 2. Per-platform creation-time reader
+### 2. Per-platform creation-token reader
 
-New function, one implementation per OS, returning `(0, false)` on any
+New function, one implementation per OS, returning `("", false)` on any
 failure (unreadable proc entry, permission denied, unsupported OS):
 
 ```go
-func processStartTime(pid int) (start uint64, ok bool)
+func processStartTime(pid int) (token string, ok bool)
 ```
 
 - **`obsidiansync_linux.go`**: read `/proc/<pid>/stat`. The `comm` field
   (2nd field) can itself contain spaces and parentheses, so split on the
   *last* `)` in the line before tokenizing the remainder by spaces — field
   22 overall is then remainder-field 20 (1-indexed after the split).
-  Field 22 is `starttime`: clock ticks since boot. Never converted to wall
-  time; compared as-is.
+  Field 22 is `starttime`: clock ticks since boot — **not wall-clock, and
+  not reboot-safe on its own**: `.pid` files persist in `dataDir` across
+  reboots, and after a reboot a freshly-started, unrelated process can
+  coincidentally have the same boot-relative tick count a stale file
+  recorded before the reboot, silently defeating the whole check for
+  exactly the stale-file scenario this fix targets. Fixed by prefixing the
+  machine's boot ID: read `/proc/sys/kernel/random/boot_id` (a fresh UUID
+  generated at every boot) once and use `token = bootID + "-" + starttime`.
+  Any reboot changes `bootID`, so a pre-reboot token can never match a
+  post-reboot one, regardless of tick coincidence. If `boot_id` is
+  unreadable, return `("", false)` (fails open to legacy PID-only
+  liveness — same as any other read failure on this platform).
 - **`obsidiansync_darwin.go`**: `unix.SysctlKinfoProc("kern.proc.pid", pid)`
-  (`golang.org/x/sys/unix`, already an indirect dependency) →
-  `KinfoProc.Proc.P_starttime`, a `Timeval`. Compared as
-  `(Sec, Usec)` tuple equality.
+  (`golang.org/x/sys/unix`, already a **direct** dependency — imported
+  today by `obsidiansync_windows.go`) → `KinfoProc.Proc.P_starttime`, a
+  `Timeval{Sec, Usec}`. `Timeval` is wall-clock (seconds since epoch), so it
+  is already reboot-safe with no extra prefixing needed. Format as
+  `token = fmt.Sprintf("%d.%d", Sec, Usec)`.
 - **`obsidiansync_windows.go`** (extends the existing file): use the
   process handle already opened by `isProcessAlive` to call
-  `windows.GetProcessTimes`, taking the creation `Filetime` as a `uint64`.
+  `windows.GetProcessTimes`, taking the creation `Filetime` (also
+  wall-clock — 100ns intervals since 1601-01-01 — so already reboot-safe).
+  Combine its `HighDateTime`/`LowDateTime` fields into a single `uint64`
+  (`Filetime.Nanoseconds()`'s underlying value, or the equivalent bit-shift)
+  and format with `strconv.FormatUint(value, 10)`.
 - **`obsidiansync_unix_other.go`** (`//go:build !windows && !linux && !darwin`):
-  always returns `(0, false)`. Covers any other Unix goreleaser might target
-  in the future; degrades to PID-only liveness, matching today's behavior
-  exactly.
+  always returns `("", false)`. Covers any other Unix goreleaser might
+  target in the future; degrades to PID-only liveness, matching today's
+  behavior exactly.
 
 ### 3. `isProcessAlive` signature change (all platform files)
 
 ```go
-func isProcessAlive(pid int, wantStart uint64, haveStart bool) bool
+func isProcessAlive(pid int, wantToken string, haveToken bool) bool
 ```
 
 Existing liveness check runs first (unchanged). If it reports alive and
-`haveStart` is true, additionally calls `processStartTime(pid)` for a fresh
-reading and requires it to equal `wantStart` — mismatch means the PID was
-recycled, so report not-alive. If the fresh reading itself fails
-(`ok == false`), fail open to "alive" (today's behavior) rather than
-flapping a live process to "dead" because of a transient read error.
+`haveToken` is true, additionally calls `processStartTime(pid)` for a fresh
+reading and requires it to equal `wantToken` (plain string equality) —
+mismatch means the PID was recycled, so report not-alive. If the fresh
+reading itself fails (`ok == false`), fail open to "alive" (today's
+behavior) rather than flapping a live process to "dead" because of a
+transient read error.
 
 ### 4. Write path
 
 `ensureObsidianSyncRunning`, `spawnResolveIfConfigured`,
 `spawnSupersedeIfConfigured`, `atomicWritePID`, and `claimPidFile` all
-currently write a bare PID. After `cmd.Start()`, read the new child's start
-time via `processStartTime(cmd.Process.Pid)` and write `"pid:starttime"` (or
-bare `pid` when `ok` is false — same as today, and forward-compatible with
-the legacy-format fallback in `isAlive`).
+currently write a bare PID; `claimPidFile` writes one in *two* places that
+both need to move to the new format:
+
+- **Placeholder claim** (`claimPidFile`, before spawning): today it writes
+  `os.Getpid()` — the stop-hook's own short-lived PID — as a lock-holding
+  placeholder, then three early-return paths in the caller
+  (`os.Executable` failure, log-file `OpenFile` failure, `cmd.Start()`
+  failure) can leave that placeholder on disk permanently after the hook
+  process exits, with no way to distinguish it from a stale reused PID —
+  reproducing the exact bug this design fixes. Fix: `claimPidFile` computes
+  its own token via `processStartTime(os.Getpid())` and writes
+  `"pid:token"` (or bare `pid` if unsupported) for the placeholder too, so
+  even an abandoned placeholder is correctly detected as dead once the hook
+  process exits and its PID is reused.
+- **Real write** (after `cmd.Start()` succeeds): read the new child's token
+  via `processStartTime(cmd.Process.Pid)` and write `"pid:token"` (or bare
+  `pid` when `ok` is false).
+
+Both writes go through one shared helper so the format logic isn't
+duplicated:
+
+```go
+func atomicWritePID(path string, pid int) error // existing signature, callers updated below
+```
+
+becomes
+
+```go
+func atomicWritePID(path string, pid int, token string, haveToken bool) error
+```
+
+which formats `"pid:token"` or bare `pid` internally before the existing
+temp-file-then-rename logic. Every call site (`claimPidFile`'s placeholder
+write, `claimPidFile`'s real write, `ensureObsidianSyncRunning`,
+`spawnResolveIfConfigured`, `spawnSupersedeIfConfigured`) computes its own
+`processStartTime` result and passes it through this one function — no
+formatting logic duplicated across call sites.
 
 `isAlive(pidPath)` itself keeps its existing signature; internally it now
 splits on `:`, parses both parts when present, and calls the 3-arg
@@ -115,13 +169,21 @@ returns propagate to callers; `isAlive` keeps returning a plain `bool`.
 - Platform-specific unit tests (build-tag gated, matching the existing
   `obsidiansync_unix.go` / `obsidiansync_windows.go` test split) for each new
   `processStartTime` implementation and for `isProcessAlive`'s 3-arg form:
-  - Own PID + own true start time → alive.
-  - Own PID + a deliberately wrong start time → not alive (this is the
+  - Own PID + own true token → alive.
+  - Own PID + a deliberately wrong token string → not alive (this is the
     regression test for PID-reuse; it doesn't require actually triggering
     PID reuse, just asserting the mismatch path).
   - Legacy bare-PID file (no colon) → behaves exactly as before
     (liveness-only).
   - Malformed file content → not alive (existing behavior, unchanged).
+  - Linux only: two `processStartTime` calls for the same live PID return
+    identical tokens (boot_id + starttime is a stable read, not
+    regenerated per call).
+- `claimPidFile` test: simulate a failure on one of the three post-claim,
+  pre-`cmd.Start()` paths (e.g. inject a `cmd.Start()` failure) and assert
+  that the leftover placeholder file, once the test's own PID naturally
+  exits/changes, is correctly detected as not-alive rather than wedging the
+  lock forever — covers the fix for the placeholder-write gap.
 - No changes needed to existing `obsidiansync_test.go` / `stophook_test.go`
   tests that exercise the public `isAlive(pidPath)` surface, since that
   signature is unchanged.

--- a/internal/mcpinit/obsidiansync.go
+++ b/internal/mcpinit/obsidiansync.go
@@ -61,23 +61,27 @@ func ensureObsidianSyncRunning() {
 	if err := cmd.Start(); err != nil {
 		return
 	}
-	_ = os.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), 0o600)
+	token, haveToken := processStartTime(cmd.Process.Pid)
+	_ = atomicWritePID(pidPath, cmd.Process.Pid, token, haveToken)
 	_ = cmd.Process.Release()
 }
 
 // isAlive reports whether pidPath names a PID file for a process that is
 // still running. It never treats a stale or missing PID file as an error —
-// the caller's only decision is "spawn a new one, or not". The liveness
-// check itself is platform-specific — see isProcessAlive in
+// the caller's only decision is "spawn a new one, or not". The file holds
+// either a bare PID (legacy format, liveness-only) or "pid:token" (see
+// processStartTime), in which case a live PID additionally has to still
+// carry that token to be reported alive — see isProcessAlive in
 // obsidiansync_unix.go / obsidiansync_windows.go.
 func isAlive(pidPath string) bool {
 	data, err := os.ReadFile(pidPath)
 	if err != nil {
 		return false
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	pidStr, token, haveToken := strings.Cut(strings.TrimSpace(string(data)), ":")
+	pid, err := strconv.Atoi(pidStr)
 	if err != nil || pid <= 0 {
 		return false
 	}
-	return isProcessAlive(pid)
+	return isProcessAlive(pid, token, haveToken)
 }

--- a/internal/mcpinit/obsidiansync_darwin.go
+++ b/internal/mcpinit/obsidiansync_darwin.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package mcpinit
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// processStartTime returns an opaque token identifying pid's process
+// creation instant, or ("", false) if it can't be determined. KinfoProc's
+// P_starttime is a wall-clock Timeval (seconds+microseconds since epoch),
+// so — unlike Linux's boot-relative ticks — it is already reboot-safe with
+// no extra prefixing needed.
+func processStartTime(pid int) (string, bool) {
+	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return "", false
+	}
+	tv := kp.Proc.P_starttime
+	return fmt.Sprintf("%d.%d", tv.Sec, tv.Usec), true
+}

--- a/internal/mcpinit/obsidiansync_darwin_test.go
+++ b/internal/mcpinit/obsidiansync_darwin_test.go
@@ -1,0 +1,35 @@
+//go:build darwin
+
+package mcpinit
+
+import (
+	"os"
+	"testing"
+)
+
+func TestProcessStartTime_OwnPID(t *testing.T) {
+	token, ok := processStartTime(os.Getpid())
+	if !ok {
+		t.Fatal("processStartTime(own pid) ok = false, want true")
+	}
+	if token == "" {
+		t.Error("processStartTime(own pid) returned an empty token with ok=true")
+	}
+}
+
+func TestProcessStartTime_Stable(t *testing.T) {
+	a, okA := processStartTime(os.Getpid())
+	b, okB := processStartTime(os.Getpid())
+	if !okA || !okB {
+		t.Fatal("processStartTime(own pid) failed on a repeat call")
+	}
+	if a != b {
+		t.Errorf("processStartTime(own pid) not stable across calls: %q vs %q", a, b)
+	}
+}
+
+func TestProcessStartTime_ImplausiblePID(t *testing.T) {
+	if _, ok := processStartTime(999999999); ok {
+		t.Error("processStartTime(implausible pid) ok = true, want false")
+	}
+}

--- a/internal/mcpinit/obsidiansync_linux.go
+++ b/internal/mcpinit/obsidiansync_linux.go
@@ -1,0 +1,50 @@
+//go:build linux
+
+package mcpinit
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// processStartTime returns an opaque token identifying pid's process
+// creation instant, or ("", false) if it can't be determined (process
+// gone, unreadable /proc entry, permission denied).
+//
+// The raw source — /proc/<pid>/stat field 22 ("starttime") — is clock
+// ticks since boot, not wall-clock, so it is NOT by itself reboot-safe:
+// .pid files persist in dataDir across reboots, and a freshly-started,
+// unrelated process after a reboot can coincidentally have the same
+// boot-relative tick count a stale file recorded before the reboot. The
+// machine's boot ID (a fresh UUID generated at every boot) is prefixed so
+// a pre-reboot token can never match a post-reboot one, regardless of tick
+// coincidence.
+func processStartTime(pid int) (string, bool) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return "", false
+	}
+	line := string(data)
+
+	// comm (field 2) is wrapped in parens and can itself contain spaces and
+	// parens, so split on the *last* ')' to find where it ends unambiguously.
+	idx := strings.LastIndexByte(line, ')')
+	if idx == -1 || idx+2 >= len(line) {
+		return "", false
+	}
+	// Fields after the split start at field 3 (state); field 22 (starttime)
+	// is therefore remainder-index 22-3 = 19.
+	fields := strings.Fields(line[idx+2:])
+	const starttimeIdx = 19
+	if starttimeIdx >= len(fields) {
+		return "", false
+	}
+	starttime := fields[starttimeIdx]
+
+	bootID, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(bootID)) + "-" + starttime, true
+}

--- a/internal/mcpinit/obsidiansync_linux_test.go
+++ b/internal/mcpinit/obsidiansync_linux_test.go
@@ -33,3 +33,31 @@ func TestProcessStartTime_ImplausiblePID(t *testing.T) {
 		t.Error("processStartTime(implausible pid) ok = true, want false")
 	}
 }
+
+func TestIsProcessAlive_TokenMatch(t *testing.T) {
+	token, ok := processStartTime(os.Getpid())
+	if !ok {
+		t.Fatal("processStartTime(own pid) failed; can't set up test")
+	}
+	if !isProcessAlive(os.Getpid(), token, true) {
+		t.Error("isProcessAlive(own pid, own true token) = false, want true")
+	}
+}
+
+func TestIsProcessAlive_TokenMismatch(t *testing.T) {
+	if isProcessAlive(os.Getpid(), "definitely-not-the-real-token", true) {
+		t.Error("isProcessAlive(own pid, wrong token) = true, want false (PID-reuse must be detected)")
+	}
+}
+
+func TestIsProcessAlive_NoToken(t *testing.T) {
+	if !isProcessAlive(os.Getpid(), "", false) {
+		t.Error("isProcessAlive(own pid, haveToken=false) = false, want true (legacy behavior preserved)")
+	}
+}
+
+func TestIsProcessAlive_DeadPIDIgnoresToken(t *testing.T) {
+	if isProcessAlive(999999999, "anything", true) {
+		t.Error("isProcessAlive(implausible pid, ...) = true, want false")
+	}
+}

--- a/internal/mcpinit/obsidiansync_linux_test.go
+++ b/internal/mcpinit/obsidiansync_linux_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package mcpinit
+
+import (
+	"os"
+	"testing"
+)
+
+func TestProcessStartTime_OwnPID(t *testing.T) {
+	token, ok := processStartTime(os.Getpid())
+	if !ok {
+		t.Fatal("processStartTime(own pid) ok = false, want true")
+	}
+	if token == "" {
+		t.Error("processStartTime(own pid) returned an empty token with ok=true")
+	}
+}
+
+func TestProcessStartTime_Stable(t *testing.T) {
+	a, okA := processStartTime(os.Getpid())
+	b, okB := processStartTime(os.Getpid())
+	if !okA || !okB {
+		t.Fatal("processStartTime(own pid) failed on a repeat call")
+	}
+	if a != b {
+		t.Errorf("processStartTime(own pid) not stable across calls: %q vs %q", a, b)
+	}
+}
+
+func TestProcessStartTime_ImplausiblePID(t *testing.T) {
+	if _, ok := processStartTime(999999999); ok {
+		t.Error("processStartTime(implausible pid) ok = true, want false")
+	}
+}

--- a/internal/mcpinit/obsidiansync_test.go
+++ b/internal/mcpinit/obsidiansync_test.go
@@ -60,3 +60,43 @@ func TestIsAlive_DeadProcess(t *testing.T) {
 		t.Error("isAlive() = true for an implausible PID, want false")
 	}
 }
+
+func TestIsAlive_TokenFormatOwnPID(t *testing.T) {
+	token, ok := processStartTime(os.Getpid())
+	if !ok {
+		t.Skip("processStartTime unsupported on this platform; nothing to test here")
+	}
+	pidPath := filepath.Join(t.TempDir(), "obsidian-sync.pid")
+	content := strconv.Itoa(os.Getpid()) + ":" + token
+	if err := os.WriteFile(pidPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !isAlive(pidPath) {
+		t.Error("isAlive() = false for own pid:token, want true")
+	}
+}
+
+func TestIsAlive_TokenMismatchMeansReuse(t *testing.T) {
+	if _, ok := processStartTime(os.Getpid()); !ok {
+		t.Skip("processStartTime unsupported on this platform; nothing to test here")
+	}
+	pidPath := filepath.Join(t.TempDir(), "obsidian-sync.pid")
+	content := strconv.Itoa(os.Getpid()) + ":stale-token-from-a-different-process-instance"
+	if err := os.WriteFile(pidPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if isAlive(pidPath) {
+		t.Error("isAlive() = true for own pid with a mismatched token, want false (this is the PID-reuse regression test)")
+	}
+}
+
+func TestIsAlive_DeadPIDWithTokenStillDead(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "obsidian-sync.pid")
+	content := "999999999:some-token"
+	if err := os.WriteFile(pidPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if isAlive(pidPath) {
+		t.Error("isAlive() = true for an implausible pid:token, want false")
+	}
+}

--- a/internal/mcpinit/obsidiansync_unix.go
+++ b/internal/mcpinit/obsidiansync_unix.go
@@ -17,11 +17,26 @@ func detachProcess(cmd *exec.Cmd) {
 
 // isProcessAlive reports whether pid names a running process, by sending
 // it signal 0 — this checks existence and permission without actually
-// signaling the process.
-func isProcessAlive(pid int) bool {
+// signaling the process. If haveToken is true, a live PID is additionally
+// required to still carry wantToken as its creation-time token — a
+// mismatch means the OS recycled pid to an unrelated process after the
+// original one exited, which plain signal-0 can't distinguish from the
+// original still running. A transient failure to read the fresh token
+// fails open to "alive" rather than flapping a live process to "dead".
+func isProcessAlive(pid int, wantToken string, haveToken bool) bool {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return false
 	}
-	return proc.Signal(syscall.Signal(0)) == nil
+	if proc.Signal(syscall.Signal(0)) != nil {
+		return false
+	}
+	if !haveToken {
+		return true
+	}
+	token, ok := processStartTime(pid)
+	if !ok {
+		return true
+	}
+	return token == wantToken
 }

--- a/internal/mcpinit/obsidiansync_unix_other.go
+++ b/internal/mcpinit/obsidiansync_unix_other.go
@@ -1,0 +1,11 @@
+//go:build !windows && !linux && !darwin
+
+package mcpinit
+
+// processStartTime has no known implementation on this OS. Returning
+// ("", false) degrades callers to legacy PID-only liveness checking,
+// identical to today's behavior — no regression, just no reuse detection
+// on whatever unlisted Unix this is.
+func processStartTime(pid int) (string, bool) {
+	return "", false
+}

--- a/internal/mcpinit/obsidiansync_windows.go
+++ b/internal/mcpinit/obsidiansync_windows.go
@@ -23,8 +23,13 @@ func detachProcess(cmd *exec.Cmd) {
 // has already exited (GetExitCodeProcess returns anything but
 // STILL_ACTIVE) is treated as not alive — otherwise a reused PID belonging
 // to an unrelated process would be mistaken for the one that owned the PID
-// file.
-func isProcessAlive(pid int) bool {
+// file. If haveToken is true, a live PID is additionally required to still
+// carry wantToken as its creation-time token — a mismatch means the OS
+// recycled pid to an unrelated process after the original one exited,
+// which STILL_ACTIVE alone can't distinguish from the original still
+// running. A transient failure to read the fresh token fails open to
+// "alive" rather than flapping a live process to "dead".
+func isProcessAlive(pid int, wantToken string, haveToken bool) bool {
 	if pid <= 0 || int64(pid) > 0xFFFFFFFF {
 		return false
 	}
@@ -40,7 +45,17 @@ func isProcessAlive(pid int) bool {
 	if err := windows.GetExitCodeProcess(h, &exitCode); err != nil {
 		return false
 	}
-	return exitCode == stillActive
+	if exitCode != stillActive {
+		return false
+	}
+	if !haveToken {
+		return true
+	}
+	token, ok := processStartTime(pid)
+	if !ok {
+		return true
+	}
+	return token == wantToken
 }
 
 // processStartTime returns an opaque token identifying pid's process

--- a/internal/mcpinit/obsidiansync_windows.go
+++ b/internal/mcpinit/obsidiansync_windows.go
@@ -4,6 +4,7 @@ package mcpinit
 
 import (
 	"os/exec"
+	"strconv"
 	"syscall"
 
 	"golang.org/x/sys/windows"
@@ -40,4 +41,26 @@ func isProcessAlive(pid int) bool {
 		return false
 	}
 	return exitCode == stillActive
+}
+
+// processStartTime returns an opaque token identifying pid's process
+// creation instant, or ("", false) if it can't be determined. The
+// creation Filetime is wall-clock (100ns intervals since 1601-01-01), so
+// it is already reboot-safe with no extra prefixing needed.
+func processStartTime(pid int) (string, bool) {
+	if pid <= 0 || int64(pid) > 0xFFFFFFFF {
+		return "", false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return "", false
+	}
+	defer windows.CloseHandle(h) //nolint:errcheck
+
+	var creationTime, exitTime, kernelTime, userTime windows.Filetime
+	if err := windows.GetProcessTimes(h, &creationTime, &exitTime, &kernelTime, &userTime); err != nil {
+		return "", false
+	}
+	value := uint64(creationTime.HighDateTime)<<32 | uint64(creationTime.LowDateTime)
+	return strconv.FormatUint(value, 10), true
 }

--- a/internal/mcpinit/obsidiansync_windows_test.go
+++ b/internal/mcpinit/obsidiansync_windows_test.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package mcpinit
+
+import (
+	"os"
+	"testing"
+)
+
+func TestProcessStartTime_OwnPID(t *testing.T) {
+	token, ok := processStartTime(os.Getpid())
+	if !ok {
+		t.Fatal("processStartTime(own pid) ok = false, want true")
+	}
+	if token == "" {
+		t.Error("processStartTime(own pid) returned an empty token with ok=true")
+	}
+}
+
+func TestProcessStartTime_Stable(t *testing.T) {
+	a, okA := processStartTime(os.Getpid())
+	b, okB := processStartTime(os.Getpid())
+	if !okA || !okB {
+		t.Fatal("processStartTime(own pid) failed on a repeat call")
+	}
+	if a != b {
+		t.Errorf("processStartTime(own pid) not stable across calls: %q vs %q", a, b)
+	}
+}
+
+func TestProcessStartTime_ImplausiblePID(t *testing.T) {
+	if _, ok := processStartTime(999999999); ok {
+		t.Error("processStartTime(implausible pid) ok = true, want false")
+	}
+}

--- a/internal/mcpinit/obsidiansync_windows_test.go
+++ b/internal/mcpinit/obsidiansync_windows_test.go
@@ -33,3 +33,25 @@ func TestProcessStartTime_ImplausiblePID(t *testing.T) {
 		t.Error("processStartTime(implausible pid) ok = true, want false")
 	}
 }
+
+func TestIsProcessAlive_TokenMatch(t *testing.T) {
+	token, ok := processStartTime(os.Getpid())
+	if !ok {
+		t.Fatal("processStartTime(own pid) failed; can't set up test")
+	}
+	if !isProcessAlive(os.Getpid(), token, true) {
+		t.Error("isProcessAlive(own pid, own true token) = false, want true")
+	}
+}
+
+func TestIsProcessAlive_TokenMismatch(t *testing.T) {
+	if isProcessAlive(os.Getpid(), "definitely-not-the-real-token", true) {
+		t.Error("isProcessAlive(own pid, wrong token) = true, want false (PID-reuse must be detected)")
+	}
+}
+
+func TestIsProcessAlive_NoToken(t *testing.T) {
+	if !isProcessAlive(os.Getpid(), "", false) {
+		t.Error("isProcessAlive(own pid, haveToken=false) = false, want true (legacy behavior preserved)")
+	}
+}

--- a/internal/mcpinit/stophook.go
+++ b/internal/mcpinit/stophook.go
@@ -194,7 +194,8 @@ func spawnResolveIfConfigured(cwd string) {
 	if err := cmd.Start(); err != nil {
 		return
 	}
-	_ = atomicWritePID(pidPath, cmd.Process.Pid)
+	token, haveToken := processStartTime(cmd.Process.Pid)
+	_ = atomicWritePID(pidPath, cmd.Process.Pid, token, haveToken)
 	_ = cmd.Process.Release()
 }
 
@@ -270,18 +271,26 @@ func spawnSupersedeIfConfigured(cwd string) {
 	if err := cmd.Start(); err != nil {
 		return
 	}
-	_ = atomicWritePID(pidPath, cmd.Process.Pid)
+	token, haveToken := processStartTime(cmd.Process.Pid)
+	_ = atomicWritePID(pidPath, cmd.Process.Pid, token, haveToken)
 	_ = cmd.Process.Release()
 }
 
-// atomicWritePID writes pid into path via write-temp-then-rename so a
-// concurrent reader (e.g. another caller's claimPidFile, which reads this
-// file under its own lock) never observes a truncated or partially-written
-// file — os.WriteFile's open+truncate+write is not atomic and this call site
-// runs outside any lock.
-func atomicWritePID(path string, pid int) error {
+// atomicWritePID writes pid (and, when haveToken is true, its creation-time
+// token in "pid:token" form — see processStartTime) into path via
+// write-temp-then-rename so a concurrent reader (e.g. another caller's
+// claimPidFile, which reads this file under its own lock) never observes a
+// truncated or partially-written file — os.WriteFile's
+// open+truncate+write is not atomic and this call site runs outside any
+// lock. When haveToken is false, the bare-PID legacy format is written,
+// same as before this token support existed.
+func atomicWritePID(path string, pid int, token string, haveToken bool) error {
+	content := strconv.Itoa(pid)
+	if haveToken {
+		content += ":" + token
+	}
 	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(strconv.Itoa(pid)), 0o600); err != nil {
+	if err := os.WriteFile(tmp, []byte(content), 0o600); err != nil {
 		return err
 	}
 	return os.Rename(tmp, path)
@@ -314,5 +323,6 @@ func claimPidFile(pidPath string) bool {
 	if isAlive(pidPath) {
 		return false
 	}
-	return atomicWritePID(pidPath, os.Getpid()) == nil
+	token, haveToken := processStartTime(os.Getpid())
+	return atomicWritePID(pidPath, os.Getpid(), token, haveToken) == nil
 }

--- a/internal/mcpinit/stophook_test.go
+++ b/internal/mcpinit/stophook_test.go
@@ -202,7 +202,8 @@ func TestClaimPidFile_ConcurrentCallersOnlyOneWins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read pidPath: %v", err)
 	}
-	if _, err := strconv.Atoi(strings.TrimSpace(string(data))); err != nil {
+	pidStr, _, _ := strings.Cut(strings.TrimSpace(string(data)), ":")
+	if _, err := strconv.Atoi(pidStr); err != nil {
 		t.Errorf("pidPath content is never a valid PID (empty/stale window observed): %q", data)
 	}
 }

--- a/internal/mcpinit/stophook_test.go
+++ b/internal/mcpinit/stophook_test.go
@@ -250,3 +250,31 @@ func raceClaimPidFile(t *testing.T, pidPath string, n int) int {
 	}
 	return wins
 }
+
+// TestClaimPidFile_PlaceholderCarriesToken proves the placeholder PID
+// claimPidFile writes (the caller's own PID, before it has spawned
+// anything) is written in the same "pid:token" format as a real spawn —
+// otherwise an abandoned placeholder (caller hits an early-return failure
+// path after claiming but before cmd.Start()) has no creation-time guard
+// and reproduces the exact PID-reuse bug this design fixes.
+func TestClaimPidFile_PlaceholderCarriesToken(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "resolve-test.pid")
+
+	if !claimPidFile(pidPath) {
+		t.Fatal("claimPidFile on an empty slot = false, want true")
+	}
+
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatalf("read pidPath: %v", err)
+	}
+	content := strings.TrimSpace(string(data))
+	pidStr, token, haveToken := strings.Cut(content, ":")
+	if _, err := strconv.Atoi(pidStr); err != nil {
+		t.Errorf("placeholder content has no valid leading PID: %q", content)
+	}
+	if wantToken, ok := processStartTime(os.Getpid()); ok && (!haveToken || token != wantToken) {
+		t.Errorf("processStartTime succeeded (token=%q) but placeholder token is %q (haveToken=%v): %q", wantToken, token, haveToken, content)
+	}
+}


### PR DESCRIPTION
## Summary
- Closes item 3 of #252: `.pid`-file liveness checks (`isAlive`) only proved *some* process holds a given PID, not that it's the *same* process instance — after the original exits, OS PID reuse could make a stale `.pid` file for obsidian-sync/resolve/supersede look wrongly "still running."
- Adds a per-platform, opaque process creation-time token stored alongside the PID (`"pid:token"`); a bare integer with no colon is treated as the legacy format and falls back to today's PID-only liveness (no regression, no migration needed).
- Implements `processStartTime(pid) (token string, ok bool)` on Linux (`/proc/<pid>/stat` starttime + boot_id prefix for reboot-safety), Darwin (`unix.SysctlKinfoProc` → `P_starttime`), Windows (`GetProcessTimes`), and a no-op fallback for any other Unix — every new syscall path fails open to legacy behavior rather than erroring.
- `isProcessAlive` gains a 3-arg signature (`pid, wantToken, haveToken`) on POSIX and Windows; all write paths (`atomicWritePID`, both of `claimPidFile`'s write sites, `ensureObsidianSyncRunning`, `spawnResolveIfConfigured`, `spawnSupersedeIfConfigured`) now persist tokens.

## Test plan
- [x] `go vet ./...` and `go test ./...` pass natively
- [x] Cross-compiled all 6 goreleaser targets (linux/darwin/windows × amd64/arm64) via `go build ./...`
- [x] `go vet` clean for darwin/arm64 and windows/amd64
- [x] Race-tested the touched concurrency test (`go test -race -count=5 ./internal/mcpinit/`)
- [x] New tests cover token match/mismatch (PID-reuse regression), no-token/legacy format, dead PID, and the `claimPidFile` placeholder-token gap
- [x] Independent spec-compliance + code-quality review passed on every task, plus a final whole-diff review (APPROVE, no Critical/Important issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process tracking to detect when a recorded PID has been reused by another process.
  * PID files now preserve process creation information when available, while remaining compatible with existing PID-only files.
  * Added platform-specific support for Linux, macOS, and Windows, with safe fallback behavior on other systems.
  * Improved stale-process and placeholder claim validation to reduce incorrect process termination or replacement.

* **Tests**
  * Added coverage for matching, mismatched, missing, and unsupported process creation tokens across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->