### PR TITLE
Add Windows one-command installer (install.ps1)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,10 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+release:
+  extra_files:
+    - glob: install.ps1
+
 changelog:
   sort: asc
   filters:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Mem0, Zep, and supermemory are excellent hosted products — but self-hosting th
 
 ### Where does my data go?
 
-One SQLite file under `~/.local/share/ghost` (or `$XDG_DATA_HOME/ghost`). Ghost makes no network calls in normal operation, with three exceptions you control: **localhost** Ollama for embeddings (optional), the Claude API *only if* you run `ghost reflect` with the Haiku tier (needs `ANTHROPIC_API_KEY`; the SQLite tier is fully offline), and the GitHub API *only if* you run `ghost upgrade`. That's the complete list.
+One SQLite file under `~/.local/share/ghost` (or `$XDG_DATA_HOME/ghost`) — this path is the same on every OS, including Windows (i.e. `%USERPROFILE%\.local\share\ghost`, not `%AppData%`); only the config file follows the OS-native convention (see Configuration below). Ghost makes no network calls in normal operation, with three exceptions you control: **localhost** Ollama for embeddings (optional), the Claude API *only if* you run `ghost reflect` with the Haiku tier (needs `ANTHROPIC_API_KEY`; the SQLite tier is fully offline), and the GitHub API *only if* you run `ghost upgrade`. That's the complete list.
 
 ### What exactly gets injected into my agent's context?
 
@@ -265,7 +265,7 @@ Ghost works with zero config. When you want to change something, layers are (lat
 
 1. Compiled defaults
 2. `/etc/ghost/config.yaml`
-3. `~/.config/ghost/config.yaml`
+3. `~/.config/ghost/config.yaml` (honors `$XDG_CONFIG_HOME` when set; on Windows, absent an `XDG_CONFIG_HOME` override, this resolves to `%AppData%\ghost\config.yaml`)
 4. `GHOST_*` environment variables, plus `ANTHROPIC_API_KEY` for the Haiku reflection tier
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ No Go toolchain? Grab a prebuilt binary from [Releases](https://github.com/wcatz
 **On Windows?** Skip the manual download/unzip/PATH steps with the one-command installer:
 
 ```powershell
-irm https://raw.githubusercontent.com/wcatz/ghost/main/install.ps1 | iex
+irm https://github.com/wcatz/ghost/releases/latest/download/install.ps1 | iex
 ```
 
 This downloads the latest release, verifies its checksum, installs

--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ This writes the `ghost` entry into `~/.config/opencode/opencode.json` (or merges
 
 No Go toolchain? Grab a prebuilt binary from [Releases](https://github.com/wcatz/ghost/releases/latest) — linux, macOS, and Windows, amd64 and arm64, with `checksums.txt`. Building from source needs Go 1.26+ (older toolchains fetch it automatically via `GOTOOLCHAIN=auto`).
 
+**On Windows?** Skip the manual download/unzip/PATH steps with the one-command installer:
+
+```powershell
+irm https://raw.githubusercontent.com/wcatz/ghost/main/install.ps1 | iex
+```
+
+This downloads the latest release, verifies its checksum, installs
+`ghost.exe` to `%LOCALAPPDATA%\ghost\bin`, and adds that directory to your
+user PATH. Open a new terminal afterward, then run `ghost mcp init`.
+
+Re-running the command upgrades an existing install in place.
+
 **Using Cursor, Goose, or another MCP client?** Ghost speaks standard MCP over stdio — point any client at the binary:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Switching *in* is just as easy: `ghost mcp init` imports Claude Code memories, a
 ### Where's the off switch?
 
 - **Per client:** remove the `ghost` entry from your MCP config. Ghost only runs when your client spawns it over stdio — there is no daemon.
-- **Embeddings:** set `embedding.enabled: false` in `~/.config/ghost/config.yaml`.
+- **Embeddings:** set `embedding.enabled: false` in your config file (see [Configuration](#configuration) for the OS-specific path — `%AppData%\ghost\config.yaml` on Windows, `~/.config/ghost/config.yaml` elsewhere).
 - **Consolidation:** never runs unless you invoke `ghost reflect` — and that's a dry run unless you pass `--apply`.
 - **Everything:** delete `$XDG_DATA_HOME/ghost`, or `~/.local/share/ghost` when `XDG_DATA_HOME` is unset. There is nothing else.
 

--- a/docs/superpowers/plans/2026-08-10-windows-installer.md
+++ b/docs/superpowers/plans/2026-08-10-windows-installer.md
@@ -480,7 +480,7 @@ git commit -m "feat: wire up install.ps1 main orchestration and error handling"
 Find the existing install instructions in `README.md` (the `go install` /
 `make install` section) and add a Windows subsection immediately after it:
 
-```markdown
+````markdown
 ### Windows
 
 ```powershell
@@ -492,7 +492,7 @@ This downloads the latest release, verifies its checksum, installs
 user PATH. Open a new terminal afterward, then run `ghost mcp init`.
 
 Re-running the command upgrades an existing install in place.
-```
+````
 
 - [ ] **Step 2: Commit**
 

--- a/docs/superpowers/plans/2026-08-10-windows-installer.md
+++ b/docs/superpowers/plans/2026-08-10-windows-installer.md
@@ -1,0 +1,562 @@
+# Windows Installer (install.ps1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `install.ps1` at the repo root so Windows users can run
+`irm https://raw.githubusercontent.com/wcatz/ghost/main/install.ps1 | iex` to
+download, verify, and install the latest `ghost` release with PATH already
+configured — closing #257 and #258.
+
+**Architecture:** A single PowerShell script composed of small, named
+functions (`Get-Arch`, `Get-LatestReleaseInfo`, `Test-Checksum`,
+`Install-Ghost`, `Add-UserPathEntry`), each independently reviewable, wired
+together by a top-level `main` block guarded by
+`if ($MyInvocation.InvocationName -ne '.')` so the functions can also be
+dot-sourced for review/inspection without executing the installer.
+
+**Tech Stack:** Windows PowerShell 5.1+ / PowerShell 7+ compatible syntax
+(avoid PS7-only operators), `Invoke-WebRequest`, `Get-FileHash`, Windows
+registry cmdlets (`Get-ItemProperty`/`Set-ItemProperty` on
+`HKCU:\Environment`), P/Invoke via `Add-Type` for `SendMessageTimeout` /
+`WM_SETTINGCHANGE` broadcast.
+
+**No Go-test equivalent exists for PowerShell in this repo, and this
+environment has no `pwsh` installed (verified: not in PATH, not in the
+default dnf repos).** Every function-level step below is verified two ways:
+(1) `powershell -NoProfile -Command "... syntax check ..."` is NOT available
+either, so verification is by careful line-by-line review of each function
+against its stated contract, kept small enough to review completely; (2) the
+final task is a real end-to-end run on a Windows machine (the UTM VM already
+used for Skinner's testing), which only the user can execute and confirm.
+This is documented up front rather than glossed over — do not claim automated
+test coverage that does not exist.
+
+---
+
+### Task 1: Script skeleton and architecture detection
+
+**Files:**
+- Create: `install.ps1`
+
+- [ ] **Step 1: Write the script header and `Get-Arch` function**
+
+```powershell
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs the latest ghost release and adds it to the user PATH.
+.DESCRIPTION
+    Downloads the latest windows/amd64 or windows/arm64 ghost release from
+    GitHub, verifies its SHA256 against the release's checksums.txt, extracts
+    ghost.exe into %LOCALAPPDATA%\ghost\bin, and adds that directory to the
+    persistent user PATH (via the registry, not setx).
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$script:Repo = 'wcatz/ghost'
+$script:InstallDir = Join-Path $env:LOCALAPPDATA 'ghost\bin'
+
+function Get-Arch {
+    <#
+    .SYNOPSIS
+        Maps the running process architecture to a goreleaser arch string.
+    .OUTPUTS
+        String: 'amd64' or 'arm64'. Throws on any other architecture.
+    #>
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+    switch ($arch) {
+        'X64' { return 'amd64' }
+        'Arm64' { return 'arm64' }
+        default {
+            throw "Unsupported architecture: $arch. ghost only ships windows/amd64 and windows/arm64 builds."
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Review the function against its contract**
+
+Confirm: `Get-Arch` returns exactly `'amd64'` or `'arm64'`, and throws (not
+`Write-Error` + continue) for anything else — the caller must not proceed
+with an unsupported arch. No test runner is available in this environment
+(no `pwsh`); this is a manual code-reading check, not an executed test. Note
+this explicitly rather than silently skipping verification.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add install.ps1
+git commit -m "feat: add install.ps1 skeleton with arch detection"
+```
+
+---
+
+### Task 2: Resolve the latest release
+
+**Files:**
+- Modify: `install.ps1`
+
+- [ ] **Step 1: Add `Get-LatestReleaseInfo`**
+
+```powershell
+function Get-LatestReleaseInfo {
+    <#
+    .SYNOPSIS
+        Queries the GitHub API for the latest ghost release and builds the
+        asset/checksum URLs for the given architecture.
+    .PARAMETER Arch
+        'amd64' or 'arm64', as returned by Get-Arch.
+    .OUTPUTS
+        Hashtable with keys: Version, ZipUrl, ZipName, ChecksumsUrl.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('amd64', 'arm64')]
+        [string]$Arch
+    )
+
+    $apiUrl = "https://api.github.com/repos/$script:Repo/releases/latest"
+    $release = Invoke-RestMethod -Uri $apiUrl -Headers @{ 'User-Agent' = 'ghost-install-script' }
+    $version = $release.tag_name -replace '^v', ''
+
+    $zipName = "ghost_${version}_windows_${Arch}.zip"
+    $asset = $release.assets | Where-Object { $_.name -eq $zipName }
+    if (-not $asset) {
+        throw "Release $($release.tag_name) has no asset named $zipName"
+    }
+    $checksumsAsset = $release.assets | Where-Object { $_.name -eq 'checksums.txt' }
+    if (-not $checksumsAsset) {
+        throw "Release $($release.tag_name) has no checksums.txt asset"
+    }
+
+    return @{
+        Version      = $version
+        ZipUrl       = $asset.browser_download_url
+        ZipName      = $zipName
+        ChecksumsUrl = $checksumsAsset.browser_download_url
+    }
+}
+```
+
+- [ ] **Step 2: Review against contract**
+
+Confirm: throws (does not silently return partial data) if either the
+versioned zip asset or `checksums.txt` is missing from the release. Confirm
+the zip filename exactly matches goreleaser's `name_template`:
+`{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}` →
+`ghost_<version>_windows_<arch>.zip` — cross-checked against
+`.goreleaser.yml:16-22` in this repo. Manual review only; no `pwsh` available
+to execute this against the live GitHub API in this environment.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add install.ps1
+git commit -m "feat: resolve latest release info in install.ps1"
+```
+
+---
+
+### Task 3: Download and checksum verification
+
+**Files:**
+- Modify: `install.ps1`
+
+- [ ] **Step 1: Add `Test-Checksum`**
+
+```powershell
+function Test-Checksum {
+    <#
+    .SYNOPSIS
+        Verifies a file's SHA256 against the matching line in a
+        goreleaser checksums.txt.
+    .PARAMETER FilePath
+        Path to the downloaded file to verify.
+    .PARAMETER FileName
+        The name as it appears in checksums.txt (e.g. ghost_1.2.3_windows_amd64.zip).
+    .PARAMETER ChecksumsPath
+        Path to the downloaded checksums.txt.
+    .OUTPUTS
+        None. Throws if the checksum is missing or does not match.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$FilePath,
+        [Parameter(Mandatory)][string]$FileName,
+        [Parameter(Mandatory)][string]$ChecksumsPath
+    )
+
+    $line = Get-Content $ChecksumsPath | Where-Object { $_ -match [regex]::Escape($FileName) }
+    if (-not $line) {
+        throw "No checksum entry found for $FileName in checksums.txt"
+    }
+    $expected = ($line -split '\s+')[0].ToLowerInvariant()
+    $actual = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+    if ($expected -ne $actual) {
+        throw "Checksum mismatch for $FileName`: expected $expected, got $actual"
+    }
+}
+```
+
+- [ ] **Step 2: Add the download orchestration in `Install-Ghost`'s download phase**
+
+```powershell
+function Get-GhostRelease {
+    <#
+    .SYNOPSIS
+        Downloads the release zip and checksums.txt into a fresh temp
+        directory and verifies the zip's checksum.
+    .PARAMETER ReleaseInfo
+        Hashtable as returned by Get-LatestReleaseInfo.
+    .OUTPUTS
+        String: path to the temp directory containing the verified zip.
+    #>
+    param(
+        [Parameter(Mandatory)][hashtable]$ReleaseInfo
+    )
+
+    $tempDir = Join-Path $env:TEMP "ghost-install-$([guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+    $zipPath = Join-Path $tempDir $ReleaseInfo.ZipName
+    $checksumsPath = Join-Path $tempDir 'checksums.txt'
+
+    Invoke-WebRequest -Uri $ReleaseInfo.ZipUrl -OutFile $zipPath
+    Invoke-WebRequest -Uri $ReleaseInfo.ChecksumsUrl -OutFile $checksumsPath
+
+    Test-Checksum -FilePath $zipPath -FileName $ReleaseInfo.ZipName -ChecksumsPath $checksumsPath
+
+    return @{ TempDir = $tempDir; ZipPath = $zipPath }
+}
+```
+
+- [ ] **Step 3: Review against contract**
+
+Confirm: `Test-Checksum` throws on both "no matching line" and "hash
+mismatch" — it never returns a boolean that a caller could ignore. Confirm
+`Get-GhostRelease` calls `Test-Checksum` before returning, so no caller can
+receive an unverified zip path. Manual review only.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add install.ps1
+git commit -m "feat: download and verify release checksum in install.ps1"
+```
+
+---
+
+### Task 4: Extract and install the binary (idempotent)
+
+**Files:**
+- Modify: `install.ps1`
+
+- [ ] **Step 1: Add `Install-Ghost`**
+
+```powershell
+function Install-Ghost {
+    <#
+    .SYNOPSIS
+        Extracts ghost.exe from a verified zip into the install directory,
+        overwriting any existing binary.
+    .PARAMETER ZipPath
+        Path to the verified release zip.
+    .PARAMETER Destination
+        Directory to install ghost.exe into (created if missing).
+    .OUTPUTS
+        String: full path to the installed ghost.exe.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$ZipPath,
+        [Parameter(Mandatory)][string]$Destination
+    )
+
+    New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+
+    $extractDir = Join-Path ([System.IO.Path]::GetDirectoryName($ZipPath)) 'extracted'
+    Expand-Archive -Path $ZipPath -DestinationPath $extractDir -Force
+
+    $exePath = Join-Path $extractDir 'ghost.exe'
+    if (-not (Test-Path $exePath)) {
+        throw "ghost.exe not found in extracted archive at $exePath"
+    }
+
+    $destExe = Join-Path $Destination 'ghost.exe'
+    Copy-Item -Path $exePath -Destination $destExe -Force
+
+    return $destExe
+}
+```
+
+- [ ] **Step 2: Review against contract**
+
+Confirm: `-Force` on both `Expand-Archive` and `Copy-Item` makes re-running
+the installer an overwrite, not an error, satisfying the spec's "idempotent
+— always overwrite with latest" decision. Confirm a missing `ghost.exe` in
+the archive throws rather than silently installing nothing. Manual review
+only.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add install.ps1
+git commit -m "feat: extract and install ghost.exe idempotently"
+```
+
+---
+
+### Task 5: Persistent PATH update via registry
+
+**Files:**
+- Modify: `install.ps1`
+
+- [ ] **Step 1: Add the `WM_SETTINGCHANGE` broadcast helper and `Add-UserPathEntry`**
+
+```powershell
+function Broadcast-EnvironmentChange {
+    <#
+    .SYNOPSIS
+        Broadcasts WM_SETTINGCHANGE so already-open processes (e.g. Explorer)
+        pick up the updated environment. Does not affect already-open shells'
+        own process environment blocks — a new terminal is still required for
+        those.
+    #>
+    $signature = @'
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+    IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+    uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+'@
+    Add-Type -MemberDefinition $signature -Namespace Win32Native -Name User32 -ErrorAction SilentlyContinue
+
+    $HWND_BROADCAST = [IntPtr]0xffff
+    $WM_SETTINGCHANGE = 0x1a
+    $SMTO_ABORTIFHUNG = 0x2
+    $result = [UIntPtr]::Zero
+    [Win32Native.User32]::SendMessageTimeout(
+        $HWND_BROADCAST, $WM_SETTINGCHANGE, [UIntPtr]::Zero, 'Environment',
+        $SMTO_ABORTIFHUNG, 5000, [ref]$result) | Out-Null
+}
+
+function Add-UserPathEntry {
+    <#
+    .SYNOPSIS
+        Adds a directory to the persistent per-user PATH via the registry,
+        avoiding setx's 1024-char truncation. No-op if already present.
+    .PARAMETER Directory
+        The directory to add.
+    .OUTPUTS
+        Boolean: $true if PATH was modified, $false if the entry already existed.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Directory
+    )
+
+    $envKey = 'Registry::HKEY_CURRENT_USER\Environment'
+    $current = (Get-ItemProperty -Path $envKey -Name 'Path' -ErrorAction SilentlyContinue).Path
+    if (-not $current) { $current = '' }
+
+    $entries = $current -split ';' | Where-Object { $_ -ne '' }
+    $alreadyPresent = $entries | Where-Object { $_.TrimEnd('\') -ieq $Directory.TrimEnd('\') }
+    if ($alreadyPresent) {
+        return $false
+    }
+
+    $newValue = if ($current -eq '') { $Directory } else { "$current;$Directory" }
+    Set-ItemProperty -Path $envKey -Name 'Path' -Value $newValue -Type ExpandString
+
+    Broadcast-EnvironmentChange
+
+    return $true
+}
+```
+
+- [ ] **Step 2: Review against contract**
+
+Confirm: reads and writes `HKCU\Environment` directly (registry cmdlets), not
+`setx` — no 1024-char truncation risk. Confirm the existing-entry check is
+case-insensitive and trailing-backslash-tolerant, so re-running the installer
+doesn't append duplicate PATH entries. Confirm `-Type ExpandString` preserves
+the `REG_EXPAND_SZ` type so any `%VAR%` references already in the user's PATH
+keep expanding correctly. Manual review only — no Windows registry available
+in this Linux dev environment to execute against.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add install.ps1
+git commit -m "feat: add registry-based persistent PATH update"
+```
+
+---
+
+### Task 6: Top-level orchestration, error handling, and cleanup
+
+**Files:**
+- Modify: `install.ps1`
+
+- [ ] **Step 1: Add the `main` orchestration block**
+
+```powershell
+function Main {
+    $tempDir = $null
+    try {
+        Write-Host 'Detecting architecture...'
+        $arch = Get-Arch
+        Write-Host "  -> $arch"
+
+        Write-Host 'Resolving latest release...'
+        $release = Get-LatestReleaseInfo -Arch $arch
+        Write-Host "  -> ghost $($release.Version)"
+
+        Write-Host 'Downloading and verifying...'
+        $downloaded = Get-GhostRelease -ReleaseInfo $release
+        $tempDir = $downloaded.TempDir
+        Write-Host '  -> checksum OK'
+
+        Write-Host "Installing to $script:InstallDir..."
+        $exePath = Install-Ghost -ZipPath $downloaded.ZipPath -Destination $script:InstallDir
+        Write-Host "  -> installed $exePath"
+
+        Write-Host 'Updating PATH...'
+        $changed = Add-UserPathEntry -Directory $script:InstallDir
+        if ($changed) {
+            Write-Host '  -> added to user PATH'
+        } else {
+            Write-Host '  -> already on PATH'
+        }
+
+        Write-Host ''
+        Write-Host 'ghost installed successfully.'
+        Write-Host 'Open a new terminal, then run: ghost mcp init'
+    }
+    catch {
+        Write-Error "Install failed: $($_.Exception.Message)"
+        exit 1
+    }
+    finally {
+        if ($tempDir -and (Test-Path $tempDir)) {
+            Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Main
+}
+```
+
+- [ ] **Step 2: Review against contract**
+
+Confirm: every function called in `Main` that can fail (`Get-Arch`,
+`Get-LatestReleaseInfo`, `Get-GhostRelease` → `Test-Checksum`,
+`Install-Ghost`) throws rather than returning a sentinel, so the single
+`try/catch` in `Main` catches all of them uniformly and exits non-zero.
+Confirm the `finally` block always attempts temp-dir cleanup, including on
+the failure path. Confirm the `if ($MyInvocation.InvocationName -ne '.')`
+guard means dot-sourcing the script (`. .\install.ps1`) loads the functions
+without running `Main` — this is what makes the functions reviewable/callable
+in isolation despite no test runner being available. Manual review only.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add install.ps1
+git commit -m "feat: wire up install.ps1 main orchestration and error handling"
+```
+
+---
+
+### Task 7: README documentation
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add a Windows install section**
+
+Find the existing install instructions in `README.md` (the `go install` /
+`make install` section) and add a Windows subsection immediately after it:
+
+```markdown
+### Windows
+
+```powershell
+irm https://raw.githubusercontent.com/wcatz/ghost/main/install.ps1 | iex
+```
+
+This downloads the latest release, verifies its checksum, installs
+`ghost.exe` to `%LOCALAPPDATA%\ghost\bin`, and adds that directory to your
+user PATH. Open a new terminal afterward, then run `ghost mcp init`.
+
+Re-running the command upgrades an existing install in place.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document Windows install.ps1 one-command install"
+```
+
+---
+
+### Task 8: Manual end-to-end verification (Windows required)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run on a real Windows environment**
+
+On a Windows machine (e.g. the UTM VM used for Skinner's testing), with no
+prior ghost install:
+
+```powershell
+irm https://raw.githubusercontent.com/<branch-or-fork-url>/install.ps1 | iex
+```
+
+(Use a `raw.githubusercontent.com` URL pointing at this branch, or copy the
+script locally and run `.\install.ps1`, since `main` won't have this script
+until the PR merges.)
+
+Confirm:
+- Script reports the detected arch, resolved version, checksum OK, install
+  path, and PATH-updated message with no errors.
+- `ghost.exe` exists at `%LOCALAPPDATA%\ghost\bin\ghost.exe`.
+- **In a newly opened terminal**, `ghost version` resolves and runs
+  (confirms PATH took effect).
+
+- [ ] **Step 2: Re-run to verify idempotent upgrade**
+
+Run the same command again in the same terminal session used for Step 1's
+new terminal. Confirm:
+- No duplicate PATH entries are added (inspect `[Environment]::GetEnvironmentVariable('Path', 'User')`
+  and confirm `%LOCALAPPDATA%\ghost\bin` appears exactly once).
+- The binary is overwritten without any prompt or error.
+
+- [ ] **Step 3: Report results back**
+
+This step cannot be performed by the implementing agent — no Windows
+environment is available in this Linux dev environment. Report pass/fail and
+any error output from Steps 1-2 to the user (or file a follow-up issue if a
+step fails) before considering #257/#258 closed.
+
+---
+
+## Plan self-review notes
+
+- **Spec coverage:** distribution (Task 7 doc + repo-root file per spec),
+  arch detection (Task 1), latest-release resolution (Task 2), checksum
+  verification against goreleaser's checksums.txt (Task 3), install to
+  `%LOCALAPPDATA%\ghost\bin` idempotently (Task 4), registry-based PATH
+  update avoiding setx (Task 5), error handling + cleanup (Task 6), no
+  install.sh / no auto mcp init / no package manager manifest (none added,
+  matches spec's explicit non-goals).
+- **Manual-verification caveat carried through every task**, not just
+  mentioned once at the top — each task's review step explicitly says
+  "manual review only, no pwsh available" rather than implying automated
+  test coverage exists.
+- Task 8 is explicitly flagged as requiring the user's Windows environment —
+  the implementing agent cannot self-certify this plan's real-world
+  correctness, only its internal logical consistency.

--- a/docs/superpowers/specs/2026-08-10-windows-installer-design.md
+++ b/docs/superpowers/specs/2026-08-10-windows-installer-design.md
@@ -1,0 +1,120 @@
+# Windows one-command installer (`install.ps1`)
+
+## Problem
+
+Filed by Skinner (opencode agent testing Ghost on a UTM Windows VM):
+
+- **#257**: No one-command install on Windows. Today, getting `ghost.exe` onto a
+  Windows machine requires either cross-compiling and `scp`-ing the binary by
+  hand, or manually downloading and unzipping a GitHub release asset.
+- **#258**: No PATH setup as part of install. Even after the binary is placed,
+  the user must run `setx PATH "%PATH%;C:\Users\ghost\bin"` by hand, in a shell
+  where `%PATH%` still expands to the *old* value (so it silently drops
+  anything set in that same session), only affects *new* processes, and `setx`
+  truncates the value at 1024 chars.
+
+POSIX users already have `make install` (copies to `$GOPATH/bin` or
+`~/go/bin`). Windows has no equivalent — this design adds one.
+
+## Goals
+
+- A single command Windows users can run to install `ghost` and have it
+  immediately usable in a new shell.
+- No admin privileges required.
+- No new signing/hosting infrastructure — reuse what `.goreleaser.yml`
+  already produces (per-OS/arch zip archives + `checksums.txt`).
+- Safe to re-run (upgrade in place).
+
+## Non-goals
+
+- No POSIX `install.sh` — #257/#258 are Windows-specific; POSIX already has
+  `make install`. Parity script is a separate future issue if wanted.
+- No automatic `ghost mcp init` invocation. The installer's job ends at
+  "binary on PATH." Wiring Claude Code/opencode remains an explicit, separate,
+  already-idempotent step the user runs themselves.
+- No package-manager manifest (winget/scoop). Worth revisiting later, but out
+  of scope here — the script is the fast, fully-in-our-control option for now.
+
+## Design
+
+### Distribution
+
+`install.ps1` is committed to the repo root and served straight from GitHub:
+
+```powershell
+irm https://raw.githubusercontent.com/wcatz/ghost/main/install.ps1 | iex
+```
+
+No extra hosting, no release-asset step in goreleaser. The script always
+reflects the `main` branch; because it downloads whatever the *latest GitHub
+release* is (not a version pinned to itself), a stale copy of the script
+served from an old commit still installs the current release correctly — the
+script's own logic rarely needs to change once it's correct.
+
+### Flow
+
+1. **Detect architecture.** Use
+   `[System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture`
+   to map to `amd64` or `arm64`. Any other architecture (e.g. x86) is a hard
+   error with a clear message — no silent fallback.
+2. **Resolve latest release.** Query
+   `https://api.github.com/repos/wcatz/ghost/releases/latest` for the tag
+   name; build the expected asset filename
+   `ghost_<version>_windows_<arch>.zip` (matching goreleaser's
+   `name_template`) and the `checksums.txt` URL for that same release.
+3. **Download.** Fetch both files into a temp directory
+   (`$env:TEMP\ghost-install-<random>`).
+4. **Verify.** Compute SHA256 of the downloaded zip
+   (`Get-FileHash -Algorithm SHA256`) and compare against the matching line in
+   `checksums.txt`. Mismatch → abort with a clear error, delete the temp dir,
+   non-zero exit. No install proceeds on unverified binaries.
+5. **Install.** Extract `ghost.exe` from the zip into
+   `%LOCALAPPDATA%\ghost\bin`, creating the directory if needed. If a binary
+   already exists there, it is overwritten — no prompt, no `-Force` flag
+   needed. Re-running the script is how you upgrade, mirroring the
+   already-idempotent `ghost mcp init` philosophy in this codebase.
+6. **Update PATH.** Read `HKCU:\Environment`'s `PATH` value directly via the
+   registry (`Get-ItemProperty`/`Set-ItemProperty`), not `setx`:
+   - If `%LOCALAPPDATA%\ghost\bin` is already present (case-insensitive
+     segment match), do nothing.
+   - Otherwise append it and write back. The registry `REG_EXPAND_SZ` value
+     has no 1024-char truncation limit, unlike `setx`.
+   - Broadcast `WM_SETTINGCHANGE` via a small inline P/Invoke
+     (`SendMessageTimeout` to `HWND_BROADCAST`) so some already-open
+     processes (e.g. Explorer) pick up the change without a reboot. Note in
+     the script's output that *already-open terminals* still need to be
+     restarted — `WM_SETTINGCHANGE` doesn't retroactively update a running
+     shell's own environment block.
+7. **Report success**, printing the install path and instructing the user to
+   open a new terminal and run `ghost mcp init` next.
+
+### Error handling
+
+Each failure mode produces a distinct, specific message and a non-zero exit,
+with the temp directory cleaned up in a `finally` block:
+
+- Network/API failure resolving the latest release
+- Download failure (either asset)
+- Checksum mismatch
+- Unsupported architecture
+- Extraction failure (corrupt zip)
+
+No partial state is left behind (e.g. a half-extracted binary with PATH
+already updated).
+
+### Testing
+
+PowerShell has no direct equivalent to Go's test suite in this repo, so this
+isn't TDD in the Go sense used elsewhere in Ghost. The script will be
+structured as small, named functions (`Get-LatestReleaseInfo`,
+`Test-Checksum`, `Add-UserPathEntry`, `Install-Ghost`) so behavior is at least
+readable and reviewable in isolation, but verification is manual: run the
+script end-to-end on a real Windows environment (the UTM VM Skinner already
+uses, or an equivalent) and confirm `ghost` resolves in a fresh terminal after
+a clean run and after a re-run (upgrade path).
+
+## Out of scope / future work
+
+- winget/scoop manifests
+- POSIX `install.sh` parity script
+- Automatic `ghost mcp init` invocation from the installer

--- a/install.ps1
+++ b/install.ps1
@@ -23,7 +23,7 @@ function Get-Arch {
     .OUTPUTS
         String: 'amd64' or 'arm64'. Throws on any other architecture.
     #>
-    $arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
     switch ($arch) {
         'X64' { return 'amd64' }
         'Arm64' { return 'arm64' }

--- a/install.ps1
+++ b/install.ps1
@@ -32,3 +32,32 @@ function Get-Arch {
         }
     }
 }
+
+function Get-LatestReleaseInfo {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('amd64', 'arm64')]
+        [string]$Arch
+    )
+
+    $apiUrl = "https://api.github.com/repos/$script:Repo/releases/latest"
+    $release = Invoke-RestMethod -Uri $apiUrl -Headers @{ 'User-Agent' = 'ghost-install-script' }
+    $version = $release.tag_name -replace '^v', ''
+
+    $zipName = "ghost_${version}_windows_${Arch}.zip"
+    $asset = $release.assets | Where-Object { $_.name -eq $zipName }
+    if (-not $asset) {
+        throw "Release $($release.tag_name) has no asset named $zipName"
+    }
+    $checksumsAsset = $release.assets | Where-Object { $_.name -eq 'checksums.txt' }
+    if (-not $checksumsAsset) {
+        throw "Release $($release.tag_name) has no checksums.txt asset"
+    }
+
+    return @{
+        Version      = $version
+        ZipUrl       = $asset.browser_download_url
+        ZipName      = $zipName
+        ChecksumsUrl = $checksumsAsset.browser_download_url
+    }
+}

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,34 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs the latest ghost release and adds it to the user PATH.
+.DESCRIPTION
+    Downloads the latest windows/amd64 or windows/arm64 ghost release from
+    GitHub, verifies its SHA256 against the release's checksums.txt, extracts
+    ghost.exe into %LOCALAPPDATA%\ghost\bin, and adds that directory to the
+    persistent user PATH (via the registry, not setx).
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$script:Repo = 'wcatz/ghost'
+$script:InstallDir = Join-Path $env:LOCALAPPDATA 'ghost\bin'
+
+function Get-Arch {
+    <#
+    .SYNOPSIS
+        Maps the running process architecture to a goreleaser arch string.
+    .OUTPUTS
+        String: 'amd64' or 'arm64'. Throws on any other architecture.
+    #>
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+    switch ($arch) {
+        'X64' { return 'amd64' }
+        'Arm64' { return 'arm64' }
+        default {
+            throw "Unsupported architecture: $arch. ghost only ships windows/amd64 and windows/arm64 builds."
+        }
+    }
+}

--- a/install.ps1
+++ b/install.ps1
@@ -97,14 +97,20 @@ function Get-GhostRelease {
     $previousProgressPreference = $ProgressPreference
     $ProgressPreference = 'SilentlyContinue'
     try {
-        Invoke-WebRequest -Uri $ReleaseInfo.ZipUrl -OutFile $zipPath
-        Invoke-WebRequest -Uri $ReleaseInfo.ChecksumsUrl -OutFile $checksumsPath
-    }
-    finally {
-        $ProgressPreference = $previousProgressPreference
-    }
+        try {
+            Invoke-WebRequest -Uri $ReleaseInfo.ZipUrl -OutFile $zipPath
+            Invoke-WebRequest -Uri $ReleaseInfo.ChecksumsUrl -OutFile $checksumsPath
+        }
+        finally {
+            $ProgressPreference = $previousProgressPreference
+        }
 
-    Test-Checksum -FilePath $zipPath -FileName $ReleaseInfo.ZipName -ChecksumsPath $checksumsPath
+        Test-Checksum -FilePath $zipPath -FileName $ReleaseInfo.ZipName -ChecksumsPath $checksumsPath
+    }
+    catch {
+        Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        throw
+    }
 
     return @{ TempDir = $tempDir; ZipPath = $zipPath }
 }
@@ -218,7 +224,10 @@ function Main {
     }
     catch {
         Write-Error "Install failed: $($_.Exception.Message)"
-        exit 1
+        if ($PSCommandPath) {
+            exit 1
+        }
+        return
     }
     finally {
         if ($tempDir -and (Test-Path $tempDir)) {

--- a/install.ps1
+++ b/install.ps1
@@ -108,3 +108,25 @@ function Get-GhostRelease {
 
     return @{ TempDir = $tempDir; ZipPath = $zipPath }
 }
+
+function Install-Ghost {
+    param(
+        [Parameter(Mandatory)][string]$ZipPath,
+        [Parameter(Mandatory)][string]$Destination
+    )
+
+    New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+
+    $extractDir = Join-Path ([System.IO.Path]::GetDirectoryName($ZipPath)) 'extracted'
+    Expand-Archive -Path $ZipPath -DestinationPath $extractDir -Force
+
+    $exePath = Join-Path $extractDir 'ghost.exe'
+    if (-not (Test-Path $exePath)) {
+        throw "ghost.exe not found in extracted archive at $exePath"
+    }
+
+    $destExe = Join-Path $Destination 'ghost.exe'
+    Copy-Item -Path $exePath -Destination $destExe -Force
+
+    return $destExe
+}

--- a/install.ps1
+++ b/install.ps1
@@ -63,3 +63,41 @@ function Get-LatestReleaseInfo {
         ChecksumsUrl = $checksumsAsset.browser_download_url
     }
 }
+
+function Test-Checksum {
+    param(
+        [Parameter(Mandatory)][string]$FilePath,
+        [Parameter(Mandatory)][string]$FileName,
+        [Parameter(Mandatory)][string]$ChecksumsPath
+    )
+
+    $line = Get-Content $ChecksumsPath | Where-Object { $_ -match [regex]::Escape($FileName) }
+    if (-not $line) {
+        throw "No checksum entry found for $FileName in checksums.txt"
+    }
+    $expected = ($line -split '\s+')[0].ToLowerInvariant()
+    $actual = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+    if ($expected -ne $actual) {
+        throw "Checksum mismatch for $FileName`: expected $expected, got $actual"
+    }
+}
+
+function Get-GhostRelease {
+    param(
+        [Parameter(Mandatory)][hashtable]$ReleaseInfo
+    )
+
+    $tempDir = Join-Path $env:TEMP "ghost-install-$([guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+    $zipPath = Join-Path $tempDir $ReleaseInfo.ZipName
+    $checksumsPath = Join-Path $tempDir 'checksums.txt'
+
+    Invoke-WebRequest -Uri $ReleaseInfo.ZipUrl -OutFile $zipPath
+    Invoke-WebRequest -Uri $ReleaseInfo.ChecksumsUrl -OutFile $checksumsPath
+
+    Test-Checksum -FilePath $zipPath -FileName $ReleaseInfo.ZipName -ChecksumsPath $checksumsPath
+
+    return @{ TempDir = $tempDir; ZipPath = $zipPath }
+}

--- a/install.ps1
+++ b/install.ps1
@@ -71,9 +71,9 @@ function Test-Checksum {
         [Parameter(Mandatory)][string]$ChecksumsPath
     )
 
-    $line = Get-Content $ChecksumsPath | Where-Object { $_ -match [regex]::Escape($FileName) }
-    if (-not $line) {
-        throw "No checksum entry found for $FileName in checksums.txt"
+    $line = Get-Content $ChecksumsPath | Where-Object { $_ -match "\s+$([regex]::Escape($FileName))$" }
+    if (@($line).Count -ne 1) {
+        throw "Expected exactly one checksum entry for $FileName, found $(@($line).Count)"
     }
     $expected = ($line -split '\s+')[0].ToLowerInvariant()
     $actual = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLowerInvariant()
@@ -94,8 +94,15 @@ function Get-GhostRelease {
     $zipPath = Join-Path $tempDir $ReleaseInfo.ZipName
     $checksumsPath = Join-Path $tempDir 'checksums.txt'
 
-    Invoke-WebRequest -Uri $ReleaseInfo.ZipUrl -OutFile $zipPath
-    Invoke-WebRequest -Uri $ReleaseInfo.ChecksumsUrl -OutFile $checksumsPath
+    $previousProgressPreference = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue'
+    try {
+        Invoke-WebRequest -Uri $ReleaseInfo.ZipUrl -OutFile $zipPath
+        Invoke-WebRequest -Uri $ReleaseInfo.ChecksumsUrl -OutFile $checksumsPath
+    }
+    finally {
+        $ProgressPreference = $previousProgressPreference
+    }
 
     Test-Checksum -FilePath $zipPath -FileName $ReleaseInfo.ZipName -ChecksumsPath $checksumsPath
 

--- a/install.ps1
+++ b/install.ps1
@@ -13,6 +13,8 @@ param()
 
 $ErrorActionPreference = 'Stop'
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 $script:Repo = 'wcatz/ghost'
 $script:InstallDir = Join-Path $env:LOCALAPPDATA 'ghost\bin'
 

--- a/install.ps1
+++ b/install.ps1
@@ -167,22 +167,25 @@ function Add-UserPathEntry {
         [Parameter(Mandatory)][string]$Directory
     )
 
-    $envKey = 'Registry::HKEY_CURRENT_USER\Environment'
-    $current = (Get-ItemProperty -Path $envKey -Name 'Path' -ErrorAction SilentlyContinue).Path
-    if (-not $current) { $current = '' }
-
-    $entries = $current -split ';' | Where-Object { $_ -ne '' }
-    $alreadyPresent = $entries | Where-Object { $_.TrimEnd('\') -ieq $Directory.TrimEnd('\') }
-    if ($alreadyPresent) {
-        return $false
-    }
-
-    $newValue = if ($current -eq '') { $Directory } else { "$current;$Directory" }
     try {
-        Set-ItemProperty -Path $envKey -Name 'Path' -Value $newValue -Type ExpandString
+        $envRegKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+        $current = $envRegKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        if (-not $current) { $current = '' }
+
+        $entries = $current -split ';' | Where-Object { $_ -ne '' }
+        $alreadyPresent = $entries | Where-Object { $_.TrimEnd('\') -ieq $Directory.TrimEnd('\') }
+        if ($alreadyPresent) {
+            return $false
+        }
+
+        $newValue = if ($current -eq '') { $Directory } else { "$current;$Directory" }
+        $envRegKey.SetValue('Path', $newValue, [Microsoft.Win32.RegistryValueKind]::ExpandString)
     }
     catch {
         throw "Failed to update user PATH in the registry: $($_.Exception.Message)"
+    }
+    finally {
+        if ($envRegKey) { $envRegKey.Dispose() }
     }
 
     Broadcast-EnvironmentChange
@@ -223,7 +226,7 @@ function Main {
         Write-Host 'Open a new terminal, then run: ghost mcp init'
     }
     catch {
-        Write-Error "Install failed: $($_.Exception.Message)"
+        Write-Error "Install failed: $($_.Exception.Message)" -ErrorAction Continue
         if ($PSCommandPath) {
             exit 1
         }

--- a/install.ps1
+++ b/install.ps1
@@ -135,3 +135,44 @@ function Install-Ghost {
 
     return $destExe
 }
+
+function Broadcast-EnvironmentChange {
+    $signature = @'
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+    IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+    uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+'@
+    Add-Type -MemberDefinition $signature -Namespace Win32Native -Name User32 -ErrorAction SilentlyContinue
+
+    $HWND_BROADCAST = [IntPtr]0xffff
+    $WM_SETTINGCHANGE = 0x1a
+    $SMTO_ABORTIFHUNG = 0x2
+    $result = [UIntPtr]::Zero
+    [Win32Native.User32]::SendMessageTimeout(
+        $HWND_BROADCAST, $WM_SETTINGCHANGE, [UIntPtr]::Zero, 'Environment',
+        $SMTO_ABORTIFHUNG, 5000, [ref]$result) | Out-Null
+}
+
+function Add-UserPathEntry {
+    param(
+        [Parameter(Mandatory)][string]$Directory
+    )
+
+    $envKey = 'Registry::HKEY_CURRENT_USER\Environment'
+    $current = (Get-ItemProperty -Path $envKey -Name 'Path' -ErrorAction SilentlyContinue).Path
+    if (-not $current) { $current = '' }
+
+    $entries = $current -split ';' | Where-Object { $_ -ne '' }
+    $alreadyPresent = $entries | Where-Object { $_.TrimEnd('\') -ieq $Directory.TrimEnd('\') }
+    if ($alreadyPresent) {
+        return $false
+    }
+
+    $newValue = if ($current -eq '') { $Directory } else { "$current;$Directory" }
+    Set-ItemProperty -Path $envKey -Name 'Path' -Value $newValue -Type ExpandString
+
+    Broadcast-EnvironmentChange
+
+    return $true
+}

--- a/install.ps1
+++ b/install.ps1
@@ -183,3 +183,50 @@ function Add-UserPathEntry {
 
     return $true
 }
+
+function Main {
+    $tempDir = $null
+    try {
+        Write-Host 'Detecting architecture...'
+        $arch = Get-Arch
+        Write-Host "  -> $arch"
+
+        Write-Host 'Resolving latest release...'
+        $release = Get-LatestReleaseInfo -Arch $arch
+        Write-Host "  -> ghost $($release.Version)"
+
+        Write-Host 'Downloading and verifying...'
+        $downloaded = Get-GhostRelease -ReleaseInfo $release
+        $tempDir = $downloaded.TempDir
+        Write-Host '  -> checksum OK'
+
+        Write-Host "Installing to $script:InstallDir..."
+        $exePath = Install-Ghost -ZipPath $downloaded.ZipPath -Destination $script:InstallDir
+        Write-Host "  -> installed $exePath"
+
+        Write-Host 'Updating PATH...'
+        $changed = Add-UserPathEntry -Directory $script:InstallDir
+        if ($changed) {
+            Write-Host '  -> added to user PATH'
+        } else {
+            Write-Host '  -> already on PATH'
+        }
+
+        Write-Host ''
+        Write-Host 'ghost installed successfully.'
+        Write-Host 'Open a new terminal, then run: ghost mcp init'
+    }
+    catch {
+        Write-Error "Install failed: $($_.Exception.Message)"
+        exit 1
+    }
+    finally {
+        if ($tempDir -and (Test-Path $tempDir)) {
+            Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Main
+}

--- a/install.ps1
+++ b/install.ps1
@@ -143,7 +143,9 @@ public static extern IntPtr SendMessageTimeout(
     IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
     uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
 '@
-    Add-Type -MemberDefinition $signature -Namespace Win32Native -Name User32 -ErrorAction SilentlyContinue
+    if (-not ([System.Management.Automation.PSTypeName]'Win32Native.User32').Type) {
+        Add-Type -MemberDefinition $signature -Namespace Win32Native -Name User32
+    }
 
     $HWND_BROADCAST = [IntPtr]0xffff
     $WM_SETTINGCHANGE = 0x1a
@@ -170,7 +172,12 @@ function Add-UserPathEntry {
     }
 
     $newValue = if ($current -eq '') { $Directory } else { "$current;$Directory" }
-    Set-ItemProperty -Path $envKey -Name 'Path' -Value $newValue -Type ExpandString
+    try {
+        Set-ItemProperty -Path $envKey -Name 'Path' -Value $newValue -Type ExpandString
+    }
+    catch {
+        throw "Failed to update user PATH in the registry: $($_.Exception.Message)"
+    }
 
     Broadcast-EnvironmentChange
 

--- a/install.ps1
+++ b/install.ps1
@@ -98,8 +98,8 @@ function Get-GhostRelease {
     $ProgressPreference = 'SilentlyContinue'
     try {
         try {
-            Invoke-WebRequest -Uri $ReleaseInfo.ZipUrl -OutFile $zipPath
-            Invoke-WebRequest -Uri $ReleaseInfo.ChecksumsUrl -OutFile $checksumsPath
+            Invoke-WebRequest -Uri $ReleaseInfo.ZipUrl -OutFile $zipPath -UseBasicParsing
+            Invoke-WebRequest -Uri $ReleaseInfo.ChecksumsUrl -OutFile $checksumsPath -UseBasicParsing
         }
         finally {
             $ProgressPreference = $previousProgressPreference
@@ -133,10 +133,19 @@ function Install-Ghost {
 
     $destExe = Join-Path $Destination 'ghost.exe'
     $oldExe = "$destExe.old"
-    if (Test-Path $destExe) {
+    $hadExisting = Test-Path $destExe
+    if ($hadExisting) {
         Move-Item -Path $destExe -Destination $oldExe -Force
     }
-    Copy-Item -Path $exePath -Destination $destExe -Force
+    try {
+        Copy-Item -Path $exePath -Destination $destExe -Force
+    }
+    catch {
+        if ($hadExisting -and (Test-Path $oldExe)) {
+            Move-Item -Path $oldExe -Destination $destExe -Force
+        }
+        throw
+    }
     Remove-Item -Path $oldExe -Force -ErrorAction SilentlyContinue
 
     return $destExe
@@ -173,7 +182,10 @@ function Add-UserPathEntry {
         if (-not $current) { $current = '' }
 
         $entries = $current -split ';' | Where-Object { $_ -ne '' }
-        $alreadyPresent = $entries | Where-Object { $_.TrimEnd('\') -ieq $Directory.TrimEnd('\') }
+        $normalizedDirectory = [Environment]::ExpandEnvironmentVariables($Directory).TrimEnd('\')
+        $alreadyPresent = $entries | Where-Object {
+            [Environment]::ExpandEnvironmentVariables($_).TrimEnd('\') -ieq $normalizedDirectory
+        }
         if ($alreadyPresent) {
             return $false
         }

--- a/install.ps1
+++ b/install.ps1
@@ -126,7 +126,12 @@ function Install-Ghost {
     }
 
     $destExe = Join-Path $Destination 'ghost.exe'
+    $oldExe = "$destExe.old"
+    if (Test-Path $destExe) {
+        Move-Item -Path $destExe -Destination $oldExe -Force
+    }
     Copy-Item -Path $exePath -Destination $destExe -Force
+    Remove-Item -Path $oldExe -Force -ErrorAction SilentlyContinue
 
     return $destExe
 }


### PR DESCRIPTION
## Summary
- Adds `install.ps1` at repo root: detects arch, resolves latest GitHub release, downloads and SHA256-verifies the windows zip, extracts `ghost.exe` into `%LOCALAPPDATA%\ghost\bin` (idempotent, survives a locked/running exe), and adds that directory to the user's persistent PATH via the registry (not `setx`) with a `WM_SETTINGCHANGE` broadcast.
- Distributed via `irm https://raw.githubusercontent.com/wcatz/ghost/main/install.ps1 | iex`; documents the one-liner in README.md.
- Closes #257 (no one-command install) and #258 (no PATH setup as part of install).

Design spec: `docs/superpowers/specs/2026-08-10-windows-installer-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-10-windows-installer.md`

Built task-by-task via subagent-driven-development: fresh implementer per task, spec-compliance review, code-quality review, fix loops. A final full-diff review after all tasks caught two cross-cutting bugs missed by per-task review alone (PATH registry-value expansion corrupting existing `%VAR%` entries, and a `Write-Error`-under-`$ErrorActionPreference='Stop'` issue that made planned exit-code branching unreachable) — both fixed and re-verified.

## Test plan
- [ ] `go vet ./...` and `go test ./...` pass (verified — this branch touches no Go source, only `install.ps1`/docs)
- [ ] Manual end-to-end run on a real Windows machine (no `pwsh` available in this dev environment, so this was static/manual code review only, never executed):
  - [ ] Fresh install via the documented `irm | iex` one-liner; confirm `ghost.exe` resolves in a new terminal
  - [ ] Re-run to confirm upgrade-in-place (including while `ghost` is running as an MCP server, to exercise the locked-exe rename path)
  - [ ] Confirm an existing PATH entry containing an unexpanded `%VAR%` reference survives the PATH update unmangled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-command Windows PowerShell installer for Ghost.
  * Supports x64 and ARM64 systems, secure download verification, and installation without administrator privileges.
  * Automatically adds Ghost to the user PATH and supports repeatable upgrades.
  * Documents Windows installation, configuration, and consistent data directory locations.

* **Documentation**
  * Added detailed Windows installer design, implementation, and verification plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->