### PR TITLE
fix(mcpinit): detect ghost.exe as a registered opencode MCP command

### DIFF
--- a/internal/mcpinit/opencode.go
+++ b/internal/mcpinit/opencode.go
@@ -140,7 +140,9 @@ func mcpGhostCommand(cfg map[string]any) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	return first, filepath.Base(first) == "ghost" && cmd[1] == "mcp"
+	base := strings.ToLower(filepath.Base(first))
+	base = strings.TrimSuffix(base, ".exe")
+	return first, base == "ghost" && cmd[1] == "mcp"
 }
 
 // mcpGhostAlreadyRegistered reports whether the config's mcp.ghost entry uses

--- a/internal/mcpinit/opencode_test.go
+++ b/internal/mcpinit/opencode_test.go
@@ -373,3 +373,21 @@ func TestCheckPrereqs_ClaudeMissing(t *testing.T) {
 		t.Errorf("opencode target should require only ghost: %v", err)
 	}
 }
+
+func TestMCPGhostCommand_ExeSuffix(t *testing.T) {
+	binPath := filepath.Join("C:", "Users", "skinner", "ghost", "bin", "ghost.exe")
+	cfg := map[string]any{
+		"mcp": map[string]any{
+			"ghost": map[string]any{
+				"command": []any{binPath, "mcp"},
+			},
+		},
+	}
+	first, ok := mcpGhostCommand(cfg)
+	if first != binPath {
+		t.Errorf("first = %q, want %q", first, binPath)
+	}
+	if !ok {
+		t.Error("mcpGhostCommand: ok = false, want true for a ghost.exe command with the mcp subcommand — Windows binaries carry a .exe suffix that exact string comparison against \"ghost\" rejects")
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #265: `mcpGhostCommand` compared `filepath.Base(first)` against the literal string `"ghost"`, which never matches `ghost.exe` on Windows. `mcp status --client opencode` always reported ghost as unregistered even when correctly configured, and `mcp init` would re-register on every run instead of detecting it was already present.
- Fix: strip a trailing `.exe` (case-insensitive) before comparing the basename.

## Test plan
- [x] Added `TestMCPGhostCommand_ExeSuffix` — red (fails for the expected reason: `ok = false` on a `ghost.exe` command), then green after the fix.
- [x] `go vet ./...` and `go test ./...` pass.