### PR TITLE
fix(mcpserver): notify embedding worker on ghost_save_global

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -900,6 +900,15 @@ func (s *Server) registerTools() {
 			return nil, nil, fmt.Errorf("save failed: %w", err)
 		}
 		s.notifyResourceUpdated(ctx, "ghost://memories/global")
+
+		// Notify embedding worker of new/updated memory.
+		if s.projectCh != nil {
+			select {
+			case s.projectCh <- "_global":
+			default: // non-blocking
+			}
+		}
+
 		msg := fmt.Sprintf("Global memory saved (id: %s)", id)
 		if duplicateOf != "" {
 			msg = fmt.Sprintf("Global memory saved (id: %s), linked as a likely duplicate of %s (score %.2f)", id, duplicateOf, score)

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -1461,6 +1461,43 @@ func TestDecisionRecordSupersedesArg(t *testing.T) {
 	}
 }
 
+func TestSaveGlobal_NotifiesEmbeddingWorker(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+
+	ch := make(chan string, 4)
+	srv.SetEmbedder(&mockEmbedder{}, ch)
+
+	ctx := context.Background()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	if _, err := srv.mcp.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	if _, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_save_global",
+		Arguments: map[string]any{"content": "global memory should trigger embedding", "category": "fact"},
+	}); err != nil {
+		t.Fatalf("CallTool ghost_save_global: %v", err)
+	}
+
+	select {
+	case got := <-ch:
+		if got != "_global" {
+			t.Errorf("projectCh notified with %q, want %q", got, "_global")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for embedding worker notification on ghost_save_global")
+	}
+}
+
 func TestTruncateUTF8(t *testing.T) {
 	tests := []struct {
 		in       string


### PR DESCRIPTION
## Summary
- Fixes #266: `ghost_save_global` never sent on the embedder notify channel (`projectCh`), so global memories only got vectorized incidentally, when a later save or reflection cycle touched them.
- Added the same non-blocking `projectCh <- "_global"` send that `ghost_memory_save` already does, right after `notifyResourceUpdated`.

## Test plan
- [x] Added `TestSaveGlobal_NotifiesEmbeddingWorker` (red: timed out waiting for notification → green after fix)
- [x] `go vet ./...`
- [x] `go build ./... && go test ./...` pass