### PR TITLE
fix(mcpinit): exit non-zero from mcp status when unhealthy

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -188,17 +188,21 @@ func runMCPStatus() {
 		client = "claude"
 	}
 
+	var healthy bool
 	switch client {
 	case "opencode":
-		err = mcpinit.StatusOpencode(os.Stdout)
+		healthy, err = mcpinit.StatusOpencode(os.Stdout)
 	case "claude":
-		err = mcpinit.Status(os.Stdout)
+		healthy, err = mcpinit.Status(os.Stdout)
 	default:
 		fmt.Fprintf(os.Stderr, "error: unknown client %q (expected claude or opencode)\n", client)
 		os.Exit(1)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if !healthy {
 		os.Exit(1)
 	}
 }

--- a/internal/mcpinit/status.go
+++ b/internal/mcpinit/status.go
@@ -15,8 +15,11 @@ import (
 	"github.com/wcatz/ghost/internal/memory"
 )
 
-// Status checks the health of the Ghost ↔ Claude Code integration.
-func Status(w io.Writer) error {
+// Status checks the health of the Ghost ↔ Claude Code integration. The
+// returned healthy bool reflects whether every check passed; err is reserved
+// for actual failures (I/O, config parse) that prevented the checks from
+// running at all.
+func Status(w io.Writer) (bool, error) {
 	_, _ = fmt.Fprintf(w, "\nGhost ↔ Claude Code integration status:\n\n")
 
 	healthy := true
@@ -121,7 +124,7 @@ func Status(w io.Writer) error {
 	} else {
 		_, _ = fmt.Fprintln(w, "Run `ghost mcp init` to fix issues.")
 	}
-	return nil
+	return healthy, nil
 }
 
 // StatusOpencode checks the health of the Ghost ↔ opencode integration.
@@ -130,7 +133,7 @@ func Status(w io.Writer) error {
 // embedding/link stats. Claude-only checks (hooks, permissions, autoMemory,
 // redirects) are never reported here, so a clean opencode setup prints
 // "All checks passed." without the Claude CLI installed.
-func StatusOpencode(w io.Writer) error {
+func StatusOpencode(w io.Writer) (bool, error) {
 	_, _ = fmt.Fprintf(w, "\nGhost ↔ opencode integration status:\n\n")
 
 	healthy := true
@@ -175,7 +178,7 @@ func StatusOpencode(w io.Writer) error {
 	} else {
 		_, _ = fmt.Fprintln(w, "Run `ghost mcp init --client opencode` to fix issues.")
 	}
-	return nil
+	return healthy, nil
 }
 
 // checkEmbeddingStats reports embedding coverage via the check closure. An

--- a/internal/mcpinit/status_test.go
+++ b/internal/mcpinit/status_test.go
@@ -33,8 +33,12 @@ func TestStatus_ReportsOpenDBFailure(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 
 	var out bytes.Buffer
-	if err := Status(&out); err != nil {
+	healthy, err := Status(&out)
+	if err != nil {
 		t.Fatalf("Status: %v", err)
+	}
+	if healthy {
+		t.Error("Status: healthy = true, want false for a broken database")
 	}
 
 	output := out.String()
@@ -69,8 +73,12 @@ func TestStatus_ReportsInaccessibleDatabase(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(ghostDir, 0o700) }) // let TempDir removal succeed
 
 	var out bytes.Buffer
-	if err := Status(&out); err != nil {
+	healthy, err := Status(&out)
+	if err != nil {
 		t.Fatalf("Status: %v", err)
+	}
+	if healthy {
+		t.Error("Status: healthy = true, want false for an inaccessible database")
 	}
 
 	output := out.String()
@@ -152,8 +160,12 @@ func TestStatusOpencode_GhostMissing(t *testing.T) {
 	writeOpencodeConfigFile(t, os.Getenv("XDG_CONFIG_HOME"), `{"mcp":{"ghost":{"type":"local","command":["ghost","mcp"],"enabled":true}}}`)
 
 	var out bytes.Buffer
-	if err := StatusOpencode(&out); err != nil {
+	healthy, err := StatusOpencode(&out)
+	if err != nil {
 		t.Fatalf("StatusOpencode: %v", err)
+	}
+	if healthy {
+		t.Error("StatusOpencode: healthy = true, want false when the ghost binary is missing")
 	}
 
 	output := out.String()
@@ -175,8 +187,12 @@ func TestStatusOpencode_RegisteredNoDatabase(t *testing.T) {
 	writeOpencodeConfigFile(t, os.Getenv("XDG_CONFIG_HOME"), `{"mcp":{"ghost":{"type":"local","command":["ghost","mcp"],"enabled":true}}}`)
 
 	var out bytes.Buffer
-	if err := StatusOpencode(&out); err != nil {
+	healthy, err := StatusOpencode(&out)
+	if err != nil {
 		t.Fatalf("StatusOpencode: %v", err)
+	}
+	if !healthy {
+		t.Error("StatusOpencode: healthy = false, want true for a clean opencode setup")
 	}
 
 	output := out.String()
@@ -209,8 +225,12 @@ func TestStatusOpencode_MCPConfigNotRegistered(t *testing.T) {
 			writeOpencodeConfigFile(t, os.Getenv("XDG_CONFIG_HOME"), cfg)
 
 			var out bytes.Buffer
-			if err := StatusOpencode(&out); err != nil {
+			healthy, err := StatusOpencode(&out)
+			if err != nil {
 				t.Fatalf("StatusOpencode: %v", err)
+			}
+			if healthy {
+				t.Error("StatusOpencode: healthy = true, want false for a bad mcp.ghost entry")
 			}
 
 			output := out.String()
@@ -256,8 +276,12 @@ func TestStatusOpencode_EmptyStoreHealthy(t *testing.T) {
 	writeOpencodeConfigFile(t, os.Getenv("XDG_CONFIG_HOME"), `{"mcp":{"ghost":{"type":"local","command":["ghost","mcp"],"enabled":true}}}`)
 
 	var out bytes.Buffer
-	if err := StatusOpencode(&out); err != nil {
+	healthy, err := StatusOpencode(&out)
+	if err != nil {
 		t.Fatalf("StatusOpencode: %v", err)
+	}
+	if !healthy {
+		t.Error("StatusOpencode: healthy = false, want true for an empty but valid store")
 	}
 
 	output := out.String()


### PR DESCRIPTION
## Summary
- Fixes #264: `ghost mcp status` (and `--client opencode`) always exited 0, even when checks failed — `Status`/`StatusOpencode` computed a `healthy` bool internally but unconditionally `return nil`.
- Changed both signatures to `(healthy bool, err error)`. `err` stays reserved for actual failures that prevent checks from running (I/O, config parse); `healthy` reflects whether every check passed.
- `runMCPStatus` now reads `healthy` and calls `os.Exit(1)` when false, without printing a redundant error line — the check output already explains what's wrong.

## Test plan
- [x] Updated all `Status`/`StatusOpencode` call sites in `status_test.go` to assert on `healthy` as well as `err`
- [x] `go vet ./...`
- [x] `go build ./... && go test ./...` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP status checks now correctly report an unhealthy integration through the command’s exit status.
  * Status results now clearly distinguish between healthy and unhealthy configurations while preserving existing error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->