### PR TITLE
fix(mcpinit): create config file during mcp init, report it in status

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,21 +158,30 @@ func DataDir() (string, error) {
 	return dir, nil
 }
 
+// ConfigFilePath returns the path to the user config file
+// (~/.config/ghost/config.yaml), without checking whether it exists or
+// creating it.
+func ConfigFilePath() (string, error) {
+	configDir, err := userConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "ghost", "config.yaml"), nil
+}
+
 // EnsureConfigFile creates ~/.config/ghost/config.yaml from the embedded example
 // if it doesn't already exist. Returns the path and whether a new file was created.
 func EnsureConfigFile() (path string, created bool, err error) {
-	configDir, err := userConfigDir()
+	path, err = ConfigFilePath()
 	if err != nil {
 		return "", false, err
 	}
-	dir := filepath.Join(configDir, "ghost")
-	path = filepath.Join(dir, "config.yaml")
 
 	if _, err := os.Stat(path); err == nil {
 		return path, false, nil
 	}
 
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return "", false, err
 	}
 	if err := os.WriteFile(path, exampleConfig, 0o600); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -270,6 +270,22 @@ func TestEnsureConfigFile(t *testing.T) {
 	}
 }
 
+func TestConfigFilePath_DoesNotCreateFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	path, err := ConfigFilePath()
+	if err != nil {
+		t.Fatalf("ConfigFilePath: %v", err)
+	}
+	if want := filepath.Join(tmpDir, "ghost", "config.yaml"); path != want {
+		t.Errorf("ConfigFilePath = %q, want %q", path, want)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("ConfigFilePath must not create the file, stat err = %v", err)
+	}
+}
+
 func TestDataDir_DefaultFallback(t *testing.T) {
 	// Unset XDG_DATA_HOME to test the fallback to ~/.local/share.
 	t.Setenv("XDG_DATA_HOME", "")

--- a/internal/mcpinit/init.go
+++ b/internal/mcpinit/init.go
@@ -17,7 +17,7 @@ import (
 	"github.com/wcatz/ghost/internal/memory"
 )
 
-// Run executes the 8-step Claude Code integration setup.
+// Run executes the 9-step Claude Code integration setup.
 // When dryRun is true, it reports what would change without modifying anything.
 func Run(w io.Writer, dryRun bool) error {
 	if dryRun {
@@ -25,44 +25,50 @@ func Run(w io.Writer, dryRun bool) error {
 	}
 
 	// Step 1: Prerequisites.
-	_, _ = fmt.Fprintln(w, "[1/8] Checking prerequisites...")
+	_, _ = fmt.Fprintln(w, "[1/9] Checking prerequisites...")
 	ghostBin, claudeBin, err := checkPrereqs(w, "claude")
 	if err != nil {
 		return retryHint(err)
 	}
 
-	// Step 2: MCP server registration.
-	_, _ = fmt.Fprintln(w, "\n[2/8] Registering MCP server...")
+	// Step 2: Config file.
+	_, _ = fmt.Fprintln(w, "\n[2/9] Ensuring config file...")
+	if err := ensureConfigBootstrap(w, dryRun); err != nil {
+		return retryHint(err)
+	}
+
+	// Step 3: MCP server registration.
+	_, _ = fmt.Fprintln(w, "\n[3/9] Registering MCP server...")
 	if err := registerMCP(w, ghostBin, claudeBin, dryRun); err != nil {
 		return retryHint(err)
 	}
 
-	// Step 3: Tool permissions.
-	_, _ = fmt.Fprintln(w, "\n[3/8] Adding tool permissions...")
+	// Step 4: Tool permissions.
+	_, _ = fmt.Fprintln(w, "\n[4/9] Adding tool permissions...")
 	settingsFile, err := ensurePermissions(w)
 	if err != nil {
 		return retryHint(err)
 	}
 
-	// Step 4: SessionStart hook.
-	_, _ = fmt.Fprintln(w, "\n[4/8] Configuring SessionStart hook...")
+	// Step 5: SessionStart hook.
+	_, _ = fmt.Fprintln(w, "\n[5/9] Configuring SessionStart hook...")
 	if err := ensureHook(w, settingsFile, ghostBin); err != nil {
 		return retryHint(err)
 	}
 
-	// Step 5: Stop hook.
-	_, _ = fmt.Fprintln(w, "\n[5/8] Configuring Stop hook...")
+	// Step 6: Stop hook.
+	_, _ = fmt.Fprintln(w, "\n[6/9] Configuring Stop hook...")
 	if err := ensureStopHook(w, settingsFile, ghostBin); err != nil {
 		return retryHint(err)
 	}
 
-	// Step 6: Disable Claude Code's built-in file memory.
-	_, _ = fmt.Fprintln(w, "\n[6/8] Disabling Claude Code built-in memory...")
+	// Step 7: Disable Claude Code's built-in file memory.
+	_, _ = fmt.Fprintln(w, "\n[7/9] Disabling Claude Code built-in memory...")
 	if err := ensureAutoMemoryDisabled(w, settingsFile, dryRun); err != nil {
 		return retryHint(err)
 	}
 
-	// Save settings (steps 3-6 all modify it).
+	// Save settings (steps 4-7 all modify it).
 	if dryRun {
 		_, _ = fmt.Fprintln(w, "\n  (skipping settings write — dry run)")
 	} else {
@@ -71,21 +77,50 @@ func Run(w io.Writer, dryRun bool) error {
 		}
 	}
 
-	// Step 7: Import Claude Code memories.
-	_, _ = fmt.Fprintln(w, "\n[7/8] Importing Claude Code memories...")
+	// Step 8: Import Claude Code memories.
+	_, _ = fmt.Fprintln(w, "\n[8/9] Importing Claude Code memories...")
 	projects, err := importMemories(w, dryRun)
 	if err != nil {
 		_, _ = fmt.Fprintf(w, "  ! import error: %v (continuing)\n", err)
 	}
 
-	// Step 8: Project memory redirects.
-	_, _ = fmt.Fprintln(w, "\n[8/8] Writing project memory redirects...")
+	// Step 9: Project memory redirects.
+	_, _ = fmt.Fprintln(w, "\n[9/9] Writing project memory redirects...")
 	writeRedirects(w, projects, dryRun)
 
 	if dryRun {
 		_, _ = fmt.Fprintln(w, "\nNo changes made (dry run).")
 	} else {
 		_, _ = fmt.Fprintln(w, "\nDone! Restart Claude Code to activate.")
+	}
+	return nil
+}
+
+// ensureConfigBootstrap creates the user config file
+// (~/.config/ghost/config.yaml) from the embedded example if it's missing.
+// In dry-run mode it reports what would happen without creating anything.
+func ensureConfigBootstrap(w io.Writer, dryRun bool) error {
+	if dryRun {
+		path, err := config.ConfigFilePath()
+		if err != nil {
+			return fmt.Errorf("config file path: %w", err)
+		}
+		if _, err := os.Stat(path); err == nil {
+			_, _ = fmt.Fprintf(w, "  ✓ config file exists: %s\n", path)
+		} else {
+			_, _ = fmt.Fprintf(w, "  ~ would create config file: %s\n", path)
+		}
+		return nil
+	}
+
+	path, created, err := config.EnsureConfigFile()
+	if err != nil {
+		return fmt.Errorf("ensure config file: %w", err)
+	}
+	if created {
+		_, _ = fmt.Fprintf(w, "  + created config file: %s\n", path)
+	} else {
+		_, _ = fmt.Fprintf(w, "  ✓ config file exists: %s\n", path)
 	}
 	return nil
 }

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -254,6 +254,59 @@ func TestEnsureAutoMemoryDisabled_DryRun(t *testing.T) {
 	}
 }
 
+func TestEnsureConfigBootstrap_CreatesFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	var out bytes.Buffer
+	if err := ensureConfigBootstrap(&out, false); err != nil {
+		t.Fatalf("ensureConfigBootstrap: %v", err)
+	}
+
+	path := filepath.Join(tmpDir, "ghost", "config.yaml")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected config file to be created: %v", err)
+	}
+	if !strings.Contains(out.String(), "created config file") {
+		t.Errorf("expected 'created config file' in output, got: %s", out.String())
+	}
+}
+
+func TestEnsureConfigBootstrap_Idempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	var out bytes.Buffer
+	if err := ensureConfigBootstrap(&out, false); err != nil {
+		t.Fatalf("ensureConfigBootstrap (1st): %v", err)
+	}
+	out.Reset()
+	if err := ensureConfigBootstrap(&out, false); err != nil {
+		t.Fatalf("ensureConfigBootstrap (2nd): %v", err)
+	}
+	if !strings.Contains(out.String(), "config file exists") {
+		t.Errorf("expected 'config file exists' in output, got: %s", out.String())
+	}
+}
+
+func TestEnsureConfigBootstrap_DryRunDoesNotCreate(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	var out bytes.Buffer
+	if err := ensureConfigBootstrap(&out, true); err != nil {
+		t.Fatalf("ensureConfigBootstrap dry run: %v", err)
+	}
+
+	path := filepath.Join(tmpDir, "ghost", "config.yaml")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("dry run must not create the config file, stat err = %v", err)
+	}
+	if !strings.Contains(out.String(), "would create config file") {
+		t.Errorf("expected 'would create config file' in output, got: %s", out.String())
+	}
+}
+
 func TestRetryHint(t *testing.T) {
 	err := retryHint(fmt.Errorf("something broke"))
 	msg := err.Error()

--- a/internal/mcpinit/opencode.go
+++ b/internal/mcpinit/opencode.go
@@ -25,14 +25,20 @@ func RunOpencode(w io.Writer, dryRun bool) error {
 	}
 
 	// Step 1: Prerequisites — only the ghost binary is required.
-	_, _ = fmt.Fprintln(w, "[1/2] Checking prerequisites...")
+	_, _ = fmt.Fprintln(w, "[1/3] Checking prerequisites...")
 	ghostBin, _, err := checkPrereqs(w, "opencode")
 	if err != nil {
 		return retryHint(err)
 	}
 
-	// Step 2: MCP server registration.
-	_, _ = fmt.Fprintln(w, "\n[2/2] Registering MCP server...")
+	// Step 2: Config file.
+	_, _ = fmt.Fprintln(w, "\n[2/3] Ensuring config file...")
+	if err := ensureConfigBootstrap(w, dryRun); err != nil {
+		return retryHint(err)
+	}
+
+	// Step 3: MCP server registration.
+	_, _ = fmt.Fprintln(w, "\n[3/3] Registering MCP server...")
 	changed, err := registerOpencodeMCP(w, ghostBin, dryRun)
 	if err != nil {
 		return retryHint(err)
@@ -43,7 +49,7 @@ func RunOpencode(w io.Writer, dryRun bool) error {
 		verifyOpencodeRegistration(w)
 	}
 
-	// Step 3: Ollama embedding model.
+	// Step 4: Ollama embedding model.
 	cfg, err := config.Load()
 	if err != nil {
 		_, _ = fmt.Fprintf(w, "  ! load config: %v\n", err)

--- a/internal/mcpinit/status.go
+++ b/internal/mcpinit/status.go
@@ -41,6 +41,8 @@ func Status(w io.Writer) error {
 		fmt.Sprintf("claude CLI: %s", claudeBin),
 		"claude CLI not found in PATH")
 
+	reportConfigFile(w)
+
 	// 3. MCP server registration.
 	if claudeBin != "" {
 		out, err := exec.Command(claudeBin, "mcp", "get", "ghost").CombinedOutput()
@@ -149,6 +151,8 @@ func StatusOpencode(w io.Writer) error {
 		fmt.Sprintf("ghost binary: %s", ghostBin),
 		"ghost binary not found in PATH")
 
+	reportConfigFile(w)
+
 	// 2. opencode MCP config.
 	path, err := opencodeConfigPath()
 	if err != nil {
@@ -176,6 +180,23 @@ func StatusOpencode(w io.Writer) error {
 		_, _ = fmt.Fprintln(w, "Run `ghost mcp init --client opencode` to fix issues.")
 	}
 	return nil
+}
+
+// reportConfigFile prints the user config file's location informationally.
+// It never fails the health check — the config file is optional, since
+// compiled defaults work without one — so it deliberately doesn't take a
+// check closure.
+func reportConfigFile(w io.Writer) {
+	path, err := config.ConfigFilePath()
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "  ! config file: %v\n", err)
+		return
+	}
+	if _, err := os.Stat(path); err == nil {
+		_, _ = fmt.Fprintf(w, "  - config file: %s\n", path)
+	} else {
+		_, _ = fmt.Fprintf(w, "  - no config file (run ghost mcp init)\n")
+	}
 }
 
 // checkEmbeddingStats reports embedding coverage via the check closure. An

--- a/internal/mcpinit/status_test.go
+++ b/internal/mcpinit/status_test.go
@@ -272,6 +272,34 @@ func TestStatusOpencode_EmptyStoreHealthy(t *testing.T) {
 	}
 }
 
+// TestReportConfigFile_Missing verifies the config file is reported
+// informationally when absent, without failing the check (the config file is
+// optional — defaults work without one).
+func TestReportConfigFile_Missing(t *testing.T) {
+	statusEnv(t)
+
+	var out bytes.Buffer
+	reportConfigFile(&out)
+
+	if !strings.Contains(out.String(), "no config file") {
+		t.Errorf("expected 'no config file' in output, got: %s", out.String())
+	}
+}
+
+// TestReportConfigFile_Present verifies the config file's path is reported
+// when it exists.
+func TestReportConfigFile_Present(t *testing.T) {
+	statusEnv(t)
+	path := writeGhostConfigFile(t, "")
+
+	var out bytes.Buffer
+	reportConfigFile(&out)
+
+	if !strings.Contains(out.String(), path) {
+		t.Errorf("expected config file path %q in output, got: %s", path, out.String())
+	}
+}
+
 // TestCheckEmbeddingStats pins the embedding-stats classification: an empty
 // store passes with "(store empty)", a populated store passes only when some
 // memories are embedded, and a populated store with zero embeddings fails.


### PR DESCRIPTION
## Summary
- Fixes #263: `ghost mcp status`/`mcp init` never created `~/.config/ghost/config.yaml`, so users had no discoverable place to edit config (e.g. to point Ollama at a non-default URL).
- Added `config.ConfigFilePath()` (path only, no side effects) and refactored `EnsureConfigFile()` to use it.
- Both `Run()` (Claude flow) and `RunOpencode()` now bootstrap the config file as a new step. `--dry-run` reports what would happen without creating anything.
- `mcp status`/`mcp status --client opencode` report the config file's presence informationally — it's optional (compiled defaults work without one), so this never flips the `healthy` verdict.

## Test plan
- [x] `go test ./internal/config/...` — new `TestConfigFilePath_DoesNotCreateFile`
- [x] `go test ./internal/mcpinit/...` — new tests for `ensureConfigBootstrap` (create/idempotent/dry-run) and `reportConfigFile` (missing/present)
- [x] `go vet ./...` && `go test ./...` — full suite, no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically creates the user configuration file during setup when needed.
  * Supports dry-run setup previews without making filesystem changes.
  * Displays the configured file path and clearly indicates when it is missing or unreadable.

* **Bug Fixes**
  * Setup can be safely repeated without recreating existing configuration files.
  * Configuration status reporting no longer affects overall health status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->