### PR TITLE
fix(mcpinit): match SessionStart hook by fragment, not literal ghost path

### DIFF
--- a/internal/mcpinit/status.go
+++ b/internal/mcpinit/status.go
@@ -75,7 +75,7 @@ func Status(w io.Writer) (bool, error) {
 				fmt.Sprintf("permissions: %d/%d (run ghost mcp init)", present, len(ghostPermissions)))
 
 			// Hook.
-			hasHk := sf.hasHook("SessionStart", "ghost hook session-start")
+			hasHk := sf.hasHook("SessionStart", "hook session-start")
 			check(hasHk, "SessionStart hook configured", "SessionStart hook missing")
 
 			hasStop := sf.hasHook("Stop", "hook stop")

--- a/internal/mcpinit/status_test.go
+++ b/internal/mcpinit/status_test.go
@@ -50,6 +50,44 @@ func TestStatus_ReportsOpenDBFailure(t *testing.T) {
 	}
 }
 
+// TestStatus_HookMatchWithQuotedPath verifies that a SessionStart hook whose
+// command is a quoted binary path (the form `ghost mcp init` writes on
+// Windows, e.g. `"C:\Users\ghost\bin\ghost.exe" hook session-start`) is
+// recognized as configured. Before this fix, Status checked for the literal
+// substring "ghost hook session-start", which never appears once the binary
+// path is quoted — so a fully healthy install was reported as missing the
+// hook on every platform where ghostBin isn't literally "ghost".
+func TestStatus_HookMatchWithQuotedPath(t *testing.T) {
+	statusEnv(t)
+	home := os.Getenv("HOME")
+	settingsDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o700); err != nil {
+		t.Fatalf("mkdir settings dir: %v", err)
+	}
+	settings := `{
+  "hooks": {
+    "SessionStart": [{"matcher": "", "hooks": [{"type": "command", "command": "\"/opt/ghost/bin/ghost\" hook session-start"}]}],
+    "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "\"/opt/ghost/bin/ghost\" hook stop"}]}]
+  }
+}`
+	if err := os.WriteFile(filepath.Join(settingsDir, "settings.json"), []byte(settings), 0o600); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+
+	var out bytes.Buffer
+	if _, err := Status(&out); err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "✓ SessionStart hook configured") {
+		t.Errorf("expected SessionStart hook to be recognized as configured, got:\n%s", output)
+	}
+	if strings.Contains(output, "✗ SessionStart hook missing") {
+		t.Errorf("a quoted-path hook command must not be reported missing, got:\n%s", output)
+	}
+}
+
 // TestStatus_ReportsInaccessibleDatabase verifies that a database which cannot
 // be stat'd for a reason other than absence (e.g. a permission error) is
 // surfaced as a failed check instead of being reported as a fresh install.


### PR DESCRIPTION
## Summary
- `mcp status` checked for the literal substring `"ghost hook session-start"`, but `ghost mcp init` writes the hook command as a quoted binary path (e.g. `"/opt/ghost/bin/ghost" hook session-start`, or a quoted `ghost.exe` path on Windows) — that substring never appears once the path is quoted.
- Result: a fully healthy install reports `✗ SessionStart hook missing` on every platform where the resolved ghost binary path isn't literally `ghost`. The Stop hook check already used the correct short fragment (`"hook stop"`) and was unaffected.
- Fix matches on `"hook session-start"`, mirroring the fragment `reconcileHook` already uses during `mcp init`.

Fixes #262, fixes #272

## Test plan
- [x] Added `TestStatus_HookMatchWithQuotedPath`, reproduced the bug (test failed against unpatched code), confirmed it passes after the fix
- [x] `go test ./internal/mcpinit/...` passes
- [x] `go vet ./...` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of configured session-start hooks.
  * Correctly recognizes hooks that use quoted executable paths, preventing incorrect missing-permission warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->