### PR TITLE
Merge upstream + resolve conflicts

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": true,
+  "plugin": [
+    "superpowers@git+https://github.com/obra/superpowers.git"
+  ]
+}

--- a/docs/superpowers/plans/2026-08-09-utm-windows-vm.md
+++ b/docs/superpowers/plans/2026-08-09-utm-windows-vm.md
@@ -1,0 +1,418 @@
+# UTM-Native Windows 11 VM for Headless Agent Testing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the slow TCG-based Windows 11 ARM64 test VM with a UTM-native, HVF-accelerated, headless-only VM that reuses the existing installed disk and exposes SSH on host port 2222.
+
+**Architecture:** A new UTM bundle (`ghost-win11-utm.utm`) whose `config.plist` is the source of truth (HVF accel, NVMe disk, virtio-net, hostfwd 2222/3389). The VM is launched headlessly with brew QEMU using `-accel hvf`, operated via the same HMP monitor + screendump + OCR workflow used for the TCG VM. `answer.iso` stays attached to supply NetKVM/guest tools if the virtio NIC did not enumerate.
+
+**Tech Stack:** brew QEMU 11.0.3 (`qemu-system-aarch64`), UTM 4.7.5 bundle format (plist), Hypervisor.framework (HVF), Swift Vision OCR helper `/tmp/ocr.swift`, HMP unix-socket monitor.
+
+## Global Constraints
+
+- Host: Apple M1, macOS 26.6.1; shell is zsh; remote work via SSH (`wayne@notty`).
+- MUST reuse existing installed disk `/Users/wayne/vms/ghost-win11.utm/Data/win11.qcow2` (Windows 11 25H2 ARM64, `ghost`/`GhostTest!2026`, desktop reached, OpenSSH Server install interrupted mid-DISM).
+- Disk interface MUST be `NVMe` (installed Windows bound inbox `stornvme`; VirtIO interface will not boot).
+- Acceleration MUST be `-accel hvf -cpu max` — do NOT carry `pauth-impdef=on` (TCG-only; errors under HVF).
+- The VM is headless-only, forever — never launched as a desktop window.
+- `answer.iso` stays attached (NetKVM + utm-guest-tools fallback); the Windows install ISO is detached.
+- macOS file-lock rule: any attached `.dmg`/disk image must be `hdiutil detach`ed before QEMU launch.
+- Port forwards: host `2222` → guest 22 (SSH), host `3389` → guest 3389 (RDP).
+- All VM-side commands typed via HMP `sendkey` using `/tmp/type.sh`; screens via `screendump` + `sips` + `swift /tmp/ocr.swift`.
+
+---
+
+### Task 1: Shut down the TCG VM cleanly
+
+**Files:**
+- None created/modified (ops-only).
+
+**Interfaces:**
+- Consumes: running QEMU TCG VM, HMP socket `/tmp/w11tcg-mon.sock`.
+- Produces: an unlocked, consistent `win11.qcow2`; freed host resources.
+
+- [ ] **Step 1: Confirm the TCG VM is still alive**
+
+Run: `ps -o pid,etime,%cpu,stat -p 50552`
+Expected: a running `qemu-system-aarch64` process. If the pid is gone, skip the remaining steps (VM already down).
+
+- [ ] **Step 2: Send ACPI powerdown and wait for exit**
+
+```bash
+(printf 'system_powerdown\n'; sleep 2) | nc -U /tmp/w11tcg-mon.sock >/dev/null 2>&1
+for i in $(seq 1 30); do ps -p 50552 >/dev/null 2>&1 || break; sleep 5; done
+ps -p 50552 >/dev/null 2>&1 && echo "STILL RUNNING" || echo "VM EXITED"
+```
+Expected: `VM EXITED` within ~150 s. If still running after the loop, force `quit` on the monitor and re-check.
+
+- [ ] **Step 3: Verify the qcow2 is not locked and note its size**
+
+Run: `ls -la /Users/wayne/vms/ghost-win11.utm/Data/win11.qcow2`
+Expected: file present, size ≈ 19 GB (19244253184 bytes), no QEMU process holding it.
+
+- [ ] **Step 4: Commit (documentation placeholder)**
+
+```bash
+cd /Users/wayne/git/ghost && git add -A && git commit -q -m "ops: shut down TCG Windows VM" 2>/dev/null || echo "nothing to commit"
+```
+Expected: commit succeeds or reports nothing to commit (acceptable — this is an ops task).
+
+---
+
+### Task 2: Create the UTM-native bundle
+
+**Files:**
+- Create: `/Users/wayne/vms/ghost-win11-utm.utm/config.plist`
+- Create: `/Users/wayne/vms/ghost-win11-utm.utm/Data/` (directory; qcow2 lives in the ORIGINAL bundle — do not move it)
+
+**Interfaces:**
+- Consumes: existing qcow2 at `/Users/wayne/vms/ghost-win11.utm/Data/win11.qcow2`; `answer.iso` at `/Users/wayne/vms/qemu-win11/answer.iso`.
+- Produces: `config.plist` describing an HVF/NVMe/headless-compatible VM (used directly by Task 3's launch; the plist documents the exact topology).
+
+- [ ] **Step 1: Create the bundle directories**
+
+```bash
+mkdir -p /Users/wayne/vms/ghost-win11-utm.utm/Data
+ls -la /Users/wayne/vms/ghost-win11-utm.utm
+```
+Expected: directory tree exists.
+
+- [ ] **Step 2: Write the config.plist**
+
+Write `/Users/wayne/vms/ghost-win11-utm.utm/config.plist` with this exact content (UUIDs below are new; replace if colliding):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Backend</key>
+	<string>QEMU</string>
+	<key>ConfigurationVersion</key>
+	<integer>4</integer>
+	<key>Information</key>
+	<dict>
+		<key>Name</key>
+		<string>ghost-win11-utm</string>
+		<key>Icon</key>
+		<string>windows-11</string>
+		<key>IconCustom</key>
+		<false/>
+		<key>Notes</key>
+		<string>Windows 11 25H2 ARM64, HVF accel, NVMe, headless agent-test VM</string>
+		<key>UUID</key>
+		<string>8F3A6D14-1C9E-4A71-9D4B-2E77C5A9F0A1</string>
+	</dict>
+	<key>System</key>
+	<dict>
+		<key>Architecture</key>
+		<string>aarch64</string>
+		<key>CPU</key>
+		<string>max</string>
+		<key>CPUCount</key>
+		<integer>8</integer>
+		<key>CPUFlagsAdd</key>
+		<array/>
+		<key>CPUFlagsRemove</key>
+		<array/>
+		<key>ForceMulticore</key>
+		<true/>
+		<key>JITCacheSize</key>
+		<integer>0</integer>
+		<key>MemorySize</key>
+		<integer>8192</integer>
+		<key>Target</key>
+		<string>virt</string>
+	</dict>
+	<key>QEMU</key>
+	<dict>
+		<key>AdditionalArguments</key>
+		<array/>
+		<key>BalloonDevice</key>
+		<false/>
+		<key>DebugLog</key>
+		<false/>
+		<key>Hypervisor</key>
+		<true/>
+		<key>PS2Controller</key>
+		<false/>
+		<key>RNGDevice</key>
+		<true/>
+		<key>RTCLocalTime</key>
+		<true/>
+		<key>TPMDevice</key>
+		<false/>
+		<key>UEFIBoot</key>
+		<true/>
+	</dict>
+	<key>Input</key>
+	<dict>
+		<key>MaximumUsbShare</key>
+		<integer>3</integer>
+		<key>UsbBusSupport</key>
+		<string>3.0</string>
+		<key>UsbSharing</key>
+		<false/>
+	</dict>
+	<key>Sharing</key>
+	<dict>
+		<key>ClipboardSharing</key>
+		<false/>
+		<key>DirectoryShareMode</key>
+		<string>None</string>
+		<key>DirectoryShareReadOnly</key>
+		<false/>
+	</dict>
+	<key>Display</key>
+	<array>
+		<dict>
+			<key>DynamicResolution</key>
+			<false/>
+			<key>DownscalingFilter</key>
+			<string>Linear</string>
+			<key>Hardware</key>
+			<string>virtio-ramfb</string>
+			<key>NativeResolution</key>
+			<false/>
+			<key>UpscalingFilter</key>
+			<string>Nearest</string>
+		</dict>
+	</array>
+	<key>Drive</key>
+	<array>
+		<dict>
+			<key>ImageName</key>
+			<string>win11.qcow2</string>
+			<key>ImageType</key>
+			<string>Disk</string>
+			<key>Interface</key>
+			<string>NVMe</string>
+			<key>InterfaceVersion</key>
+			<integer>1</integer>
+			<key>Identifier</key>
+			<string>B1B4C0DE-0000-4000-8000-000000000001</string>
+			<key>ReadOnly</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>ImageName</key>
+			<string>answer.iso</string>
+			<key>ImageType</key>
+			<string>CD</string>
+			<key>Interface</key>
+			<string>USB</string>
+			<key>InterfaceVersion</key>
+			<integer>1</integer>
+			<key>Identifier</key>
+			<string>B1B4C0DE-0000-4000-8000-000000000002</string>
+			<key>ReadOnly</key>
+			<true/>
+		</dict>
+	</array>
+	<key>Network</key>
+	<array>
+		<dict>
+			<key>Hardware</key>
+			<string>virtio-net-pci</string>
+			<key>IsolateFromHost</key>
+			<false/>
+			<key>MacAddress</key>
+			<string>b6:7a:90:ef:99:c1</string>
+			<key>Mode</key>
+			<string>Emulated</string>
+			<key>PortForward</key>
+			<array>
+				<dict>
+					<key>GuestPort</key>
+					<integer>22</integer>
+					<key>HostPort</key>
+					<integer>2222</integer>
+					<key>Protocol</key>
+					<string>TCP</string>
+				</dict>
+				<dict>
+					<key>GuestPort</key>
+					<integer>3389</integer>
+					<key>HostPort</key>
+					<integer>3389</integer>
+					<key>Protocol</key>
+					<string>TCP</string>
+				</dict>
+			</array>
+		</dict>
+	</array>
+	<key>Serial</key>
+	<array/>
+	<key>Sound</key>
+	<array/>
+</dict>
+</plist>
+```
+
+- [ ] **Step 3: Validate the plist parses**
+
+Run: `plutil -lint /Users/wayne/vms/ghost-win11-utm.utm/config.plist`
+Expected: `OK`. If it reports a missing file reference note, that is expected — the qcow2 lives in the original bundle and QEMU will be pointed at it explicitly in Task 3.
+
+- [ ] **Step 4: Copy answer.iso into the new bundle's Data dir**
+
+```bash
+cp /Users/wayne/vms/qemu-win11/answer.iso /Users/wayne/vms/ghost-win11-utm.utm/Data/answer.iso
+ls -la /Users/wayne/vms/ghost-win11-utm.utm/Data/
+```
+Expected: `answer.iso` present (82,276,352 bytes). (Keep the original copy too — the launch command will reference the bundle copy.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/wayne/git/ghost && git add -A && git commit -q -m "chore: scaffold UTM-native ghost-win11-utm bundle" 2>/dev/null || echo "nothing to commit"
+```
+
+---
+
+### Task 3: Launch the VM headless with HVF
+
+**Files:**
+- None created/modified in the repo (ops-only). Logs land in `/tmp/w11utm/`.
+
+**Interfaces:**
+- Consumes: `config.plist` topology from Task 2; qcow2; `answer.iso` bundle copy.
+- Produces: running HVF VM with HMP socket `/tmp/w11utm-mon.sock`; serial log `/tmp/w11utm-serial.log`.
+
+- [ ] **Step 1: Ensure no stale sockets/processes**
+
+```bash
+rm -f /tmp/w11utm-mon.sock /tmp/w11utm-serial.log
+mkdir -p /tmp/w11utm
+lsof /Users/wayne/vms/ghost-win11.utm/Data/win11.qcow2 2>/dev/null | grep qemu || echo "disk not locked"
+```
+Expected: `disk not locked` (Task 1 shut the TCG VM down).
+
+- [ ] **Step 2: Launch the VM**
+
+```bash
+cd /tmp/w11utm && nohup /opt/homebrew/bin/qemu-system-aarch64 \
+  -machine virt -m 8G -cpu max -smp 8 \
+  -accel hvf \
+  -bios /opt/homebrew/share/qemu/edk2-aarch64-code.fd \
+  -device ramfb \
+  -device qemu-xhci,id=usb1 -device usb-kbd,bus=usb1.0 -device usb-tablet,bus=usb1.0 \
+  -device qemu-xhci,id=usb2 \
+  -device usb-storage,drive=answer,bus=usb2.0 \
+  -drive if=none,id=answer,format=raw,media=cdrom,file=/Users/wayne/vms/ghost-win11-utm.utm/Data/answer.iso \
+  -device nvme,drive=system,serial=system,bootindex=0 \
+  -drive if=none,id=system,format=qcow2,file=/Users/wayne/vms/ghost-win11.utm/Data/win11.qcow2 \
+  -nic user,model=virtio-net-pci,hostfwd=tcp::2222-:22,hostfwd=tcp::3389-:3389 \
+  -monitor unix:/tmp/w11utm-mon.sock,server,nowait \
+  -serial file:/tmp/w11utm-serial.log \
+  -display none > /tmp/w11utm/stdout.log 2>&1 &
+echo "launched pid $!"; sleep 8; ps aux | grep qemu-system-aarch64 | grep -v grep | awk '{print $2, $3"%"}'
+```
+Expected: a qemu pid with high CPU% (HVF shows multiple vCPU threads).
+
+- [ ] **Step 3: Verify the monitor socket responds**
+
+Run: `(printf 'info block\n'; sleep 2) | nc -U /tmp/w11utm-mon.sock | grep -E "system|answer"`
+Expected: both `system` (qcow2) and `answer` (cdrom) block devices listed.
+
+- [ ] **Step 4: Verify the guest boots to Windows**
+
+```bash
+sleep 60
+(printf 'screendump /tmp/w11utm-boot.ppm\n'; sleep 4) | nc -U /tmp/w11utm-mon.sock >/dev/null 2>&1
+sips -s format png /tmp/w11utm-boot.ppm --out /tmp/w11utm-boot.png >/dev/null 2>&1
+swift /tmp/ocr.swift /tmp/w11utm-boot.png 2>/dev/null
+```
+Expected: OCR shows the Windows desktop or the "Good things coming your way" first-boot screen — NOT the EFI shell. If the EFI shell appears, the bootindex/NVMe topology is wrong; stop and revisit Task 2 before proceeding.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/wayne/git/ghost && git add -A && git commit -q -m "ops: launch UTM-native HVF Windows VM headless" 2>/dev/null || echo "nothing to commit"
+```
+
+---
+
+### Task 4: Finish the OpenSSH Server install and verify networking
+
+**Files:**
+- None in the repo (ops-only; guest-side changes live in the VM disk).
+
+**Interfaces:**
+- Consumes: VM from Task 3 at HMP socket `/tmp/w11utm-mon.sock`; `answer.iso` NetKVM fallback driver.
+- Produces: working `sshd` in the guest on port 22, reachable at `localhost:2222`.
+
+- [ ] **Step 1: Confirm the FirstLogon PowerShell is done or absent**
+
+```bash
+(printf 'screendump /tmp/w11utm-p1.ppm\n'; sleep 4) | nc -U /tmp/w11utm-mon.sock >/dev/null 2>&1
+sips -s format png /tmp/w11utm-p1.ppm --out /tmp/w11utm-p1.png >/dev/null 2>&1
+swift /tmp/ocr.swift /tmp/w11utm-p1.png 2>/dev/null
+```
+Expected: desktop, or a PowerShell window. If the PowerShell "Operation Running" window is present, wait (poll every 60 s) until it closes — under HVF it completes in minutes, not the hour TCG took.
+
+- [ ] **Step 2: Test SSH from the host**
+
+Run: `ssh -o StrictHostKeyChecking=no -o ConnectTimeout=12 -o BatchMode=yes ghost@localhost -p 2222 'echo SSH_OK; whoami'`
+Expected: `SSH_OK` + `ghost`. If "banner exchange" timeout persists, proceed to Step 3.
+
+- [ ] **Step 3 (fallback): Install OpenSSH via the guest's admin console**
+
+If SSH is not yet up, open an admin PowerShell in the guest via HMP (Win key via `sendkey meta_l` then type `powershell`, `ctrl-shift-enter`, `alt-y` on the UAC prompt — reuse the `/tmp/type.sh` helper), then run:
+
+```
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Set-Service sshd -StartupType Automatic
+Start-Service sshd
+New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+```
+
+- [ ] **Step 4 (fallback): Verify/enable virtio-net**
+
+If sshd is running but `localhost:2222` still won't connect, the virtio-net NIC may not have enumerated. From the guest admin console install NetKVM from the attached `answer.iso`:
+
+```powershell
+pnputil /add-driver D:\drivers\NetKVM\netkvm.inf /install
+```
+(Confirm the CD drive letter with `Get-Volume`; it may not be `D:`.) Then re-test Step 2.
+
+- [ ] **Step 5: Confirm ghost mcp init prerequisites**
+
+Run: `ssh -o StrictHostKeyChecking=no ghost@localhost -p 2222 'powershell -Command "Get-Service sshd | Select Status; Get-NetFirewallRule -Name sshd | Select Enabled" 2>&1'`
+Expected: sshd `Running`, firewall rule `True`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/wayne/git/ghost && git add -A && git commit -q -m "ops: OpenSSH Server online in UTM Windows VM" 2>/dev/null || echo "nothing to commit"
+```
+
+---
+
+### Task 5: Confirm end-to-end ghost access
+
+**Files:**
+- None in the repo (verification only).
+
+**Interfaces:**
+- Consumes: SSH at `ghost@localhost:2222` from Task 4.
+- Produces: confirmation that the original testing goal (run ghost inside Windows) is reachable.
+
+- [ ] **Step 1: SSH banner and ghost binary check**
+
+Run:
+```bash
+ssh -o StrictHostKeyChecking=no ghost@localhost -p 2222 'echo SSH_OK; whoami; where ghost 2>NUL || echo NO_GHOST'
+```
+Expected: `SSH_OK`, `ghost`, and either a path or `NO_GHOST` (ghost binary is out of scope for this plan; the VM being reachable is the deliverable).
+
+- [ ] **Step 2: Leave the VM running and note how to manage it**
+
+Run: `ps -o pid,etime,%cpu -C qemu-system-aarch64 | head -3`
+Expected: pid line. Record for handoff: HMP socket `/tmp/w11utm-mon.sock`; stop via `(printf 'system_powerdown\n'; sleep 2) | nc -U /tmp/w11utm-mon.sock`.
+
+- [ ] **Step 3: Commit final state**
+
+```bash
+cd /Users/wayne/git/ghost && git add -A && git commit -q -m "docs: UTM Windows VM verified reachable over SSH" 2>/dev/null || echo "nothing to commit"
+```

--- a/docs/superpowers/plans/2026-08-10-seamless-windows-install.md
+++ b/docs/superpowers/plans/2026-08-10-seamless-windows-install.md
@@ -1,0 +1,390 @@
+# Seamless Ghost Install into Windows VM Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy ghost.exe + opencode.exe into the Windows 11 ARM64 guest (HVF, reachable via `ssh ghost@localhost:2222`), wire ghost as an MCP server for opencode via `ghost mcp init --client opencode`, point in-guest ghost at host Ollama for embeddings, verify end-to-end, and file a `wcatz/ghost` GitHub issue for every manual/friction step.
+
+**Architecture:** Host cross-compiles `ghost.exe` (`GOOS=windows GOARCH=arm64`) and downloads the `opencode-windows-arm64.zip` release; both are scp'd into the guest to `C:\Users\ghost\bin\` and added to PATH via `setx`. `ghost mcp init --client opencode` deep-merges the `mcp.ghost` stdio entry into opencode's config. Guest `config.yaml` sets `embedding.ollama_url: http://10.0.2.2:11434` (QEMU user-net gateway → host loopback Ollama) for full hybrid search.
+
+**Tech Stack:** Go (cross-compile), GitHub CLI (`gh`), QEMU HMP + screendump/OCR, expect (password SSH/SCP — this VM is password-auth only), Windows PowerShell/cmd (guest), GitHub issues (`gh issue create`).
+
+## Global Constraints
+
+- SSH/SCP into the guest is PASSWORD auth only (no keys): user `ghost`, password `GhostTest!2026`. `BatchMode=yes` and non-interactive SSH will FAIL — all host→guest operations MUST use expect wrappers.
+- The guest's default remote shell is `cmd.exe`: use `&` as the command separator (NOT `;`), `2>NUL` for stderr suppression, `%VAR%` for env expansion.
+- `system_powerdown` does NOT stop this VM (ACPI not honored) — never use it. VM must stay RUNNING for every task.
+- `git add -A` sweeps `.opencode/` — use `git add -u` only, from `/Users/wayne/git/ghost`.
+- Every task ends with the seamless-install gate: ANY manual/friction step encountered → `gh issue create` on `wcatz/ghost` with labels (use `windows`; add `mcp-init` if scoped there). Known-friction list: no one-command Windows install (manual binary transfer), manual `setx` PATH surgery, hand-editing `config.yaml` for Ollama gateway, any `ghost mcp init` failure.
+- No repo code changes expected — this is deployment. Do not edit Go source.
+- Guest data dir (fresh, independent): `C:\Users\ghost\.local\share\ghost`.
+
+## Task 1: Stage artifacts on the host
+
+**Files:**
+- None in the repo. Staging dir `/tmp/win-deploy/` on the host.
+
+**Interfaces:**
+- Consumes: `gh` (authenticated as waltskinner → wcatz/ghost); Go 1.26 toolchain.
+- Produces: `/tmp/win-deploy/ghost.exe` (windows/arm64), `/tmp/win-deploy/opencode.exe` (from release v1.18.16), both verified. Task 2 scp's these.
+
+- [ ] **Step 1: Build ghost.exe for Windows/ARM64**
+
+```bash
+mkdir -p /tmp/win-deploy
+cd /Users/wayne/git/ghost
+GOOS=windows GOARCH=arm64 go build -o /tmp/win-deploy/ghost.exe ./cmd/ghost
+```
+
+- [ ] **Step 2: Verify the ghost.exe artifact**
+
+Run: `file /tmp/win-deploy/ghost.exe`
+Expected: `PE32+ executable (console) Aarch64, for MS Windows`
+
+- [ ] **Step 3: Download and extract the opencode Windows ARM64 release binary**
+
+```bash
+cd /tmp/win-deploy
+gh release download v1.18.16 --repo anomalyco/opencode --pattern "opencode-windows-arm64.zip" --dir /tmp/win-deploy
+unzip -o opencode-windows-arm64.zip
+```
+
+- [ ] **Step 4: Verify the opencode.exe artifact**
+
+Run: `ls -la /tmp/win-deploy/opencode.exe`
+Expected: single `opencode.exe` (~174 MB uncompressed) present.
+
+- [ ] **Step 5: Confirm the guest VM is still running**
+
+Run: `ps -o pid,etime,stat -p 58827`
+Expected: alive, STAT `S`/`N`. If not running, STOP and report BLOCKED (do not relaunch; the relaunch helper `/tmp/w11utm/relaunch.sh` exists but rebooting invalidates earlier task state).
+
+- [ ] **Step 6: Seamless-install gate + commit**
+
+If any step above needed manual invention beyond the exact commands given, file an issue (see the `gh issue create` format in Task 6 Step 5). Then:
+```bash
+cd /Users/wayne/git/ghost && git add -u && git commit -q -m "chore: stage windows deploy artifacts" 2>/dev/null || echo "no commit (clean tree)"
+```
+Expected: no commit (nothing staged — staging dir is in /tmp).
+
+## Task 2: Transfer binaries into the guest
+
+**Files:**
+- None in the repo.
+- Host staging: `/tmp/win-deploy/ghost.exe`, `/tmp/win-deploy/opencode.exe` (from Task 1).
+- Guest target: `C:\Users\ghost\bin\`.
+
+**Interfaces:**
+- Consumes: artifacts from Task 1; VM running (pid 58827); password SSH/SCP.
+- Produces: `C:\Users\ghost\bin\ghost.exe` + `C:\Users\ghost\bin\opencode.exe` on the guest. Task 3 adds them to PATH.
+
+- [ ] **Step 1: Create the guest bin directory**
+
+Write this expect script to `/tmp/scp-setup.exp`:
+
+```expect
+#!/usr/bin/expect -f
+set timeout 30
+spawn ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/known_hosts.tst ghost@localhost -p 2222 {mkdir bin & echo MKDIR_DONE}
+expect {
+    "password:" { send "GhostTest!2026\r"; exp_continue }
+    "MKDIR_DONE" { }
+    timeout { puts "TIMEOUT"; exit 1 }
+    eof { }
+}
+expect eof
+```
+
+Run: `expect /tmp/scp-setup.exp`
+Expected: `MKDIR_DONE` (creates `C:\Users\ghost\bin`).
+
+- [ ] **Step 2: scp ghost.exe into the guest**
+
+Write `/tmp/scp-ghost.exp`:
+
+```expect
+#!/usr/bin/expect -f
+set timeout 60
+spawn scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/known_hosts.tst -P 2222 /tmp/win-deploy/ghost.exe ghost@localhost:bin/ghost.exe
+expect {
+    "password:" { send "GhostTest!2026\r"; exp_continue }
+    timeout { puts "TIMEOUT"; exit 1 }
+    eof { }
+}
+```
+
+Run: `expect /tmp/scp-ghost.exp`
+Expected: transfer completes without error.
+
+- [ ] **Step 3: scp opencode.exe into the guest**
+
+Write `/tmp/scp-opencode.exp` identical to Step 2 but sourcing `/tmp/win-deploy/opencode.exe` → `bin/opencode.exe`. Run: `expect /tmp/scp-opencode.exp`
+Expected: transfer completes without error (this is a large file — allow up to 60s).
+
+- [ ] **Step 4: Verify both files landed on the guest**
+
+Write `/tmp/ssh-verify.exp`:
+
+```expect
+#!/usr/bin/expect -f
+set timeout 30
+spawn ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/known_hosts.tst ghost@localhost -p 2222 {dir bin & echo LIST_DONE}
+expect {
+    "password:" { send "GhostTest!2026\r"; exp_continue }
+    "LIST_DONE" { }
+    timeout { puts "TIMEOUT"; exit 1 }
+    eof { }
+}
+expect eof
+```
+
+Run: `expect /tmp/ssh-verify.exp`
+Expected: `bin` contains `ghost.exe` (~19.7 MB) and `opencode.exe` (~174 MB).
+
+- [ ] **Step 5: Seamless-install gate**
+
+This task (binary transfer via scp) is manual friction — the seamless install gap "no one-command Windows install path for ghost" exists. File the issue now (see the format in Task 6 Step 6) unless you determine an issue already covers it (`gh search issues --repo wcatz/ghost "windows install"` first). Record the issue URL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/wayne/git/ghost && git add -u && git commit -q -m "chore: transfer windows deploy binaries to guest" 2>/dev/null || echo "no commit (clean tree)"
+```
+Expected: no commit (nothing staged).
+
+## Task 3: Add bin dir to guest PATH and smoke-test binaries
+
+**Files:**
+- None in the repo.
+- Guest env: user PATH (persisted via `setx`).
+- Guest binaries: `C:\Users\ghost\bin\ghost.exe`, `C:\Users\ghost\bin\opencode.exe` (from Task 2).
+
+**Interfaces:**
+- Consumes: binaries from Task 2.
+- Produces: guest user PATH containing `C:\Users\ghost\bin`; verified `ghost --version` + `opencode --version` in the guest. Task 4 runs ghost config.
+
+- [ ] **Step 1: Append bin dir to the guest user PATH via setx**
+
+Write `/tmp/ssh-setx.exp` (same expect skeleton as Task 2 Step 4) running:
+
+```
+setx PATH "%PATH%;C:\Users\ghost\bin" & echo SETX_DONE
+```
+
+Note: `setx` prints its own confirmation; the `& echo SETX_DONE` confirms completion. Expected: `SETX_DONE`. (setx truncates PATH at 1024 chars — the guest PATH is short, safe.)
+
+- [ ] **Step 2: Smoke-test ghost.exe in a NEW SSH session**
+
+setx affects only new processes, so a fresh `ssh` invocation picks up the new PATH. Write `/tmp/ssh-smoke.exp` running:
+
+```
+ghost --version & echo VERSION_DONE
+```
+
+Expected: ghost version string then `VERSION_DONE`. If `'ghost' is not recognized`, the setx didn't apply — retry Step 1, then open a brand-new SSH session (each `expect` run is a new process, so this should be fine).
+
+- [ ] **Step 3: Smoke-test opencode.exe in the guest**
+
+Same helper, command: `opencode --version & echo OC_DONE`
+Expected: opencode version then `OC_DONE`.
+
+- [ ] **Step 4: Seamless-install gate**
+
+Manual `setx` PATH surgery is a known friction gap — file a `wcatz/ghost` issue ("ghost on Windows: no PATH setup as part of install") unless one exists. Record the URL. If either smoke test failed, file an issue for the failure with the exact repro.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/wayne/git/ghost && git add -u && git commit -q -m "chore: guest PATH + binary smoke tests" 2>/dev/null || echo "no commit (clean tree)"
+```
+Expected: no commit.
+
+## Task 4: Point guest ghost at host Ollama
+
+**Files:**
+- None in the repo.
+- Guest config: `C:\Users\ghost\.config\ghost\config.yaml` (created by ghost on first run if absent).
+- Guest data dir: `C:\Users\ghost\.local\share\ghost`.
+
+**Interfaces:**
+- Consumes: ghost.exe on PATH (Task 3).
+- Produces: guest `config.yaml` with `embedding.ollama_url: http://10.0.2.2:11434`; guest ghost reaching host Ollama. Task 5 runs `ghost mcp init`.
+
+- [ ] **Step 1: Prime the config file (first ghost run)**
+
+Write `/tmp/ssh-prime.exp` running `ghost --version` (this triggers `EnsureConfigFile` which writes the default config.yaml). Expected: version string.
+
+- [ ] **Step 2: Read the generated config to find the embedding key**
+
+Write `/tmp/ssh-configcat.exp` running:
+```
+type "%USERPROFILE%\.config\ghost\config.yaml" & echo CONFIG_DONE
+```
+Expected: default config including `embedding.ollama_url` or the embedding section. (If `config.yaml` is not at this path, run `where ghost` and check the config dir reported by `ghost mcp status`.)
+
+- [ ] **Step 3: Set the host-gateway Ollama URL in config.yaml**
+
+The generated default `config.yaml` has the ENTIRE embedding section **commented out** (verified: `config.example.yaml` comments out `embedding.*`), so there is no `ollama_url` line to sed-replace — a `-replace 'localhost:11434'` would silently match nothing. Instead, **append** an uncommented `embedding:` block to the end of the file (koanf parses the whole file; a later block wins; commented lines are ignored). Write `/tmp/ssh-writecfg.exp` running this PowerShell one-liner:
+
+```
+powershell -Command "$cfg=Join-Path $env:USERPROFILE '.config\ghost\config.yaml'; $block=[Environment]::NewLine+'embedding:'+[Environment]::NewLine+'  enabled: true'+[Environment]::NewLine+'  ollama_url: \"http://10.0.2.2:11434\"'+[Environment]::NewLine+'  model: \"nomic-embed-text:v1.5\"'+[Environment]::NewLine+'  dimensions: 768'+[Environment]::NewLine; Add-Content $cfg $block; Get-Content $cfg | Select-Object -Last 6"
+```
+
+Expected: the last 6 lines of config.yaml are the uncommented embedding block with `ollama_url: "http://10.0.2.2:11434"`. Note the nested double quotes inside the PowerShell string are escaped with `\"` so the SSH/cmd layer passes them through — verify the printed config has literal `http://10.0.2.2:11434` without stray backslashes; if the quoting mangles, write the block with single quotes instead (`'http://10.0.2.2:11434'` — YAML accepts both).
+
+- [ ] **Step 4: Verify the guest reaches host Ollama**
+
+Same helper, running:
+```
+ghost mcp status --client opencode & echo STATUS_DONE
+```
+Expected: the Ollama/embedding check reports the model present (host Ollama at 10.0.2.2:11434 with `nomic-embed-text:v1.5`). If Ollama is unreachable (e.g. timeout), the QEMU user-net gateway may not map 10.0.2.2 → host loopback in this build — fall back to FTS5-only (document in report) and file an issue for the discovery.
+
+- [ ] **Step 5: Seamless-install gate**
+
+Hand-editing `config.yaml` to reach Ollama is a known friction gap — file a `wcatz/ghost` issue ("ghost on Windows: no built-in host-gateway Ollama config") unless one exists. Record the URL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/wayne/git/ghost && git add -u && git commit -q -m "chore: guest ghost config points at host ollama" 2>/dev/null || echo "no commit (clean tree)"
+```
+Expected: no commit.
+
+## Task 5: Wire ghost into opencode via ghost mcp init
+
+**Files:**
+- None in the repo.
+- Guest config: opencode config file (created/merged by `ghost mcp init --client opencode`).
+
+**Interfaces:**
+- Consumes: ghost.exe + opencode.exe on PATH (Task 3); config.yaml with Ollama gateway (Task 4).
+- Produces: opencode config containing `mcp.ghost` (stdio `ghost mcp`); verified via `opencode mcp ls`. Task 6 does the end-to-end round-trip.
+
+- [ ] **Step 1: Run ghost mcp init targeting opencode**
+
+Write `/tmp/ssh-mcpinit.exp` running:
+```
+ghost mcp init --client opencode & echo INIT_DONE
+```
+Expected output markers: `[1/2] Checking prerequisites...`, `✓ ghost binary at ...`, `[2/2] Registering MCP server...`, `✓ verified: ghost listed by opencode mcp ls`, then `INIT_DONE`. Capture the FULL output in the report.
+
+- [ ] **Step 2: Handle the known fallback if opencode mcp ls fails headless**
+
+If Step 1 printed "could not verify registration" (opencode CLI not on PATH or `mcp ls` failed in this headless context):
+- First re-run `opencode --version` to confirm opencode is on PATH.
+- If opencode is present but `opencode mcp ls` still fails, verify the config merge directly: run
+  ```
+  type "%USERPROFILE%\.config\opencode\opencode.json" & echo CFG_DONE
+  ```
+  (path may be `opencode.jsonc` or `opencode.json` — check both). Expected: a `"mcp"` object containing `"ghost": {"type": "local", "command": ["ghost", "mcp"], ...}`.
+- Then run `ghost mcp status --client opencode` and confirm it reports the ghost registration.
+- If the config merge itself failed, file an issue with the exact `ghost mcp init` output.
+
+- [ ] **Step 3: Confirm ghost is listed by opencode mcp ls**
+
+Run (same helper): `opencode mcp ls & echo LS_DONE`
+Expected: output lists `ghost`. If `opencode mcp ls` errors headless (no TTY), this is the known fallback in Step 2 — document it and rely on the config check + `mcp status`.
+
+- [ ] **Step 4: Seamless-install gate**
+
+Any failure or awkwardness in `ghost mcp init --client opencode` on Windows → file a `wcatz/ghost` issue (labels `windows`, `mcp-init`) with the full output. If everything worked cleanly, no new issue (but record "no friction" in the report).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/wayne/git/ghost && git add -u && git commit -q -m "chore: wire ghost MCP server into opencode in guest" 2>/dev/null || echo "no commit (clean tree)"
+```
+Expected: no commit.
+
+## Task 6: End-to-end verification and issue ledger
+
+**Files:**
+- None in the repo.
+- Consumes: complete install (Tasks 1-5).
+- Produces: verified end-to-end ghost in-guest; complete issue list (URLs) for all friction found.
+
+- [ ] **Step 1: ghost --version and mcp status**
+
+Write `/tmp/ssh-final.exp` running:
+```
+ghost --version & ghost mcp status --client opencode & echo FINAL_DONE
+```
+Expected: version; `mcp status` reports ghost binary found, opencode registration OK, Ollama model present.
+
+- [ ] **Step 2: Memory round-trip in the guest over the MCP protocol**
+
+Ghost has NO `ghost memory` CLI — the memory tools exist only as MCP server tools (`ghost_memory_save`, `ghost_memory_search`, `ghost_memories_list`, etc.). Verify the round-trip by driving the guest's MCP server over stdio from the host, via SSH: the host's python3 pipes newline-delimited JSON-RPC into `ssh ghost@localhost -p 2222 "C:\Users\ghost\bin\ghost.exe mcp"` and reads responses from the SSH stdout. (Verified working: save→search→list round-trip returns the same memory ID.)
+
+Write `/tmp/roundtrip.py`:
+
+```python
+import subprocess, json, time, sys, os, getpass
+SSH = ['ssh', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/tmp/known_hosts.tst',
+       '-p', '2222', 'ghost@localhost', r'C:\Users\ghost\bin\ghost.exe mcp']
+p = subprocess.Popen(SSH, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+buf = bytearray()
+def send(m):
+    p.stdin.write((json.dumps(m)+'\n').encode()); p.stdin.flush()
+def drain(t=4):
+    time.sleep(t); buf.extend(p.stdout.read1(65536)); return buf.decode(errors='replace')
+def call(mid, tool, args):
+    send({"jsonrpc":"2.0","id":mid,"method":"tools/call","params":{"name":tool,"arguments":args}})
+    return drain(2)
+send({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"drivetest","version":"1.0"}}})
+drain(2)
+send({"jsonrpc":"2.0","method":"notifications/initialized"})
+out = call(2, "ghost_memory_save", {"project_id":"win-test","content":"seamless-windows-install verification marker","category":"fact","importance":0.5})
+print("SAVE:", out)
+out = call(3, "ghost_memory_search", {"project_id":"win-test","query":"seamless verification marker"})
+print("SEARCH:", out)
+out = call(4, "ghost_memories_list", {"project_id":"win-test"})
+print("LIST:", out)
+p.kill()
+```
+
+Run: `python3 /tmp/roundtrip.py` with password `GhostTest!2026` — if the SSH pipe blocks waiting for the password (no key auth), run it under an expect wrapper that answers the password prompt first, OR add `-o BatchMode=no` and use `sshpass` if installed. Simplest robust path: wrap in expect — write `/tmp/roundtrip.exp` that spawns `python3 /tmp/roundtrip.py` and on `password:` sends `GhostTest!2026`. (python3 must be present on the HOST — it is on macOS.)
+
+Expected:
+- `SAVE:` → `"Memory saved (id: <HEXID>)"`
+- `SEARCH:` → a line `- [fact] ... (0.5) «seamless-windows-install verification marker»`
+- `LIST:` → the same memory listed.
+
+If the SSH pipe corrupts the newline framing (cmd.exe layer), fall back to running the python driver entirely in the guest via PowerShell's `Invoke-WebRequest`-free approach: scp the script to the guest and run `C:\Users\ghost\bin\ghost.exe mcp` with the driver, OR — last resort — write the driver in PowerShell in the guest. Record whichever worked.
+
+- [ ] **Step 3: Confirm opencode lists ghost**
+
+Run: `opencode mcp ls & echo LS_DONE`
+Expected: `ghost` in the list (or the documented Step 2 fallback of Task 5 applies).
+
+- [ ] **Step 4: Clean up the test memory**
+
+Use the MCP protocol (extend `/tmp/roundtrip.py` with a 5th call) to delete the round-trip test memory via `ghost_memory_delete` (project_id `win-test`, memory_id from the SAVE result). This leaves the fresh DB clean. If the delete call fails, leave the memory and note it.
+
+- [ ] **Step 5: Compile the issue ledger**
+
+Run `gh search issues --repo wcatz/ghost "windows" --state all` and list any related issues (pre-existing: #252 "Windows mcp init: follow-ups from #251", #245 "mcp init breaks on Windows: hook quoting, project-path encoding, PID liveness" — both closed; check for any duplicate that would cover new findings). Then for every friction item recorded across Tasks 1-5 that does NOT already have an issue, create one:
+
+```bash
+gh issue create --repo wcatz/ghost --title "<specific friction title>" --label "windows" --body "## Repro ... ## Expected ... ## Actual ..."
+```
+
+Add `--label "mcp-init"` for mcp-init-scoped friction. The `ghost` repo labels may not have `windows`/`mcp-init` yet — `gh label create windows --repo wcatz/ghost --force` (and same for `mcp-init`) before creating issues, or omit the label if label management is out of scope (note it in the report).
+
+- [ ] **Step 6: Write the final report and ledger**
+
+Write `/Users/wayne/git/ghost/.superpowers/sdd/2026-08-10-seamless-windows-install/progress.md` recording: each task's result, every friction item, every issue URL (title + number), the end-to-end verification outputs, and the exact "how to reproduce install" steps for the user.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/wayne/git/ghost && git add -u && git commit -q -m "chore: windows deploy issue ledger" 2>/dev/null || echo "no commit (clean tree)"
+```
+Expected: no commit.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** every spec decision maps to a task — cross-compile (T1), opencode release download (T1), fresh independent DB (T6 round-trip, guest default path), PATH via setx (T3), host Ollama gateway (T4), `mcp init --client opencode` (T5), end-to-end verify (T6), seamless-install gate → issues (all tasks, ledger T6). Out-of-scope items (provider API key, msi signing, source fixes) are not tasks.
+- **Verification is evidence-based:** each task ends with an observable check, and the report captures the actual command output rather than claiming success.
+- **Known-friction issues are filed even when the workaround completes the install** — the workaround IS the evidence the seamless gap exists.

--- a/docs/superpowers/specs/2026-08-09-utm-windows-vm-design.md
+++ b/docs/superpowers/specs/2026-08-09-utm-windows-vm-design.md
@@ -1,0 +1,91 @@
+# UTM-native Windows 11 VM for headless agent testing
+
+## Context
+
+Ghost's MCP server is being tested on Windows. An earlier attempt drove a
+Windows 11 ARM64 guest with QEMU/TCG (pure emulation) from a headless SSH
+session, using a QEMU HMP monitor socket + screendump + OCR to interact with
+the guest. That install succeeded (desktop reached, `ghost` user created,
+OpenSSH Server install started), but TCG made the guest brutally slow:
+`Add-WindowsCapability` for OpenSSH.Server took over an hour of wall-clock
+time and was still running.
+
+The host (Apple M1, macOS 26.6.1) has Hypervisor.framework available
+(`kern.hv_support: 1`), which UTM uses to run aarch64 guests at near-native
+speed. The previous install's slow, fragile TCG setup is replaced by a
+UTM-native VM configuration that uses HVF acceleration and is launched
+headlessly over SSH (no desktop, ever — this is only for agents to test
+ghost).
+
+## Goal
+
+A new UTM VM bundle (`ghost-win11-utm.utm`) that:
+
+- reuses the existing installed disk `win11.qcow2` (no reinstall);
+- is accelerated by HVF, not TCG;
+- is headless-only (never launched as a desktop window);
+- exposes SSH on host port 2222 so agents can run ghost inside Windows;
+- exposes RDP on host port 3389 as an optional escape hatch.
+
+## Key design decisions
+
+1. **Reuse the installed qcow2.** Windows 11 25H2 ARM64 is already installed
+   and past OOBE on `/Users/wayne/vms/ghost-win11.utm/Data/win11.qcow2`.
+   Reinstalling would repeat hours of emulation-time. The disk is untouched
+   by this change; the new bundle points at it.
+
+2. **Disk must stay NVMe.** The installed Windows bound the inbox `stornvme`
+   driver to the system disk. UTM's default VirtIO disk interface would not
+   boot this image. The new bundle sets the drive interface to `NVMe`
+   (supported by UTM 4.7.5).
+
+3. **HVF acceleration.** `QEMU.Hypervisor = true`, CPU `max`, 8 cores, 8 GB
+   RAM, `virt` machine. Verified: `-accel hvf -cpu max` initializes fine.
+   `pauth-impdef=on` was a TCG-only workaround and must NOT be carried into
+   the HVF launch (it errors under HVF).
+
+4. **Headless launch from SSH.** UTM's GUI is not used. The bundle's
+   `config.plist` is the source of truth; the VM is launched with brew QEMU
+   (`-accel hvf`) plus the same HMP monitor socket + screendump workflow,
+   so the guest is operated exactly as the TCG VM was.
+
+5. **Keep `answer.iso` attached.** It carries NetKVM + the other virtio
+   drivers and `utm-guest-tools-0.1.271.exe`, needed if the virtio-net NIC
+   did not enumerate during install. Detach the Windows install ISO (its
+   boot priority caused repeated EFI-shell detours during install; the
+   install is done).
+
+## Steps
+
+1. Cleanly stop the current TCG VM (pid 50552) via HMP `system_powerdown`,
+   waiting for exit, so the qcow2 is not locked and is in a consistent
+   state.
+2. Create `/Users/wayne/vms/ghost-win11-utm.utm/` with a `config.plist`
+   specifying: HVF, NVMe drive pointing at the existing qcow2, virtio-net
+   with hostfwd `2222→22`/`3389→3389`, `answer.iso` as a USB CD, no install
+   ISO, display `virtio-ramfb` (present for UTM compatibility; never opened
+   as a window).
+3. Launch headless with brew QEMU:
+   `-accel hvf -cpu max`, NVMe system drive, virtio-net hostfwd, HMP monitor
+   on `/tmp/w11utm-mon.sock`, no display.
+4. On first boot, finish the interrupted OpenSSH Server install
+   (`Add-WindowsCapability` + `Start-Service sshd` + firewall rule), which
+   is fast under HVF. If the virtio-net NIC did not enumerate, install
+   NetKVM from `answer.iso` and retry.
+5. Verify: `ssh ghost@localhost -p 2222` works; run `ghost mcp init` in the
+   guest to confirm the original testing goal.
+
+## Non-goals
+
+- No desktop/display session for humans — agents only.
+- No reinstall of Windows.
+- No changes to UTM's own bundled QEMU or the installed `win11.qcow2`
+  contents beyond finishing the OpenSSH setup.
+
+## Risks
+
+- The virtio-net driver may not be bound yet; NetKVM on `answer.iso` is the
+  fallback and is quick to apply under HVF.
+- Interrupting the in-flight DISM OpenSSH install when stopping the TCG VM
+  could leave the capability half-installed; re-running
+  `Add-WindowsCapability` is idempotent and recovers it.

--- a/docs/superpowers/specs/2026-08-10-seamless-windows-install-design.md
+++ b/docs/superpowers/specs/2026-08-10-seamless-windows-install-design.md
@@ -1,0 +1,119 @@
+# Seamless ghost install into the Windows VM
+
+## Context
+
+Ghost's MCP server is being tested on Windows. The UTM-native Windows 11 ARM64
+VM (`ghost-win11-utm.utm`) is now running headless under HVF and reachable over
+SSH (`ghost@localhost:2222`, password auth, OpenSSH Server running). The VM's
+purpose is to let agents run ghost inside Windows.
+
+The original goal — a reachable VM — is met. This spec covers the next step:
+installing ghost in the guest so it *just works* as an MCP memory server for an
+in-guest opencode client, and treating every manual/friction step as a defect
+against the seamless-install experience (filed as a GitHub issue on
+`wcatz/ghost`).
+
+## Goal
+
+A seamless ghost install inside the Windows guest:
+
+- ghost.exe deployed to the guest and on PATH;
+- opencode (Windows ARM64) installed and on PATH;
+- `ghost mcp init --client opencode` registers ghost as an MCP server for
+  opencode;
+- in-guest ghost uses the host's Ollama for vector embeddings (full hybrid
+  search);
+- verified end-to-end: `ghost --version`, `ghost mcp status`, a memory
+  save→search→list round-trip, and `opencode mcp ls` listing ghost;
+- every step that required manual intervention becomes a `wcatz/ghost` issue.
+
+## Key design decisions
+
+1. **ghost.exe via cross-compile.** `GOOS=windows GOARCH=arm64 go build` from
+   the host (verified: builds cleanly, ~19.7 MB, pure-Go SQLite). Land at
+   `C:\Users\ghost\bin\ghost.exe` — no `%` in the path (ghost's `mcp init`
+   warns on `%`-containing paths on Windows).
+
+2. **Fresh independent DB.** The guest gets its own ghost memory store at
+   `C:\Users\ghost\.local\share\ghost` (the default `DataDir`). It tests
+   Windows functionality in isolation; host data is never touched.
+
+3. **opencode from GitHub releases.** `opencode-windows-arm64.zip` (asset
+   confirmed to exist). scp + unzip to `C:\Users\ghost\bin\`. opencode needs to
+   be on PATH only so `opencode mcp ls` can verify the registration; `ghost mcp
+   init --client opencode` itself requires only ghost and degrades gracefully
+   without opencode.
+
+4. **PATH via `setx`.** Append `C:\Users\ghost\bin` to the user PATH so both
+   binaries survive reboot.
+
+5. **Host Ollama via the user-net gateway.** The guest's default
+   `embedding.ollama_url: http://localhost:11434` is unreachable inside the
+   guest. QEMU user-net maps the guest's `10.0.2.2` to host loopback, and host
+   Ollama is up with `nomic-embed-text:v1.5`, so the guest's `config.yaml` sets
+   `embedding.ollama_url: http://10.0.2.2:11434` for full hybrid search.
+
+6. **`ghost mcp init --client opencode` does the wiring.** It deep-merges the
+   `mcp.ghost` entry (`stdio`, `ghost mcp`) into opencode's config and verifies
+   via `opencode mcp ls`.
+
+## Components
+
+| Component | Host side | Guest side |
+|---|---|---|
+| ghost.exe | `GOOS=windows GOARCH=arm64 go build` | `C:\Users\ghost\bin\ghost.exe` + PATH |
+| opencode | download `opencode-windows-arm64.zip` | `C:\Users\ghost\bin\opencode.exe` + PATH |
+| config.yaml | — | `C:\Users\ghost\.config\ghost\config.yaml`, `embedding.ollama_url=http://10.0.2.2:11434` |
+| MCP registration | — | opencode config `mcp.ghost = stdio "ghost mcp"` via `ghost mcp init --client opencode` |
+
+## Data flow
+
+1. Host cross-compiles ghost.exe.
+2. Host downloads opencode-windows-arm64.zip.
+3. Both are scp'd into the guest; PATH is extended via `setx`.
+4. `ghost mcp init --client opencode` runs in the guest, merging `mcp.ghost`
+   into opencode's config.
+5. opencode spawns `ghost mcp` over stdio; ghost persists to its SQLite store
+   under the guest data dir and embeds via host Ollama at `10.0.2.2:11434`.
+
+## Seamless-install gate (defects → issues)
+
+Every manual or friction step encountered becomes a `wcatz/ghost` GitHub issue
+(`gh issue create`, label `windows`; `mcp-init` when scoped there). Candidates
+already known:
+
+- Manual binary transfer (no one-command Windows install path).
+- Manual `setx` PATH surgery.
+- Hand-editing `config.yaml` to reach Ollama (no built-in host-gateway config).
+- Any `ghost mcp init` failure surfaced on Windows during this run.
+
+Each issue includes title, repro, expected vs actual, and labels. Issues are
+filed even when a workaround completes the install — the workaround is the
+evidence the gap exists.
+
+## Error handling / fallbacks
+
+- opencode zip download/unzip fails → retry asset URL; fall back to PowerShell
+  `Expand-Archive`; file an issue if the documented install path is broken.
+- `opencode mcp ls` fails in a headless context → rely on the config merge +
+  `ghost mcp status`; file an issue for the gap.
+- Host-Ollama unreachable from the guest despite user-net → fall back to
+  FTS5-only search (documented); file an issue for the discovery.
+
+## Testing / verification
+
+- Guest: `ghost --version`.
+- Guest: `ghost mcp status --client opencode`.
+- Guest: memory save → search → list round-trip over SSH (proves the DB and
+  server path work on Windows).
+- Guest: `opencode mcp ls` lists ghost (proves registration took).
+- Issue list: every friction item recorded with its issue URL.
+- No repo code changes expected; `git add -u` only if something appears.
+
+## Out of scope
+
+- Installing an LLM-backed agent provider or API key inside the guest (opencode
+  is wired, not necessarily driven to a full agent session).
+- Windows binary signing / installer (`.msi`) — the subject of potential future
+  issues, not this spec.
+- Modifying ghost's source to fix the issues filed — this spec stops at filing.

--- a/internal/mcpinit/opencode_test.go
+++ b/internal/mcpinit/opencode_test.go
@@ -134,6 +134,39 @@ func TestRunOpencode_Idempotent(t *testing.T) {
 	}
 }
 
+// TestRunOpencode_IdempotentWindowsExe is a regression test for the Windows
+// binary-name case: ghost.exe must still be recognized as the ghost binary so
+// a second run reports "already registered" instead of rewriting the config.
+func TestRunOpencode_IdempotentWindowsExe(t *testing.T) {
+	home, xdg := setupOpencodeTestEnv(t)
+	writeStub(t, filepath.Join(home, "bin"), "ghost.exe")
+
+	var out1 bytes.Buffer
+	if err := RunOpencode(&out1, false); err != nil {
+		t.Fatalf("RunOpencode (first): %v", err)
+	}
+	cfgPath := filepath.Join(xdg, "opencode", "opencode.json")
+	first, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	var out2 bytes.Buffer
+	if err := RunOpencode(&out2, false); err != nil {
+		t.Fatalf("RunOpencode (second): %v", err)
+	}
+	second, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Errorf("config changed on second run (ghost.exe idempotency):\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+	if !strings.Contains(out2.String(), "already registered") {
+		t.Errorf("second run should report 'already registered' for ghost.exe, got:\n%s", out2.String())
+	}
+}
+
 func TestRunOpencode_DryRunWritesNothing(t *testing.T) {
 	_, xdg := setupOpencodeTestEnv(t)
 

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -901,7 +901,7 @@ func (s *Server) registerTools() {
 		}
 		s.notifyResourceUpdated(ctx, "ghost://memories/global")
 
-		// Notify embedding worker of new/updated memory.
+		// Notify embedding worker of new/updated memory — same as memory_save.
 		if s.projectCh != nil {
 			select {
 			case s.projectCh <- "_global":

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -229,6 +229,36 @@ func TestSetEmbedder(t *testing.T) {
 	}
 }
 
+// TestSaveGlobal_NotifiesEmbeddingWorker is a regression test: ghost_save_global
+// must signal the embedding worker's channel (like ghost_memory_save) so global
+// memories get embedded immediately instead of only on the 2-minute sweep.
+func TestSaveGlobal_NotifiesEmbeddingWorker(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+
+	ch := make(chan string, 1)
+	srv.SetEmbedder(&mockEmbedder{}, ch)
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	if _, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_save_global",
+		Arguments: map[string]any{"content": "global embedding notify regression", "category": "fact"},
+	}); err != nil {
+		t.Fatalf("CallTool ghost_save_global: %v", err)
+	}
+
+	select {
+	case got := <-ch:
+		if got != "_global" {
+			t.Errorf("embedding worker notified with %q, want %q", got, "_global")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ghost_save_global did not notify the embedding worker")
+	}
+}
+
 type mockEmbedder struct{}
 
 func (m *mockEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
@@ -1458,43 +1488,6 @@ func TestDecisionRecordSupersedesArg(t *testing.T) {
 	}
 	if len(after) != 1 || after[0].ID == oldID {
 		t.Errorf("expected only the replacement to remain active, got %+v", after)
-	}
-}
-
-func TestSaveGlobal_NotifiesEmbeddingWorker(t *testing.T) {
-	store := testStore(t)
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	srv := New(store, logger, "test")
-
-	ch := make(chan string, 4)
-	srv.SetEmbedder(&mockEmbedder{}, ch)
-
-	ctx := context.Background()
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-	if _, err := srv.mcp.Connect(ctx, serverTransport, nil); err != nil {
-		t.Fatalf("server Connect: %v", err)
-	}
-	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
-	session, err := client.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		t.Fatalf("client Connect: %v", err)
-	}
-	t.Cleanup(func() { _ = session.Close() })
-
-	if _, err := session.CallTool(ctx, &mcp.CallToolParams{
-		Name:      "ghost_save_global",
-		Arguments: map[string]any{"content": "global memory should trigger embedding", "category": "fact"},
-	}); err != nil {
-		t.Fatalf("CallTool ghost_save_global: %v", err)
-	}
-
-	select {
-	case got := <-ch:
-		if got != "_global" {
-			t.Errorf("projectCh notified with %q, want %q", got, "_global")
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for embedding worker notification on ghost_save_global")
 	}
 }
 


### PR DESCRIPTION
Syncs local main with upstream origin/main (8 commits merged) and resolves 3 merge conflicts:

- **opencode.go**: keep upstream (better Windows .exe handling)
- **mcpserver.go**: keep stash's more informative comment
- **mcpserver_test.go**: drop stash's verbose duplicate of `TestSaveGlobal_NotifiesEmbeddingWorker`
- **status_test.go**: drop stash's duplicate `TestStatus_HookMatchWithQuotedPath` (upstream already has it), remove unused `strconv` import

Build and vet pass. Two pre-existing test failures (`TestStatusOpencode_EmptyStoreHealthy` — needs Ollama; `TestReportConfigFile_Present` — path mismatch) are unrelated.