### PR TITLE
fix(deps): bump go toolchain to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wcatz/ghost
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/knadh/koanf/parsers/yaml v1.1.1


### PR DESCRIPTION
## Problem

`govulncheck` in CI fails on `main` and every open PR right now, unrelated to any specific diff: `go.mod` pins `go 1.26.5`, and 4 CVEs against that exact stdlib build have been published since release, all fixed in `go1.26.6`:

- GO-2026-6218 (net/url — quadratic complexity in resolvePath)
- GO-2026-6090 (crypto/tls — unbounded post-handshake messages)
- GO-2026-5972 (encoding/asn1 — unbounded recursion)
- GO-2026-5026 (net/http via x/net/idna — Punycode label validation)

## Fix

Bump the `go` directive to `1.26.6`. `actions/setup-go` reads `go-version-file: go.mod`, so CI picks this up automatically.

## Verification

- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — full suite passes
- `govulncheck ./...` — 0 vulnerabilities (was 4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go version to 1.26.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->