### PR TITLE
fix(memory): preserve pinned memories through reflection replace/restore

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -970,12 +970,17 @@ func (s *Store) ReplaceNonManual(ctx context.Context, projectID string, memories
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Snapshot existing non-manual memories before deleting.
+	// Snapshot existing non-manual memories before deleting. Pinned memories
+	// are excluded throughout this function — like source='manual', a pin is
+	// an explicit user override that reflection must never delete, rewrite,
+	// or silently drop (it has no way to know a consolidated memory it emits
+	// corresponds to a pinned one it never saw as such, so preservation has
+	// to mean "don't touch it" rather than "carry the flag through").
 	snapshotID := fmt.Sprintf("%s-%d", projectID, time.Now().Unix())
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO memory_snapshots (snapshot_id, project_id, category, content, importance, source, tags)
 		SELECT ?, project_id, category, content, importance, source, tags
-		FROM memories WHERE project_id = ? AND source != 'manual'
+		FROM memories WHERE project_id = ? AND source != 'manual' AND pinned = 0
 	`, snapshotID, projectID)
 	if err != nil {
 		return fmt.Errorf("snapshot memories: %w", err)
@@ -989,7 +994,7 @@ func (s *Store) ReplaceNonManual(ctx context.Context, projectID string, memories
 	if consolidatedSince != "" {
 		rows, err := tx.QueryContext(ctx, `
 			SELECT category, content, importance, source, tags
-			FROM memories WHERE project_id = ? AND source != 'manual' AND created_at >= ?
+			FROM memories WHERE project_id = ? AND source != 'manual' AND pinned = 0 AND created_at >= ?
 		`, projectID, consolidatedSince)
 		if err != nil {
 			return fmt.Errorf("find concurrent memories: %w", err)
@@ -1011,7 +1016,7 @@ func (s *Store) ReplaceNonManual(ctx context.Context, projectID string, memories
 		}
 	}
 
-	_, err = tx.ExecContext(ctx, `DELETE FROM memories WHERE project_id = ? AND source != 'manual'`, projectID)
+	_, err = tx.ExecContext(ctx, `DELETE FROM memories WHERE project_id = ? AND source != 'manual' AND pinned = 0`, projectID)
 	if err != nil {
 		return fmt.Errorf("delete old memories: %w", err)
 	}
@@ -1089,8 +1094,10 @@ func (s *Store) RestoreSnapshot(ctx context.Context, projectID string) (int, err
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Delete current non-manual memories.
-	_, err = tx.ExecContext(ctx, `DELETE FROM memories WHERE project_id = ? AND source != 'manual'`, projectID)
+	// Delete current non-manual memories. Pinned memories are excluded, same
+	// as ReplaceNonManual: reflection never touched them, so restore must not
+	// delete them either — they aren't in the snapshot to bring back.
+	_, err = tx.ExecContext(ctx, `DELETE FROM memories WHERE project_id = ? AND source != 'manual' AND pinned = 0`, projectID)
 	if err != nil {
 		return 0, fmt.Errorf("delete current: %w", err)
 	}

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -587,6 +587,114 @@ func TestStoreReplaceNonManual(t *testing.T) {
 			t.Error("consolidator output should still be present")
 		}
 	})
+
+	t.Run("pinned non-manual memory survives replace", func(t *testing.T) {
+		s := testStore(t)
+
+		pinnedID, err := s.Create(ctx, testProject, Memory{
+			Category:   "gotcha",
+			Content:    "user-pinned mcp memory",
+			Source:     "mcp",
+			Importance: 0.7,
+			Tags:       []string{},
+		})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if err := s.TogglePin(ctx, pinnedID, true); err != nil {
+			t.Fatalf("TogglePin: %v", err)
+		}
+
+		replacement := []Memory{
+			{Category: "fact", Content: "new consolidated fact", Importance: 0.6, Tags: []string{}},
+		}
+		if err := s.ReplaceNonManual(ctx, testProject, replacement, ""); err != nil {
+			t.Fatalf("ReplaceNonManual: %v", err)
+		}
+
+		all, err := s.GetAll(ctx, testProject, 100)
+		if err != nil {
+			t.Fatalf("GetAll: %v", err)
+		}
+
+		var found *Memory
+		for i := range all {
+			if all[i].ID == pinnedID {
+				found = &all[i]
+			}
+		}
+		if found == nil {
+			t.Fatalf("pinned memory %s was dropped by ReplaceNonManual", pinnedID)
+		}
+		if !found.Pinned {
+			t.Error("pinned memory lost its pinned flag after ReplaceNonManual")
+		}
+	})
+}
+
+func TestStoreRestoreSnapshot(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	pinnedID, err := s.Create(ctx, testProject, Memory{
+		Category:   "gotcha",
+		Content:    "user-pinned mcp memory",
+		Source:     "mcp",
+		Importance: 0.7,
+		Tags:       []string{},
+	})
+	if err != nil {
+		t.Fatalf("Create pinned: %v", err)
+	}
+	if err := s.TogglePin(ctx, pinnedID, true); err != nil {
+		t.Fatalf("TogglePin: %v", err)
+	}
+
+	if _, err := s.Create(ctx, testProject, Memory{
+		Category:   "fact",
+		Content:    "old reflection fact to be snapshotted",
+		Source:     "reflection",
+		Importance: 0.5,
+		Tags:       []string{},
+	}); err != nil {
+		t.Fatalf("Create old: %v", err)
+	}
+
+	replacement := []Memory{
+		{Category: "fact", Content: "new consolidated fact", Importance: 0.6, Tags: []string{}},
+	}
+	if err := s.ReplaceNonManual(ctx, testProject, replacement, ""); err != nil {
+		t.Fatalf("ReplaceNonManual: %v", err)
+	}
+
+	if _, err := s.RestoreSnapshot(ctx, testProject); err != nil {
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+
+	all, err := s.GetAll(ctx, testProject, 100)
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+
+	var found *Memory
+	var foundOld bool
+	for i := range all {
+		if all[i].ID == pinnedID {
+			found = &all[i]
+		}
+		if all[i].Content == "old reflection fact to be snapshotted" {
+			foundOld = true
+		}
+	}
+	if found == nil {
+		t.Fatalf("pinned memory %s was dropped by RestoreSnapshot", pinnedID)
+	}
+	if !found.Pinned {
+		t.Error("pinned memory lost its pinned flag after RestoreSnapshot")
+	}
+	if !foundOld {
+		t.Error("snapshotted memory should have been restored")
+	}
 }
 
 func TestStoreSearchFTS(t *testing.T) {


### PR DESCRIPTION
Fixes #276.

## Problem

`ReplaceNonManual` (`internal/memory/store.go`) deletes every `source != 'manual'` memory unconditionally, then reinserts only the LLM's consolidated output. The consolidated output has no `pinned` field and no reliable identity link back to whatever it may have summarized (reflection can merge/reword content, so even adding a `Pinned` field to `ReflectMemory` and asking the LLM to carry it through would be fragile). Net effect: a user-pinned `source='mcp'` memory was silently and completely dropped by every `ghost reflect --apply`, contradicting CLAUDE.md's documented guarantee that pinned memories "survive reflection pruning" — which in practice only ever held for `source='manual'` seed memories.

## Fix

Exclude pinned memories from `ReplaceNonManual` entirely — same treatment as `source='manual'` — across all three queries that scope its snapshot/preserve/delete (they need to agree, or a memory ends up snapshotted-and-deleted but not preserved, or preserved-and-reinserted as a duplicate). A pin is a user override reflection must never touch, not a flag to thread through a rewrite.

`RestoreSnapshot`'s delete gets the same `AND pinned = 0` exclusion. Without it, fixing `ReplaceNonManual` alone would introduce a new regression: `--restore` would delete a pinned memory that reflection never touched and that was therefore never captured in the snapshot — restore would just lose it, with nothing to bring back.

## Verification

- Added `TestStoreReplaceNonManual/pinned_non-manual_memory_survives_replace` — watched it fail (pinned memory dropped entirely) before the fix, passes after.
- Added `TestStoreRestoreSnapshot` — watched it fail (pinned memory dropped by restore's delete) before the fix, passes after.
- `go vet ./...`, `go build ./...`, full `go test ./...` all pass.