### PR TITLE
docs(memory): note decay floor dead zone at low importance

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -544,6 +544,12 @@ func (s *Store) Upsert(ctx context.Context, projectID, category, content, source
 // for the category-aware time-decay + pinned-boost formula so the two
 // callers can never drift apart. It is a fragment, not a full query: callers
 // interpolate it into their own "ORDER BY (...) DESC" clause.
+// The 0.15 and 0.3 floors create a dead zone at the low end of each decaying
+// category: a brand-new memory saved at importance 0.15 (or 0.3) scores
+// identically to a maximally-important, fully-decayed one of the same
+// category (1.0 * 0.15 == 0.15 * 1.0). Accepted — importance that low is rare
+// in practice (defaults are 0.5+) — but if ranking ever looks off for a
+// low-importance category member, this tie is why.
 const DecayRankingSQL = `
 	importance
 	* CASE


### PR DESCRIPTION
Closes #281.

## Verified

`DecayRankingSQL`'s floors (`MAX(0.15, ...)` for gotcha/decision/dependency, `MAX(0.3, ...)` for pattern/architecture) create exactly the tie the issue describes: importance 0.15 new == importance 1.0 fully-decayed, both at score 0.15. No `access_count`/`last_accessed` tiebreaker exists to separate them (see #284).

## Decision

By-design, per the issue's own risk assessment (low in practice — default importance is 0.5+). No behavior change — one-line doc comment on `DecayRankingSQL` so the tie is explained in the one place future readers will look when ranking seems off.