### PR TITLE
test(mcpserver): cover ghost_task_update invalid-status rejection

### DIFF
--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -719,6 +719,53 @@ func TestTaskUpdate_EmptyStatusPreservesCurrentStatus(t *testing.T) {
 	}
 }
 
+func TestGhostTaskUpdate_RejectsInvalidStatus(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	id, err := store.CreateTask(ctx, "abc123", "Fix the bug", "needs triage", 2)
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_task_update",
+		Arguments: map[string]any{"task_id": id, "status": "pendding"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_task_update: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected error result for invalid status, got: %+v", result.Content)
+	}
+
+	var msg string
+	if len(result.Content) > 0 {
+		if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+			msg = tc.Text
+		}
+	}
+	if strings.Contains(msg, "CHECK constraint") {
+		t.Errorf("expected a clear validation error, but got the raw SQLite constraint error: %s", msg)
+	}
+	wantSubstr := `invalid status "pendding" — must be one of: pending, active, blocked, done`
+	if !strings.Contains(msg, wantSubstr) {
+		t.Errorf("expected error to contain %q, got: %s", wantSubstr, msg)
+	}
+
+	// The task's status must be untouched by the rejected update.
+	task, err := store.GetTask(ctx, id)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.Status != "pending" {
+		t.Errorf("status should remain pending after rejected update, got %q", task.Status)
+	}
+}
+
 func TestParseProjectIDFromURI(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Refs #277

## Finding: not reproducible on `main`

#277 reports that `ghost_task_update` accepts any `status` string and passes it straight to `store.UpdateTask`, so an invalid value like `"pendding"` surfaces a raw `update task: CHECK constraint failed: tasks` instead of a clear error.

That validation already exists on `main`, in the exact handler the issue cites (`internal/mcpserver/mcpserver.go`, `ghost_task_update`):

```go
var status *string
if args.Status != "" {
	validStatuses := map[string]bool{
		"pending": true, "active": true, "blocked": true, "done": true,
	}
	if !validStatuses[args.Status] {
		return nil, nil, fmt.Errorf("invalid status %q — must be one of: pending, active, blocked, done", args.Status)
	}
	status = &args.Status
}
```

Evidence:
- `git blame` shows this was added by `e82a3214` ("fix(mcp): path prefix false-match, optional task status, global limit, URI tests", #148, merged 2026-04-18) and touched again by `f3b1f60a` (#229, 2026-08-02).
- The error text is already verbatim what the issue asks for: `invalid status "pendding" — must be one of: pending, active, blocked, done"`.
- `store.UpdateTask` has exactly one caller in the whole repo (the mcpserver handler above) — no unvalidated path reaches it.
- `git tag --contains e82a3214` includes every release from `v0.10.0` onward; `git tag --contains f3b1f60a` includes `v0.18.0` through the current latest, `v0.21.0` (released 2026-08-10). So the fix has shipped for a while, not just merged-but-unreleased.
- Branching directly from `origin/main` and diffing against it shows zero difference in `mcpserver.go` — this PR's branch started from the exact state the issue describes as buggy, and that state already validates.

## What this PR actually adds

A regression test was genuinely missing: the only existing task-update test, `TestTaskUpdate_EmptyStatusPreservesCurrentStatus`, covers the empty-status/no-op path, not rejection of an invalid status. This adds `TestGhostTaskUpdate_RejectsInvalidStatus` in `internal/mcpserver/mcpserver_test.go`, which drives the real tool handler end-to-end via `CallTool("ghost_task_update", ...)` (the same pattern as `TestGhostTaskCreate_RejectsUnknownProject`) with `status: "pendding"` and asserts:
- the call returns an error result,
- the error text is the clear validation message, not a raw SQLite `CHECK constraint` failure,
- the task's status is left untouched.

I wrote this test first and ran it against unmodified `main` to confirm the premise empirically (not just by reading the code) — it passed immediately, with no production code changes needed.

No production code was changed. Suggest closing #277 as already-fixed (by #148/#229), with this PR merged for the added coverage.

## Verification

```
$ go vet ./...
(clean)

$ go build ./...
(clean)

$ go test ./...
ok  	github.com/wcatz/ghost/bench/longmemeval	0.009s
ok  	github.com/wcatz/ghost/cmd/ghost	0.018s
ok  	github.com/wcatz/ghost/internal/ai	0.020s
ok  	github.com/wcatz/ghost/internal/bench	1.262s
ok  	github.com/wcatz/ghost/internal/claudeimport	0.012s
ok  	github.com/wcatz/ghost/internal/config	0.008s
ok  	github.com/wcatz/ghost/internal/embedding	0.114s
ok  	github.com/wcatz/ghost/internal/linking	0.021s
ok  	github.com/wcatz/ghost/internal/mcpinit	0.153s
ok  	github.com/wcatz/ghost/internal/mcpserver	0.207s
ok  	github.com/wcatz/ghost/internal/memory	0.263s
ok  	github.com/wcatz/ghost/internal/obsidian	0.208s
?   	github.com/wcatz/ghost/internal/provider	[no test files]
ok  	github.com/wcatz/ghost/internal/reflection	0.002s
ok  	github.com/wcatz/ghost/internal/resolve	0.004s
ok  	github.com/wcatz/ghost/internal/selfupdate	0.006s
ok  	github.com/wcatz/ghost/internal/supersede	44.191s
```

Note: CI's `build-and-test` check may show an unrelated `govulncheck` failure about go1.26.5 stdlib CVEs — pre-existing, already addressed by a separate not-yet-merged PR (#294), unrelated to this change.