### PR TITLE
fix(memory): acquire read lock in GetMemoryContent

### DIFF
--- a/internal/memory/vector.go
+++ b/internal/memory/vector.go
@@ -60,6 +60,9 @@ func (s *Store) UnembeddedMemoryIDs(ctx context.Context, projectID string, limit
 
 // GetMemoryContent returns the content of a memory by ID.
 func (s *Store) GetMemoryContent(ctx context.Context, id string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	var content string
 	err := s.db.QueryRowContext(ctx, `SELECT content FROM memories WHERE id = ?`, id).Scan(&content)
 	return content, err


### PR DESCRIPTION
Fixes #285

## Problem

`GetMemoryContent` (`internal/memory/vector.go`) was the only method in that
file missing the `s.mu.RLock()` / `defer s.mu.RUnlock()` guard that every
sibling read method (`SearchVector`, `GetByIDs`, `SearchVectorAll`, and every
read method in `store.go` such as `CountMemories`, `GetLearnedContext`,
`SearchFTS`, etc.) already acquires.

## Fix

Added the same `s.mu.RLock()` / `defer s.mu.RUnlock()` pair at the top of the
function body, matching the exact style used by same-shaped single-query
methods like `CountMemories` and `GetLearnedContext`:

```go
func (s *Store) GetMemoryContent(ctx context.Context, id string) (string, error) {
	s.mu.RLock()
	defer s.mu.RUnlock()

	var content string
	err := s.db.QueryRowContext(ctx, `SELECT content FROM memories WHERE id = ?`, id).Scan(&content)
	return content, err
}
```

Currently a no-op behaviorally: `OpenDB` sets `db.SetMaxOpenConns(1)`
(`internal/memory/schema.go:224`), which already serializes all SQLite access
within the process. This is a pure consistency fix so the locking model
doesn't silently drift if that connection-pool setting ever changes.

**Reentrancy checked:** the only callers of `GetMemoryContent` are external to
package `memory` (`internal/embedding/worker.go` via the `provider.MemoryStore`
interface, plus its mock). No code path inside package `memory` calls
`GetMemoryContent` while already holding `s.mu`, so adding `RLock` here cannot
self-deadlock against an already-locked caller (the risk the package's own
comments flag elsewhere, e.g. `Upsert`'s and `PromoteToGlobal`'s notes on why
`CreateLink`/`EnsureProject` can't be called while `s.mu` is held).

## Scope note (not fixed here, filing only as an observation)

Issue #285 describes `GetMemoryContent` as "the only read method in `Store`
that does not acquire `s.mu.RLock()`." While confirming that, I found it
isn't quite the only one — three more methods touch `s.db` directly with no
lock at all: `UnembeddedMemoryIDs` and `StoreEmbedding`/`DeleteEmbedding` in
the same file (`internal/memory/vector.go`), and `CurrentTimestamp` in
`internal/memory/store.go`. The first three are called by the async embedding
worker (`internal/embedding/worker.go`), so they're arguably a closer miss
than `GetMemoryContent` itself. Left untouched per this task's scope (fixing
only #285) — noting it here rather than expanding the diff.

## Testing

- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all packages pass
- `go test -race ./internal/memory/...` — pass
- `go test -race ./internal/embedding/...` — pass (real caller of `GetMemoryContent`)

No new test was added for the lock itself. `GetMemoryContent` reads exactly
one `Store` field, `s.db`, which is set once in `NewStore` before the `Store`
is shared and never reassigned afterward; the two fields `s.mu` actually
guards elsewhere (`onSave`, `demotionThreshold`) aren't touched by this
method, and `*sql.DB` is internally synchronized by the standard library.
There's no unsynchronized Go-level memory access here for `-race` to catch,
so a concurrent-goroutine test would pass identically with or without the
lock — it would prove nothing about this fix, so I skipped writing one rather
than manufacture a test that can't fail red.

## Known unrelated CI item

CI's `build-and-test` check may show a `govulncheck` failure for go1.26.5
stdlib CVEs — already fixed in a separate, not-yet-merged PR (#294).
Unrelated to this change; not touching `go.mod` here.
