### PR TITLE
fix(memory): wrap RecordUsage error with context

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1298,7 +1298,10 @@ func (s *Store) RecordUsage(ctx context.Context, projectID, model string, usage 
 		INSERT INTO token_usage (project_id, model, input_tokens, output_tokens, cache_creation, cache_read, cost_usd)
 		VALUES (?, ?, ?, ?, ?, ?, ?)
 	`, projectID, model, usage.InputTokens, usage.OutputTokens, usage.CacheCreation, usage.CacheRead, usage.CostUSD)
-	return err
+	if err != nil {
+		return fmt.Errorf("record usage: %w", err)
+	}
+	return nil
 }
 
 // TokenUsage for cost tracking.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1497,6 +1497,22 @@ func TestStoreRecordUsage(t *testing.T) {
 	}
 }
 
+func TestStoreRecordUsage_ClosedDB(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	if err := s.db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	err := s.RecordUsage(ctx, testProject, "claude-opus-4-6", TokenUsage{InputTokens: 1})
+	if err == nil {
+		t.Fatal("expected error from RecordUsage on closed DB, got nil")
+	}
+	if !strings.Contains(err.Error(), "record usage") {
+		t.Errorf("expected error to contain %q, got %q", "record usage", err.Error())
+	}
+}
+
 func TestStoreSetOnSave(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- `Store.RecordUsage` (`internal/memory/store.go`) returned the bare error from the `token_usage` INSERT instead of wrapping it, unlike every other `Store` method in the file, which wraps with `fmt.Errorf("<action>: %w", err)`.
- Wraps it as `fmt.Errorf("record usage: %w", err)`, matching the short lowercase action-phrase convention used by neighboring methods (`create memory`, `update memory`, `delete memory`, etc).

Fixes #289

## Test plan
- Added `TestStoreRecordUsage_ClosedDB` in `internal/memory/store_test.go`: closes the DB, calls `RecordUsage`, and asserts the returned error's message contains `"record usage"`.
- Confirmed RED first: before the fix, the test failed with `expected error to contain "record usage", got "sql: database is closed"` — i.e. an error existed but lacked the wrap context.
- After the fix: GREEN.
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test -race -count=1 ./...` — all packages pass (matches CI's `build-and-test` test invocation)
- Verified no other code in the repo calls `RecordUsage` and re-wraps its error, so this doesn't introduce double-prefixed messages (`grep -rn "RecordUsage" --include='*.go' .` — only the interface declaration in `internal/provider/provider.go`, the implementation, and tests).

## Note
CI's `build-and-test` check may show an unrelated `govulncheck` failure (go1.26.5 stdlib CVEs). This is already fixed in a separate, not-yet-merged PR (#294); not touched here.