### PR TITLE
fix(memory): log swallowed ghost_state insert error in SeedGlobalMemories

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -111,7 +111,9 @@ func (s *Store) SeedGlobalMemories(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("ensure _global project: %w", err)
 	}
-	_, _ = s.db.ExecContext(ctx, `INSERT OR IGNORE INTO ghost_state (project_id) VALUES ('_global')`)
+	if _, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO ghost_state (project_id) VALUES ('_global')`); err != nil {
+		s.logger.Warn("seed global ghost_state insert failed", "error", err)
+	}
 
 	for _, seed := range defaultSeedMemories {
 		// Skip if content already exists in _global (exact match).

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
@@ -2129,6 +2130,41 @@ func TestSeedGlobalMemories(t *testing.T) {
 	}
 	if !seedSurvived {
 		t.Error("seed memory was deleted by ReplaceNonManual — consolidation protection broken")
+	}
+}
+
+// TestSeedGlobalMemories_GhostStateInsertFailureLogged covers issue #291:
+// the ghost_state seed insert's error was discarded via `_, _ =`. The
+// ghost_state table is renamed away before calling SeedGlobalMemories so
+// that specific INSERT OR IGNORE fails deterministically ("no such table"),
+// while the preceding "ensure _global project" statement (projects table,
+// already error-checked) and the seed-memory insert loop (memories table)
+// are unaffected and still succeed.
+func TestSeedGlobalMemories_GhostStateInsertFailureLogged(t *testing.T) {
+	db, err := OpenDB(":memory:")
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	s := NewStore(db, logger)
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `ALTER TABLE ghost_state RENAME TO ghost_state_broken`); err != nil {
+		t.Fatalf("rename ghost_state: %v", err)
+	}
+
+	// Non-fatal: the issue treats a missing ghost_state row as acceptable
+	// (GetLearnedContext just sees sql.ErrNoRows), so SeedGlobalMemories
+	// must still return nil even though the insert failed underneath.
+	if err := s.SeedGlobalMemories(ctx); err != nil {
+		t.Fatalf("SeedGlobalMemories should not return a hard error, got: %v", err)
+	}
+
+	if !strings.Contains(logBuf.String(), "seed global ghost_state insert failed") {
+		t.Errorf("expected ghost_state insert failure to be logged, got log output: %q", logBuf.String())
 	}
 }
 


### PR DESCRIPTION
Fixes #291

## Bug

`SeedGlobalMemories` (internal/memory/store.go) fully discarded the error from the `ghost_state` seed insert:

```go
_, _ = s.db.ExecContext(ctx, `INSERT OR IGNORE INTO ghost_state (project_id) VALUES ('_global')`)
```

Per the issue, impact of a failure here is low — a missing `ghost_state` row for `_global` just makes `GetLearnedContext` see `sql.ErrNoRows`, treated as empty context, which is acceptable — but silently swallowing the error on a one-time seed operation risks masking a real problem (e.g. an FK constraint issue on a corrupted `projects` table).

## Fix

Check the error and log it at Warn level, matching the established style used a few lines below for the per-seed-memory insert failure (`s.logger.Warn("seed memory insert failed", "content", seed.Content, "error", err)`):

```go
if _, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO ghost_state (project_id) VALUES ('_global')`); err != nil {
    s.logger.Warn("seed global ghost_state insert failed", "error", err)
}
```

The function still does not return this as a hard error — per the issue, logging is the ask, not escalation.

## Test

Added `TestSeedGlobalMemories_GhostStateInsertFailureLogged`, which renames the `ghost_state` table away before calling `SeedGlobalMemories` so that specific `INSERT OR IGNORE` fails deterministically ("no such table"), while the preceding "ensure _global project" statement (projects table, already error-checked) and the seed-memory insert loop (memories table) are unaffected and still succeed. Asserts the failure is logged via a `bytes.Buffer`-backed `slog.TextHandler`, following the same style as `internal/obsidian/sync_test.go`'s log-capture pattern.

Watched it fail first (empty log buffer, since the error was discarded), then implemented the fix, then watched it pass.

## Found but out of scope

While reading this function, `PromoteToGlobal` (same file) has the identical unfixed pattern:

```go
_, _ = s.db.ExecContext(ctx, `INSERT OR IGNORE INTO ghost_state (project_id) VALUES ('_global')`)
```

That instance wasn't filed as its own issue, so it's intentionally untouched here — flagging it for separate triage.

## Verification

`go vet ./...`, `go build ./...`, and `go test ./...` all clean (full suite, all packages).

Note: CI's `build-and-test` check may show an unrelated `govulncheck` failure (go1.26.5 stdlib CVEs) — already fixed in a separate, not-yet-merged PR (#294). Not touched here.