### PR TITLE
fix(mcpserver,memory): add ownership check and RowsAffected guard to memory pin

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -1279,29 +1279,48 @@ func (s *Server) registerTools() {
 
 	// ghost_memory_pin — pin or unpin a memory.
 	type pinArgs struct {
-		MemoryID string `json:"memory_id" jsonschema:"ID of the memory to pin/unpin"`
-		Pinned   bool   `json:"pinned" jsonschema:"true to pin, false to unpin"`
+		ProjectID string `json:"project_id" jsonschema:"Project name the memory belongs to (required for ownership check)"`
+		MemoryID  string `json:"memory_id" jsonschema:"ID of the memory to pin/unpin"`
+		Pinned    bool   `json:"pinned" jsonschema:"true to pin, false to unpin"`
 	}
 
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_memory_pin",
 		Title:       "Pin/Unpin Memory",
-		Description: "Pin or unpin a memory. Pinned memories always appear at top of project context and survive reflection pruning. Pin non-negotiable rules, security constraints, or core architectural invariants.",
+		Description: "Pin or unpin a memory. Requires project_id to verify ownership — you cannot pin memories from other projects. Pinned memories always appear at top of project context and survive reflection pruning. Pin non-negotiable rules, security constraints, or core architectural invariants.",
 		Annotations: &mcp.ToolAnnotations{
 			DestructiveHint: boolPtr(false),
 			IdempotentHint:  true,
 			OpenWorldHint:   boolPtr(false),
 		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args pinArgs) (*mcp.CallToolResult, any, error) {
-		if args.MemoryID == "" {
-			return nil, nil, fmt.Errorf("memory_id is required")
+		if args.ProjectID == "" || args.MemoryID == "" {
+			return nil, nil, fmt.Errorf("project_id and memory_id are required")
 		}
+		resolvedProjectID, _, err := s.store.ResolveProject(ctx, args.ProjectID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve project: %w", err)
+		}
+		if resolvedProjectID == "" {
+			return nil, nil, fmt.Errorf("project %q not found", args.ProjectID)
+		}
+
+		// Verify the memory exists and belongs to the specified project.
+		mems, err := s.store.GetByIDs(ctx, []string{args.MemoryID})
+		if err != nil {
+			return nil, nil, fmt.Errorf("lookup failed: %w", err)
+		}
+		if len(mems) == 0 {
+			return nil, nil, fmt.Errorf("memory %s not found", args.MemoryID)
+		}
+		if mems[0].ProjectID != resolvedProjectID {
+			return nil, nil, fmt.Errorf("memory %s does not belong to project %s", args.MemoryID, args.ProjectID)
+		}
+
 		if err := s.store.TogglePin(ctx, args.MemoryID, args.Pinned); err != nil {
 			return nil, nil, fmt.Errorf("toggle pin: %w", err)
 		}
-		if mems, err := s.store.GetByIDs(ctx, []string{args.MemoryID}); err == nil && len(mems) > 0 {
-			s.notifyProjectResource(ctx, mems[0].ProjectID, "context")
-		}
+		s.notifyProjectResource(ctx, resolvedProjectID, "context")
 		action := "pinned"
 		if !args.Pinned {
 			action = "unpinned"

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -508,6 +508,77 @@ func TestDeleteMemory_EndToEnd(t *testing.T) {
 	}
 }
 
+func TestGhostMemoryPin_EndToEnd(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	id, err := store.Create(ctx, "abc123", memory.Memory{
+		Category: "decision", Content: "pin me", Source: "mcp", Importance: 0.5, Tags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_memory_pin",
+		Arguments: map[string]any{"project_id": "test-project", "memory_id": id, "pinned": true},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_memory_pin: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error result: %+v", result.Content)
+	}
+
+	mems, err := store.GetByIDs(ctx, []string{id})
+	if err != nil || len(mems) != 1 {
+		t.Fatalf("GetByIDs: %v (n=%d)", err, len(mems))
+	}
+	if !mems[0].Pinned {
+		t.Error("expected memory to be pinned")
+	}
+}
+
+func TestGhostMemoryPin_RejectsWrongProject(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	if err := store.EnsureProject(ctx, "other", "/tmp/other-pin", "other"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+	id, err := store.Create(ctx, "abc123", memory.Memory{
+		Category: "decision", Content: "do not pin from another project", Source: "mcp", Importance: 0.5, Tags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_memory_pin",
+		Arguments: map[string]any{"project_id": "other", "memory_id": id, "pinned": true},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_memory_pin: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected ownership rejection, got: %+v", result.Content)
+	}
+
+	mems, err := store.GetByIDs(ctx, []string{id})
+	if err != nil || len(mems) != 1 {
+		t.Fatalf("GetByIDs: %v (n=%d)", err, len(mems))
+	}
+	if mems[0].Pinned {
+		t.Error("pin state must be unchanged after rejected cross-project pin")
+	}
+}
+
 func TestSearchAll_CrossProject(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -927,10 +927,20 @@ func (s *Store) TogglePin(ctx context.Context, id string, pinned bool) error {
 	if pinned {
 		pinnedInt = 1
 	}
-	_, err := s.db.ExecContext(ctx, `
+	res, err := s.db.ExecContext(ctx, `
 		UPDATE memories SET pinned = ?, updated_at = datetime('now') WHERE id = ?
 	`, pinnedInt, id)
-	return err
+	if err != nil {
+		return fmt.Errorf("toggle pin: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("toggle pin rows: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("memory %s not found", id)
+	}
+	return nil
 }
 
 // CurrentTimestamp returns the database's own notion of "now", formatted

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -862,6 +862,13 @@ func TestStoreTogglePin(t *testing.T) {
 	if all[0].Pinned {
 		t.Error("expected not pinned after TogglePin(false)")
 	}
+
+	// Toggling pin on a non-existent memory should return an error, not
+	// silently succeed with zero rows affected.
+	err = s.TogglePin(ctx, "nonexistent-id", true)
+	if err == nil {
+		t.Error("expected error toggling pin on non-existent memory")
+	}
 }
 
 func TestStoreGetTopMemories(t *testing.T) {


### PR DESCRIPTION
Fixes #283

## Root cause

Two related gaps in `ghost_memory_pin`, both in `internal/mcpserver/mcpserver.go` / `internal/memory/store.go`:

1. **No ownership check.** `pinArgs` only declared `memory_id` and `pinned` — no `project_id`. Every other mutation tool (`ghost_memory_delete`, `ghost_memory_update`, `ghost_memory_promote`) requires `project_id` and verifies the memory belongs to that project before writing. Pin was the outlier: any session could pin/unpin any memory by ID regardless of which project it belonged to.
2. **No RowsAffected check.** `Store.TogglePin` ran a bare `UPDATE memories SET pinned = ? ... WHERE id = ?` and discarded the result. Pinning a nonexistent memory ID silently returned `nil` (and the tool replied "Memory pinned.") even though zero rows changed.

## Fix

**`internal/mcpserver/mcpserver.go`** — `pinArgs` gains a `ProjectID string` field (identical `jsonschema` tag to `deleteArgs.ProjectID`). The handler now mirrors `ghost_memory_delete` exactly: resolve `project_id` via `ResolveProject`, error if not found; look up the memory via `GetByIDs`, error if not found; compare `mems[0].ProjectID` against the resolved project ID, error on mismatch; only then call `TogglePin`. The tool `Description` now states the ownership requirement, matching `ghost_memory_delete`'s phrasing. The stale post-write `GetByIDs` (used only to find the project ID for the resource-update notification) is gone — the already-resolved project ID is reused, same as delete's handler.

**`internal/memory/store.go`** — `TogglePin` now checks `RowsAffected()` after the `UPDATE` and returns `fmt.Errorf("memory %s not found", id)` when it's 0, matching `PromoteToGlobal`'s existing pattern. This is an independent, second layer of defense underneath the MCP-level ownership check.

## Breaking change (intentional, matches the issue's ask)

`project_id` is now a **required** field on `ghost_memory_pin`. The go-sdk enforces the generated JSON schema strictly, so any caller sending only `memory_id`/`pinned` (the old shape) now gets a schema-validation error rather than being silently ignored. This is the same contract `ghost_memory_delete`, `ghost_memory_update`, and `ghost_memory_promote` already impose.

One consequence worth flagging: pinning a `_global` memory now requires passing `project_id: "_global"` (or `"global"` by name), where previously `memory_id` alone was sufficient. This matches delete's existing semantics for global memories — not a new inconsistency, just pin catching up.

## Tests

TDD throughout — each new/extended test was watched failing against the pre-fix code before implementing:

- `internal/memory/store_test.go`: extended `TestStoreTogglePin` with a case asserting `TogglePin` on a nonexistent ID returns an error instead of silently succeeding. (Confirmed red pre-fix, green post-fix.)
- `internal/mcpserver/mcpserver_test.go`: two new end-to-end tests using the real MCP wire protocol (`connectedClient` + `session.CallTool`), mirroring the existing `TestGhostTaskCreate_RejectsUnknownProject` / `TestApplyMemoryUpdate` "rejects wrong project" style:
  - `TestGhostMemoryPin_EndToEnd` — pin succeeds when `project_id` matches the memory's actual project; asserts `Pinned == true` afterward.
  - `TestGhostMemoryPin_RejectsWrongProject` — pin is rejected (`result.IsError`) when `project_id` names a different, valid project; asserts the memory's pin state is unchanged afterward (proves no write happened, not just that an error came back).

I additionally ran a mutation check (temporarily disabled just the ownership-mismatch comparison, reran) to confirm `TestGhostMemoryPin_RejectsWrongProject` fails for the right reason — a missing ownership check — rather than passing as an accident of schema validation. It failed as expected, then I restored the real fix.

## Docs

Grepped the whole repo (not just `*.go`/`*.md`) for `ghost_memory_pin`. The only non-code hits are name-only tool listings (`README.md:241`, two dated `docs/superpowers/plans/*.md` files) and a permission allowlist (`internal/mcpinit/settings.go:20`) — none document the tool's argument/call signature, so none needed updating. `internal/mcpserver/mcpserver.go:1182`'s decision-record hint text ("...with `ghost_memory_pin` or `ghost_memory_update`") also needs no edit — `ghost_memory_update` already requires `project_id` and that sentence doesn't spell out either tool's arguments, so pin is now consistent with the parity that text already assumed.

## Verification

```
go vet ./...     # clean
go build ./...   # clean
go test ./...    # all packages ok, including internal/mcpserver and internal/memory
```

## Noticed, not fixed (out of scope for #283)

- Pin's ownership check is check-then-write (lookup, then a separate `TogglePin` call), same as `ghost_memory_delete`. By contrast, `UpdateMemory` and `PromoteToGlobal` bind `project_id` directly into the `UPDATE`'s `WHERE` clause specifically to close the TOCTOU race where a memory could move projects between the check and the write (see their doc comments). Pin now inherits delete's window by design (this PR mirrors delete exactly, per the issue's instructions) — a follow-up hardening both delete and pin to the atomic-WHERE-clause style would be reasonable.
- `gofmt -l` currently flags `internal/mcpinit/init.go` and `internal/memory/vector.go`. Confirmed via `git stash` that both are already unformatted on `main`, untouched by this change.

## CI note

CI's `build-and-test` check may show an unrelated `govulncheck` failure (go1.26.5 stdlib CVEs). This is already fixed in #294, not yet merged. Not touched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pinning a memory now requires a valid project and prevents cross-project changes.
  * Clear validation errors are shown when the project or memory is missing.
  * Attempts to pin a non-existent memory no longer appear successful.
  * Project updates now remain consistent after rejected pinning attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->