### PR TITLE
fix(mcpinit): align hook busy_timeout with Store

### DIFF
--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -23,6 +23,15 @@ import (
 // read-write and would create a phantom empty ghost.db on first read. The path
 // is URI-escaped so a '?' or '#' in it can't corrupt the query, and no
 // journal_mode pragma is set (a read-only connection cannot write the header).
+//
+// busy_timeout is intentionally left at 1000ms here — shorter than rwDSN's
+// 5000ms below, and deliberately not raised to match it for #288. Store
+// (memory.OpenDB, internal/memory/schema.go) opens the database in WAL mode,
+// which is persisted in the database file itself rather than negotiated per
+// connection, so this connection is in WAL mode too even though it sets no
+// journal_mode pragma of its own. In WAL, a reader does not wait on a
+// concurrent writer for its snapshot, so this path is not exposed to the
+// write-lock contention #288 describes — that fix is scoped to rwDSN.
 func roDSN(dbPath string) string {
 	u := url.URL{
 		Scheme:   "file",
@@ -32,21 +41,34 @@ func roDSN(dbPath string) string {
 	return u.String()
 }
 
+// rwDSN builds a read-write DSN for dbPath, URI-escaped like roDSN. Its
+// busy_timeout matches Store's own (memory.OpenDB, internal/memory/schema.go:
+// busy_timeout(5000)) so a short write from a live MCP server, or from the
+// linking/embedding background workers, can't make a caller on this DSN fail
+// merely because it arrived mid-write (#288: the previous 1000ms could time
+// out and return 0 under contention that 5000ms rides out).
+func rwDSN(dbPath string) string {
+	u := url.URL{
+		Scheme:   "file",
+		Opaque:   (&url.URL{Path: dbPath}).EscapedPath(),
+		RawQuery: "_pragma=busy_timeout(5000)",
+	}
+	return u.String()
+}
+
 // bumpSessionCount increments the project's session counter and returns the
 // new count, or 0 on any failure. It is the session hook's single deliberate
-// write: its own short-lived read-write connection (URI-escaped like roDSN,
-// busy_timeout so a live MCP server never blocks it for long), guarded by an
-// existence check so a missing database is never created.
+// write: its own short-lived read-write connection (rwDSN — URI-escaped like
+// roDSN, busy_timeout matching Store's so a live MCP server's own write can't
+// make this fail under ordinary contention), guarded by an existence check so
+// a missing database is never created. Still best-effort: on any failure
+// (contention that outlasts even 5s, permissions) the stale stored count is
+// shown instead.
 func bumpSessionCount(dbPath, projectID string) int {
 	if _, err := os.Stat(dbPath); err != nil {
 		return 0
 	}
-	u := url.URL{
-		Scheme:   "file",
-		Opaque:   (&url.URL{Path: dbPath}).EscapedPath(),
-		RawQuery: "_pragma=busy_timeout(1000)",
-	}
-	db, err := sql.Open("sqlite", u.String())
+	db, err := sql.Open("sqlite", rwDSN(dbPath))
 	if err != nil {
 		return 0
 	}

--- a/internal/mcpinit/hook_test.go
+++ b/internal/mcpinit/hook_test.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wcatz/ghost/internal/memory"
 	_ "modernc.org/sqlite"
@@ -560,6 +562,173 @@ func TestBumpSessionCountNoPhantomDB(t *testing.T) {
 	}
 	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
 		t.Errorf("bumpSessionCount must not create %s", dbPath)
+	}
+}
+
+// TestDSNBusyTimeoutValues locks in the deliberate #288 asymmetry: the write
+// path's busy_timeout now matches Store's (memory.OpenDB, busy_timeout(5000)),
+// while the read path stays at the original 1000ms — a reader never blocks on
+// a concurrent writer under Store's WAL journal mode, so it was never exposed
+// to the write-contention failure #288 reported. A future edit that silently
+// drifts either value, or flips mode=ro, should fail this test.
+func TestDSNBusyTimeoutValues(t *testing.T) {
+	const dbPath = "/unused/ghost.db" // DSN string shape only - never opened
+
+	ro := roDSN(dbPath)
+	if !strings.Contains(ro, "busy_timeout(1000)") {
+		t.Errorf("roDSN = %q, want it to contain busy_timeout(1000)", ro)
+	}
+	if !strings.Contains(ro, "mode=ro") {
+		t.Errorf("roDSN = %q, want it to contain mode=ro", ro)
+	}
+
+	rw := rwDSN(dbPath)
+	if !strings.Contains(rw, "busy_timeout(5000)") {
+		t.Errorf("rwDSN = %q, want it to contain busy_timeout(5000)", rw)
+	}
+	if strings.Contains(rw, "mode=ro") {
+		t.Errorf("rwDSN = %q, must not be read-only", rw)
+	}
+}
+
+// TestBumpSessionCountSurvivesWriteContention proves the #288 fix: a
+// concurrent writer — standing in for a live MCP server, or the
+// linking/embedding background workers — holding SQLite's single write lock
+// for longer than the old 1000ms busy_timeout, but less than the new 5000ms,
+// must no longer make the bump fail. Uses a real file-backed database and a
+// genuine BEGIN IMMEDIATE lock: busy_timeout is a real SQLite locking
+// behavior, not something a fake connection could stand in for.
+func TestBumpSessionCountSurvivesWriteContention(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "ghost.db")
+
+	db, err := memory.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	insertProject(t, db, "p1", "/tmp/contend-new", "contend-new")
+	db.Close() //nolint:errcheck
+
+	// Longer than the old 1000ms busy_timeout, comfortably short of the new
+	// 5000ms one.
+	const holdTime = 2 * time.Second
+
+	blocker, err := sql.Open("sqlite", rwDSN(dbPath))
+	if err != nil {
+		t.Fatalf("open blocker: %v", err)
+	}
+	defer blocker.Close() //nolint:errcheck
+
+	conn, err := blocker.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Conn: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	// BEGIN IMMEDIATE (rather than a plain deferred BEGIN) grabs SQLite's
+	// write lock right away instead of waiting for the first write statement,
+	// so the hold below is deterministic from this point on.
+	if _, err := conn.ExecContext(context.Background(), "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("BEGIN IMMEDIATE: %v", err)
+	}
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		time.Sleep(holdTime)
+		if _, err := conn.ExecContext(context.Background(), "COMMIT"); err != nil {
+			t.Errorf("release COMMIT: %v", err)
+		}
+	}()
+
+	start := time.Now()
+	n := bumpSessionCount(dbPath, "p1")
+	elapsed := time.Since(start)
+	<-released
+
+	if n == 0 {
+		t.Fatalf("bumpSessionCount failed under %v of write contention; want it to ride out the lock now that it uses busy_timeout(5000)", holdTime)
+	}
+	if elapsed < holdTime {
+		t.Errorf("bumpSessionCount returned after %v, before the %v lock was even released — busy_timeout may not be taking effect", elapsed, holdTime)
+	}
+}
+
+// TestOldBusyTimeoutFailsUnderSameContention documents the #288 regression
+// directly: the exact DSN bumpSessionCount used before this fix
+// (busy_timeout(1000), reconstructed verbatim here since rwDSN now reports
+// 5000ms) does time out and fail under the same write contention that
+// TestBumpSessionCountSurvivesWriteContention proves the new value survives —
+// this is the "silently returns 0, showing a stale session count" symptom
+// #288 reported.
+func TestOldBusyTimeoutFailsUnderSameContention(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "ghost.db")
+
+	db, err := memory.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	insertProject(t, db, "p1", "/tmp/contend-old", "contend-old")
+	db.Close() //nolint:errcheck
+
+	const holdTime = 2 * time.Second // > old 1000ms busy_timeout
+
+	blocker, err := sql.Open("sqlite", rwDSN(dbPath))
+	if err != nil {
+		t.Fatalf("open blocker: %v", err)
+	}
+	defer blocker.Close() //nolint:errcheck
+
+	conn, err := blocker.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Conn: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	if _, err := conn.ExecContext(context.Background(), "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("BEGIN IMMEDIATE: %v", err)
+	}
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		time.Sleep(holdTime)
+		if _, err := conn.ExecContext(context.Background(), "COMMIT"); err != nil {
+			t.Errorf("release COMMIT: %v", err)
+		}
+	}()
+
+	oldDSN := url.URL{
+		Scheme:   "file",
+		Opaque:   (&url.URL{Path: dbPath}).EscapedPath(),
+		RawQuery: "_pragma=busy_timeout(1000)",
+	}
+	oldDB, err := sql.Open("sqlite", oldDSN.String())
+	if err != nil {
+		t.Fatalf("open with pre-#288 DSN: %v", err)
+	}
+	defer oldDB.Close() //nolint:errcheck
+
+	start := time.Now()
+	var n int
+	err = oldDB.QueryRow(`
+		INSERT INTO ghost_state (project_id, interaction_count)
+		VALUES (?, 1)
+		ON CONFLICT(project_id) DO UPDATE SET
+			interaction_count = interaction_count + 1,
+			updated_at = datetime('now')
+		RETURNING interaction_count
+	`, "p1").Scan(&n)
+	elapsed := time.Since(start)
+	<-released
+
+	// The load-bearing assertion is err != nil: that's what proves the old
+	// 1000ms value fails under this contention. Elapsed time is logged, not
+	// asserted on — SQLite's busy handler retries until ~1000ms of
+	// *accumulated* sleep, not a wall-clock guarantee, and a loaded/-race CI
+	// runner can push observed elapsed well past that (see the similar
+	// caveat in internal/obsidian/sync_test.go). Asserting elapsed < holdTime
+	// here would give a test that fails two different ways under slowness.
+	t.Logf("pre-#288 DSN write failed after %v (hold time %v)", elapsed, holdTime)
+	if err == nil {
+		t.Fatalf("expected the pre-#288 busy_timeout(1000) to fail under %v of contention, but it succeeded (n=%d) — the contention setup itself may be wrong", holdTime, n)
 	}
 }
 


### PR DESCRIPTION
Fixes #288

## What was wrong

`bumpSessionCount` (internal/mcpinit/hook.go) opened its own read-write connection with `busy_timeout(1000)` (1s) — much shorter than `Store`'s own `busy_timeout(5000)` (5s, set in `memory.OpenDB`, internal/memory/schema.go:219). Under write contention — a live MCP server mid-write, or the linking/embedding background workers — the bump could hit SQLite's busy timeout and silently return 0, showing a stale "Session #N" count. Non-critical (informational counter only) but worth aligning, per the issue.

## What changed

- Extracted the write DSN into a new `rwDSN(dbPath string)` helper (mirroring the existing `roDSN`), with `busy_timeout(5000)` to match `Store`.
- `bumpSessionCount` now opens via `rwDSN` instead of building its own one-off DSN.
- Updated doc comments on both `roDSN` and `bumpSessionCount` to explain the new reasoning.

## What I deliberately did NOT change

`roDSN` — used by `loadSessionContext`/`loadGlobalMemories` to load session context at hook time — stays at `busy_timeout(1000)`. Reasoning, checked empirically rather than assumed:

- `Store` opens the database with `journal_mode(WAL)`. WAL mode is a property persisted in the database file itself, not negotiated per connection — I verified this directly: opened a DB via `memory.OpenDB` (which sets WAL), closed it, reopened with a bare connection setting no `journal_mode` pragma at all, and `PRAGMA journal_mode;` still reported `wal`.
- In WAL mode, a reader does not wait on a concurrent writer for its snapshot — so `roDSN`'s read path was never exposed to the write-lock contention #288 describes. The fix is scoped to the write path (`rwDSN`).
- It's also outside #288's literal scope, which is specifically about the session bump.

So: this is a real behavior change on the write path, and a deliberate no-op (with a documented reason) on the read path — not a blanket "align everything to 5s."

## Testing (TDD)

Added to `internal/mcpinit/hook_test.go`:

- `TestDSNBusyTimeoutValues` — locks in the DSN string shape: `roDSN` still contains `busy_timeout(1000)` + `mode=ro`; `rwDSN` contains `busy_timeout(5000)` and is not read-only. Guards against silent drift.
- `TestBumpSessionCountSurvivesWriteContention` — real file-backed DB, a second connection takes SQLite's write lock via `BEGIN IMMEDIATE` and holds it for 2s (longer than the old 1s timeout, well under the new 5s one), then `bumpSessionCount` is called concurrently. Asserts it succeeds and that it actually waited for the lock (elapsed >= hold time) rather than returning instantly.
- `TestOldBusyTimeoutFailsUnderSameContention` — same contention setup, but reconstructs the exact pre-fix DSN (`busy_timeout(1000)`) verbatim and proves it fails (times out) under the same 2s hold. This directly demonstrates the #288 regression and that the fix addresses it. (Only asserts `err != nil`, not tight timing, since SQLite's busy handler retries on accumulated sleep rather than wall-clock, and a loaded/`-race` CI runner could otherwise flake either direction — logged via `t.Logf` instead.)

These use a real SQLite write lock, not a mock — busy_timeout is a genuine locking behavior that a fake connection can't stand in for.

## Verification

```
go vet ./...     # clean
go build ./...   # clean
go test ./...    # all packages pass
go test ./internal/mcpinit/... -race -run 'TestDSNBusyTimeoutValues|TestBumpSessionCountSurvivesWriteContention|TestOldBusyTimeoutFailsUnderSameContention|TestBumpSessionCountNoPhantomDB|TestSessionCounterIncrements|TestSessionCounterIgnoresResumeClearCompact' -v
# all PASS, including the contention tests under -race
```

Sample output from the regression-proof test:
```
hook_test.go:729: pre-#288 DSN write failed after 1.016024289s (hold time 2s)
--- PASS: TestOldBusyTimeoutFailsUnderSameContention (2.12s)
```

## Note

CI's `build-and-test` check may show an unrelated `govulncheck` failure (go1.26.5 stdlib CVEs) — already fixed in not-yet-merged #294. Not touched here.

## Out of scope (found, not fixed)

While reading `loadSessionContext`, noticed that a `roDSN` read failure (e.g. permissions, or in principle a busy timeout) renders identically to a genuine "no project matched this directory" — the two cases are indistinguishable to the user. Separate issue, not touched here.