### PR TITLE
fix(embedding,linking): recover from panics in worker loops

### DIFF
--- a/internal/embedding/worker.go
+++ b/internal/embedding/worker.go
@@ -51,12 +51,38 @@ func (w *Worker) Run(ctx context.Context, projectIDs <-chan string) {
 			if !ok {
 				return
 			}
-			w.processProject(ctx, pid)
+			w.safeProcessProject(ctx, pid)
 
 		case <-ticker.C:
-			w.SweepOnce(ctx)
+			w.safeSweepOnce(ctx)
 		}
 	}
+}
+
+// safeProcessProject wraps processProject with panic recovery. A panic here
+// must not escape into Run's select loop: unwinding past Run itself would
+// leave nothing left to fire the loop's next tick/message, so embedding
+// would stop for good even after the panic is otherwise "handled". Recovering
+// inside this small function means control returns to Run — still live —
+// once this call completes, so the loop keeps going on the next iteration.
+func (w *Worker) safeProcessProject(ctx context.Context, projectID string) {
+	defer func() {
+		if r := recover(); r != nil {
+			w.logger.Error("panic in embedding processProject, recovered", "panic", r, "project_id", projectID)
+		}
+	}()
+	w.processProject(ctx, projectID)
+}
+
+// safeSweepOnce wraps SweepOnce with panic recovery for the same reason as
+// safeProcessProject above.
+func (w *Worker) safeSweepOnce(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			w.logger.Error("panic in embedding sweep, recovered", "panic", r)
+		}
+	}()
+	w.SweepOnce(ctx)
 }
 
 // SweepOnce embeds unembedded memories across all projects.

--- a/internal/embedding/worker_test.go
+++ b/internal/embedding/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,6 +23,11 @@ type mockStore struct {
 	memories   map[string]string    // id -> content
 	embeddings map[string][]float32 // id -> vector
 	embModel   map[string]string    // id -> model
+
+	// embedded, if non-nil, receives a memory ID each time StoreEmbedding
+	// successfully stores it. Tests use this to detect — without sleeping —
+	// that the worker loop is still alive and processing work.
+	embedded chan string
 }
 
 func (m *mockStore) ListProjects(_ context.Context) ([]memory.Project, error) {
@@ -71,11 +77,147 @@ func (m *mockStore) GetMemoryContent(_ context.Context, id string) (string, erro
 
 func (m *mockStore) StoreEmbedding(_ context.Context, memoryID string, vec []float32, model string) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.embeddings[memoryID] = vec
 	m.embModel[memoryID] = model
+	notify := m.embedded
+	m.mu.Unlock()
+
+	if notify != nil {
+		select {
+		case notify <- memoryID:
+		default:
+		}
+	}
 	return nil
+}
+
+// panicOnceStore wraps mockStore and panics exactly once — on the first
+// invocation of the named method — before delegating to the real
+// implementation on every call after that (including the retry of that same
+// method). It exists to prove that Run's select loop survives a panic raised
+// deep in one unit of work and keeps processing later ticks/messages, rather
+// than merely proving recover() appears somewhere in the source.
+type panicOnceStore struct {
+	*mockStore
+	method string // "ListProjects" or "UnembeddedMemoryIDs"
+	fired  atomic.Bool
+}
+
+func (p *panicOnceStore) ListProjects(ctx context.Context) ([]memory.Project, error) {
+	if p.method == "ListProjects" && p.fired.CompareAndSwap(false, true) {
+		panic("simulated panic in ListProjects")
+	}
+	return p.mockStore.ListProjects(ctx)
+}
+
+func (p *panicOnceStore) UnembeddedMemoryIDs(ctx context.Context, projectID string, limit int) ([]string, error) {
+	if p.method == "UnembeddedMemoryIDs" && p.fired.CompareAndSwap(false, true) {
+		panic("simulated panic in UnembeddedMemoryIDs")
+	}
+	return p.mockStore.UnembeddedMemoryIDs(ctx, projectID, limit)
+}
+
+// embedOllamaStub returns an httptest server that answers Alive() checks at
+// "/" and Embed() calls at "/api/embed", matching the real Ollama client's
+// request shape (see TestSweepOnce_BackfillsWithoutSaves for the original
+// use of this exact handler).
+func embedOllamaStub() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.WriteHeader(http.StatusOK)
+		case "/api/embed":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"embeddings":[[0.1,0.2,0.3]]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// TestWorkerRun_SurvivesPanicInTickerSweep proves the ticker branch of Run's
+// select loop keeps firing after a panic inside SweepOnce (via ListProjects).
+// Before the fix, the first tick's panic is unrecovered anywhere in the
+// goroutine's call stack, which crashes the whole process; the fix must keep
+// later ticks embedding normally.
+func TestWorkerRun_SurvivesPanicInTickerSweep(t *testing.T) {
+	srv := embedOllamaStub()
+	defer srv.Close()
+
+	base := newMockStore()
+	base.projects = []string{"proj-a"}
+	base.memories["mem-1"] = "pre-existing memory"
+	base.embedded = make(chan string, 1)
+
+	store := &panicOnceStore{mockStore: base, method: "ListProjects"}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewClient(srv.URL, "test-model", 3)
+	worker := NewWorker(client, store, logger, 20*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	projectIDs := make(chan string)
+
+	done := make(chan struct{})
+	go func() {
+		worker.Run(ctx, projectIDs)
+		close(done)
+	}()
+
+	select {
+	case id := <-base.embedded:
+		if id != "mem-1" {
+			t.Fatalf("embedded %q, want mem-1", id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not embed after a panic on the first sweep tick — ticker loop likely died")
+	}
+
+	cancel()
+	<-done
+}
+
+// TestWorkerRun_SurvivesPanicInChannelProcessProject proves the projectIDs
+// channel branch of Run's select loop keeps firing after a panic inside
+// processProject (via UnembeddedMemoryIDs). The ticker interval is set to
+// 24h so this test isolates the channel path from the sweep path.
+func TestWorkerRun_SurvivesPanicInChannelProcessProject(t *testing.T) {
+	srv := embedOllamaStub()
+	defer srv.Close()
+
+	base := newMockStore()
+	base.memories["mem-1"] = "content triggered via save notification"
+	base.embedded = make(chan string, 1)
+
+	store := &panicOnceStore{mockStore: base, method: "UnembeddedMemoryIDs"}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewClient(srv.URL, "test-model", 3)
+	worker := NewWorker(client, store, logger, 24*time.Hour) // ticker must not fire
+
+	ctx, cancel := context.WithCancel(context.Background())
+	projectIDs := make(chan string, 2)
+
+	done := make(chan struct{})
+	go func() {
+		worker.Run(ctx, projectIDs)
+		close(done)
+	}()
+
+	projectIDs <- "proj-a" // triggers the panic inside processProject
+	projectIDs <- "proj-a" // must still be processed if the loop survived
+
+	select {
+	case id := <-base.embedded:
+		if id != "mem-1" {
+			t.Fatalf("embedded %q, want mem-1", id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not embed after a panic on the first channel message — loop likely died")
+	}
+
+	cancel()
+	<-done
 }
 
 func TestEmbedOne_HappyPath(t *testing.T) {

--- a/internal/linking/worker.go
+++ b/internal/linking/worker.go
@@ -51,9 +51,24 @@ func (w *Worker) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			w.SweepOnce(ctx)
+			w.safeSweepOnce(ctx)
 		}
 	}
+}
+
+// safeSweepOnce wraps SweepOnce with panic recovery. A panic here must not
+// escape into Run's select loop: unwinding past Run itself would leave
+// nothing left to fire the loop's next tick, so linking would stop for good
+// even after the panic is otherwise "handled". Recovering inside this small
+// function means control returns to Run — still live — once this call
+// completes, so the loop keeps going on the next tick.
+func (w *Worker) safeSweepOnce(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			w.logger.Error("panic in linking sweep, recovered", "panic", r)
+		}
+	}()
+	w.SweepOnce(ctx)
 }
 
 // SweepOnce links unscanned embedded memories across all projects.

--- a/internal/linking/worker_test.go
+++ b/internal/linking/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -86,4 +87,70 @@ func TestSweepOnceLinksSimilarMemories(t *testing.T) {
 	if len(ids) != 0 {
 		t.Fatalf("got %d unscanned after sweep, want 0", len(ids))
 	}
+}
+
+// panicOnceStore wraps a real *memory.Store, panicking exactly once — on the
+// first call to ListProjects — before delegating to the real implementation
+// on every call after that. It also observes MarkLinkScanned so the test can
+// detect (without sleeping) that a later sweep tick actually completed
+// processing, proving the worker loop is still alive rather than merely
+// proving recover() appears somewhere in the source.
+type panicOnceStore struct {
+	*memory.Store
+	fired   atomic.Bool
+	scanned chan string
+}
+
+func (p *panicOnceStore) ListProjects(ctx context.Context) ([]memory.Project, error) {
+	if p.fired.CompareAndSwap(false, true) {
+		panic("simulated panic in ListProjects")
+	}
+	return p.Store.ListProjects(ctx)
+}
+
+func (p *panicOnceStore) MarkLinkScanned(ctx context.Context, memoryID string) error {
+	err := p.Store.MarkLinkScanned(ctx, memoryID)
+	if err == nil && p.scanned != nil {
+		select {
+		case p.scanned <- memoryID:
+		default:
+		}
+	}
+	return err
+}
+
+// TestRun_SurvivesPanicInTickerSweep proves Run's ticker branch keeps firing
+// after a panic inside SweepOnce (via ListProjects). Before the fix, the
+// first tick's panic is unrecovered anywhere in the goroutine's call stack,
+// which crashes the whole process; the fix must keep later ticks scanning
+// normally.
+func TestRun_SurvivesPanicInTickerSweep(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	id := addEmbedded(t, s, "SQLite WAL journal mode", []float32{1, 0, 0.1})
+
+	store := &panicOnceStore{Store: s, scanned: make(chan string, 1)}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	w := NewWorker(store, logger, 20*time.Millisecond, 0.70)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		w.Run(runCtx)
+		close(done)
+	}()
+
+	select {
+	case got := <-store.scanned:
+		if got != id {
+			t.Fatalf("scanned %q, want %q", got, id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not mark the memory scanned after a panic on the first sweep tick — ticker loop likely died")
+	}
+
+	cancel()
+	<-done
 }


### PR DESCRIPTION
Fixes #278

## Root cause

Both `internal/embedding/worker.go`'s `(*Worker).Run` and `internal/linking/worker.go`'s `(*Worker).Run` run a `for { select { ... } }` loop on a ticker, calling `SweepOnce`/`processProject` with zero panic recovery anywhere in the call chain.

`cmd/ghost/main.go` starts both with a bare, unwrapped goroutine spawn:

```go
go embedWorker.Run(ctx, projectCh)
...
go linkWorker.Run(ctx)
```

So the actual pre-fix failure mode is worse than the issue describes: an unrecovered panic in a goroutine is not scoped to that goroutine — it is unhandled all the way up the stack and **crashes the entire `ghost mcp` process**. The issue's stated symptom ("the process keeps running... with no crash") would require something further up the stack to already be recovering; nothing does. I did not add recovery at the `main.go` spawn sites — out of scope for this fix, and it would in fact be the same wrong pattern described below.

## Why a naive top-level recover doesn't work

`recover()` only stops a panic if the deferred function calling it is in a frame the panic unwinds through, and execution resumes **after the function that owns that defer returns** — not where the panic happened. A single `defer func(){ recover() }()` at the top of `Run()` would catch the panic, but `Run()` would then return for good — the ticker loop stops forever, silently, on the very first panic. That trades a process crash for the originally-reported symptom; it doesn't fix it.

## Fix

Each unit of work invoked from inside the `select` gets its own defer/recover, so a recovered panic returns control to the *caller* — still inside `Run()`'s live loop — and the next tick/message is processed normally:

- `internal/embedding/worker.go`: added `safeProcessProject` (wraps the channel-message case) and `safeSweepOnce` (wraps the ticker case), both logging via the existing `w.logger`.
- `internal/linking/worker.go`: added `safeSweepOnce` (wraps the ticker case — linking's `Run` has no channel branch).

## Tests

Added tests proving the loop **survives** a panic and keeps processing subsequent work, not just that `recover()` exists in the source:

- `TestWorkerRun_SurvivesPanicInTickerSweep` / `TestWorkerRun_SurvivesPanicInChannelProcessProject` (embedding) — a `panicOnceStore` wrapper panics exactly once on the first call to `ListProjects` (ticker path) or `UnembeddedMemoryIDs` (channel path), then behaves normally. The test asserts a *later* tick/message still completes a real embedding, synchronized via a signal channel (no sleep-polling).
- `TestRun_SurvivesPanicInTickerSweep` (linking) — same pattern wrapping a real `*memory.Store`, panicking once on `ListProjects`, asserting a later sweep still marks the memory scanned.

**Discrimination check** (requested in the issue): I temporarily replaced both fixes with the naive top-level `defer recover()` in `Run()` and reran these tests — they failed cleanly on the 2s timeout ("loop likely died"), not a crash. That's the evidence these tests catch "recover exists but the loop is dead," not just "recover exists somewhere." Reverted after confirming, then reconfirmed green on the real fix.

### Verification output

Red (pre-fix, isolated per test — an unrecovered panic aborts the whole test binary, so `-run` was scoped to one new test at a time):
```
panic: simulated panic in ListProjects
...
FAIL	github.com/wcatz/ghost/internal/embedding	0.026s
```
(same crash pattern for the channel-path and linking tests)

Naive-top-level-recover check (temporary, reverted):
```
--- FAIL: TestWorkerRun_SurvivesPanicInTickerSweep (2.00s)
    worker_test.go:173: worker did not embed after a panic on the first sweep tick — ticker loop likely died
--- FAIL: TestWorkerRun_SurvivesPanicInChannelProcessProject (2.00s)
    worker_test.go:216: worker did not embed after a panic on the first channel message — loop likely died
--- FAIL: TestRun_SurvivesPanicInTickerSweep (2.00s)
    worker_test.go:151: worker did not mark the memory scanned after a panic on the first sweep tick — ticker loop likely died
```

Green (actual fix), `-race -count=20` on the new tests, no flakiness:
```
ok  	github.com/wcatz/ghost/internal/embedding	2.007s
ok  	github.com/wcatz/ghost/internal/linking	4.075s
```

Full suite:
```
go build ./...   -> clean
go vet ./...     -> clean
go test ./...    -> ok, all packages
```

## Note on CI

The `build-and-test` check may show an unrelated `govulncheck` failure (go1.26.5 stdlib CVEs). That's already fixed in a separate, not-yet-merged PR #294 — unrelated to this change, and go.mod is untouched here.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race -count=20 ./internal/embedding/... ./internal/linking/...` on the new tests — no flakiness
- [x] Confirmed new tests fail (crash) pre-fix and fail (clean timeout) against a naive top-level-recover variant
- [ ] Not merging per instructions