### PR TITLE
fix(memory): stop swallowing errors in EnsureProject's duplicate-merge paths

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -190,20 +190,13 @@ func (s *Store) EnsureProject(ctx context.Context, id, path, name string) error 
 			`SELECT id FROM projects WHERE path = ? AND id != ? LIMIT 1`,
 			path, id).Scan(&existingID)
 		if scanErr == nil && existingID != "" {
-			// Merge any child records from the incoming ID into the canonical project.
-			for _, stmt := range []string{
-				`UPDATE memories SET project_id = ? WHERE project_id = ?`,
-				`UPDATE conversations SET project_id = ? WHERE project_id = ?`,
-				`UPDATE tasks SET project_id = ? WHERE project_id = ?`,
-				`UPDATE decisions SET project_id = ? WHERE project_id = ?`,
-				`UPDATE token_usage SET project_id = ? WHERE project_id = ?`,
-				`UPDATE audit_log SET project_id = ? WHERE project_id = ?`,
-			} {
-				_, _ = s.db.ExecContext(ctx, stmt, existingID, id)
+			// Merge any child records from the incoming ID into the canonical
+			// project. mergeProjectLocked does not lock internally (only the
+			// public MergeProject wrapper does), so it's safe to call directly
+			// here while we already hold s.mu.
+			if err := s.mergeProjectLocked(ctx, id, existingID); err != nil {
+				return fmt.Errorf("auto-merge path duplicate: %w", err)
 			}
-			_, _ = s.db.ExecContext(ctx, `DELETE FROM ghost_state WHERE project_id = ?`, id)
-			_, _ = s.db.ExecContext(ctx, `DELETE FROM projects WHERE id = ?`, id)
-			s.logger.Info("auto-merged path duplicate", "old_id", id, "canonical_id", existingID, "path", path)
 			return nil
 		}
 	}
@@ -234,20 +227,11 @@ func (s *Store) EnsureProject(ctx context.Context, id, path, name string) error 
 			`SELECT id FROM projects WHERE name = ? AND id != ? AND path NOT LIKE '/%' LIMIT 1`,
 			name, id).Scan(&dupID)
 		if scanErr == nil && dupID != "" {
-			// Use inline merge to avoid deadlock (we already hold s.mu).
-			for _, stmt := range []string{
-				`UPDATE memories SET project_id = ? WHERE project_id = ?`,
-				`UPDATE conversations SET project_id = ? WHERE project_id = ?`,
-				`UPDATE tasks SET project_id = ? WHERE project_id = ?`,
-				`UPDATE decisions SET project_id = ? WHERE project_id = ?`,
-				`UPDATE token_usage SET project_id = ? WHERE project_id = ?`,
-				`UPDATE audit_log SET project_id = ? WHERE project_id = ?`,
-			} {
-				_, _ = s.db.ExecContext(ctx, stmt, id, dupID)
+			// Call mergeProjectLocked directly to avoid deadlock (we already
+			// hold s.mu; only the public MergeProject wrapper locks).
+			if err := s.mergeProjectLocked(ctx, dupID, id); err != nil {
+				return fmt.Errorf("auto-merge duplicate project: %w", err)
 			}
-			_, _ = s.db.ExecContext(ctx, `DELETE FROM ghost_state WHERE project_id = ?`, dupID)
-			_, _ = s.db.ExecContext(ctx, `DELETE FROM projects WHERE id = ?`, dupID)
-			s.logger.Info("auto-merged duplicate project", "old_id", dupID, "new_id", id)
 		}
 	}
 

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2479,6 +2479,124 @@ func TestEnsureProject_AutoMerge(t *testing.T) {
 	}
 }
 
+// TestEnsureProject_AutoMerge_PathCollision covers EnsureProject's *other*
+// auto-merge path: a different incoming id colliding with an absolute path
+// that's already owned by another project (as opposed to
+// TestEnsureProject_AutoMerge, which covers the name/non-absolute-path
+// duplicate case). Guards that the DRY refactor onto mergeProjectLocked
+// preserves this success-path outcome (canonical id survives, incoming id's
+// records are reassigned and its row is gone).
+func TestEnsureProject_AutoMerge_PathCollision(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Canonical project already owns this absolute path.
+	if err := s.EnsureProject(ctx, "hash-original", "/home/wayne/git/pathcollide", "pathcollide"); err != nil {
+		t.Fatalf("EnsureProject original: %v", err)
+	}
+
+	// A second, distinct project id accumulates its own record first.
+	if err := s.EnsureProject(ctx, "hash-new", "hash-new", "hash-new"); err != nil {
+		t.Fatalf("EnsureProject placeholder: %v", err)
+	}
+	if _, _, _, err := s.Upsert(ctx, "hash-new", "fact", "belongs to the incoming duplicate id", "manual", 0.5, []string{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Re-registering "hash-new" against the path already owned by
+	// hash-original must self-heal: fold hash-new into the canonical
+	// project instead of violating the projects.path UNIQUE constraint.
+	if err := s.EnsureProject(ctx, "hash-new", "/home/wayne/git/pathcollide", "pathcollide"); err != nil {
+		t.Fatalf("EnsureProject collision: %v", err)
+	}
+
+	projects, _ := s.ListProjects(ctx)
+	for _, p := range projects {
+		if p.ID == "hash-new" {
+			t.Error("incoming colliding id should have been merged away, not kept")
+		}
+	}
+
+	mems, _ := s.GetTopMemories(ctx, "hash-original", 10)
+	found := false
+	for _, m := range mems {
+		if strings.Contains(m.Content, "belongs to the incoming duplicate id") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected memory reassigned to canonical (pre-existing) project id")
+	}
+}
+
+// TestEnsureProject_AutoMergeErrorNotSwallowed guards issue #290: a failed
+// UPDATE/DELETE inside EnsureProject's auto-merge paths must surface as a
+// real error instead of being silently discarded while the function reports
+// success — and, worse, having already partially reassigned records with no
+// atomicity. Forces the merge to fail partway through by dropping one of the
+// child tables the merge touches.
+func TestEnsureProject_AutoMergeErrorNotSwallowed(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Simulate MCP creating a project with name-as-ID.
+	if err := s.EnsureProject(ctx, "myproject", "myproject", "myproject"); err != nil {
+		t.Fatalf("EnsureProject MCP: %v", err)
+	}
+	if _, _, _, err := s.Upsert(ctx, "myproject", "fact", "deployed on k8s cluster alpha-7", "mcp", 0.8, []string{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Break one of the tables the merge must touch, so the merge fails
+	// partway through instead of completing cleanly.
+	if _, err := s.db.ExecContext(ctx, `DROP TABLE token_usage`); err != nil {
+		t.Fatalf("drop token_usage: %v", err)
+	}
+
+	// Orchestrator creates the real project (abs path, hash ID). This
+	// triggers the name/path-duplicate auto-merge, which must now return a
+	// real error instead of silently reporting success.
+	hashID := "abc123def456"
+	err := s.EnsureProject(ctx, hashID, "/home/wayne/git/myproject", "myproject")
+	if err == nil {
+		t.Fatal("EnsureProject returned nil despite the merge failing — error was silently swallowed")
+	}
+
+	// The merge must have rolled back entirely, not just reported an error
+	// while the old code's uncommitted-transaction-free loop had already
+	// deleted "myproject" and reassigned some (but not all) of its records.
+	// This is what actually distinguishes the fixed, transactional merge
+	// from a version that merely wraps the same errors and returns them.
+	projects, _ := s.ListProjects(ctx)
+	found := false
+	for _, p := range projects {
+		if p.ID == "myproject" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("myproject should still exist — the failed merge must not have deleted it")
+	}
+
+	mems, _ := s.GetTopMemories(ctx, "myproject", 10)
+	memFound := false
+	for _, m := range mems {
+		if strings.Contains(m.Content, "alpha-7") {
+			memFound = true
+		}
+	}
+	if !memFound {
+		t.Error("memory should still be under myproject — the failed merge must not have partially reassigned it")
+	}
+
+	hashMems, _ := s.GetTopMemories(ctx, hashID, 10)
+	for _, m := range hashMems {
+		if strings.Contains(m.Content, "alpha-7") {
+			t.Error("memory should NOT have been reassigned to hashID — the failed merge must not partially apply")
+		}
+	}
+}
+
 func TestResolveCandidatesAndSetResolved(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #290

## Bug

`EnsureProject` in `internal/memory/store.go` has two separate inline "merge duplicate project" code blocks:

1. **Path collision** (~line 187): fires when the incoming `id` has an absolute `path` that another project row already owns. Records move from the incoming `id` to the pre-existing canonical `existingID`.
2. **Name/path duplicate** (~line 224): fires when this call has a real absolute path but an older MCP-created project with the same `name` and a non-absolute path (`dupID`) already exists. Records move from `dupID` to the current `id`.

Each block ran a `for _, stmt := range []string{...}` loop of 6 UPDATE statements (reassigning `memories`/`conversations`/`tasks`/`decisions`/`token_usage`/`audit_log` to the canonical project ID) followed by 2 DELETEs (`ghost_state`, then `projects`) — and every one of those 8 execs used `_, _ = s.db.ExecContext(...)`, discarding the error. No transaction, either, so a failure partway through left the merge partially applied: some child rows reassigned, others still orphaned under the deleted (or about-to-be-deleted) project id, with `EnsureProject` still returning `nil`.

## Fix

`mergeProjectLocked` (used by the public `MergeProject`) already implements this exact operation correctly — transactional (`BeginTx`/`defer Rollback`/`Commit`), every statement's error checked and wrapped, and already covered by `TestMergeProject`/`TestMergeProject_SameID`. It doesn't lock internally (only the public `MergeProject` wrapper does), so it's safe to call directly from `EnsureProject`, which already holds `s.mu`.

Both inline loops are deleted and replaced with a single call each, matching the direction each block already moved records in:

- Path collision: `s.mergeProjectLocked(ctx, id, existingID)` (unchanged control flow: still returns `nil` immediately after, on the same success path as before).
- Name/path duplicate: `s.mergeProjectLocked(ctx, dupID, id)`.

Net effect: ~26 lines of duplicated, drifted-from-`mergeProjectLocked` logic removed, and both auto-merge paths are now atomic and error-checked. A failure in either path now returns a wrapped error from `EnsureProject` (`"auto-merge path duplicate: %w"` / `"auto-merge duplicate project: %w"`) instead of silently returning `nil`, and — because it's transactional — a failure no longer leaves a half-applied merge behind.

One intentional side effect worth calling out: both paths previously logged their own bespoke message (`"auto-merged path duplicate"` / `"auto-merged duplicate project"`, with slightly different fields). Those are now replaced by `mergeProjectLocked`'s own generic `"merged duplicate project"` log line, so a successful auto-merge from either trigger now looks the same in logs (distinguishable on *failure* only, via the two different wrapped error prefixes above). Grepped the repo for both removed log strings — nothing else references them.

Checked all non-test call sites of `EnsureProject` (`internal/bench/*.go`, `internal/mcpserver/mcpserver.go`, `bench/longmemeval/main.go`) — every one already does `if err := ...EnsureProject(...); err != nil`, so this isn't a contract change, just a previously-dead error path that can now actually fire.

## Tests

- `TestMergeProject`, `TestMergeProject_SameID`, `TestEnsureProject_AutoMerge`, `TestEnsureProject_EmptyPath_NoUniqueConflict` — pre-existing, all still pass unchanged, proving the success-path outcome (which id survives, which is deleted, where records end up) is identical before/after.
- `TestEnsureProject_AutoMerge_PathCollision` (new) — the path-collision block (#1 above) had *no* existing test coverage at all. Added a success-path test for it so the refactor of that block is verified by more than reasoning. Passes both before and after the refactor (confirms the DRY swap alone doesn't change behavior).
- `TestEnsureProject_AutoMergeErrorNotSwallowed` (new, the required regression test) — drops the `token_usage` table out from under an in-flight name/path-duplicate merge, forcing one of `mergeProjectLocked`'s UPDATEs to fail. Asserts `EnsureProject` returns a real error, **and** that the old project row and its child memory are still intact (proving the transaction rolled back rather than partially applying, which a weaker fix that merely wrapped-and-returned the same unguarded loop could still pass). Confirmed red against the old code (fails with "error was silently swallowed"), green after the fix.

`go vet ./...`, `go build ./...`, and `go test ./...` all pass clean across the whole repo.

## Out of scope (noticed, not touched)

- `memory_snapshots` has `project_id REFERENCES projects(id) ON DELETE CASCADE` but isn't in `mergeProjectLocked`'s reassignment list — a merge cascade-deletes that project's snapshot rows instead of reassigning them. Pre-existing in `mergeProjectLocked` itself, unrelated to the swallowed-errors bug this PR fixes.
- CI's `build-and-test` check may show an unrelated `govulncheck` failure (go1.26.5 stdlib CVEs) — already fixed in unmerged #294. Did not touch `go.mod` here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic project merging when duplicate paths are detected.
  * Ensured associated records are transferred to the canonical project and duplicate entries are removed.
  * Prevented partial updates by rolling back changes when a merge fails.
  * Errors during automatic merging are now reported instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->