### PR TITLE
fix(mcpserver): truncate task IDs via shortID consistently

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -45,8 +45,8 @@ type resolveCapableStore interface {
 	SetResolved(ctx context.Context, ids []string) (int, error)
 }
 
-// shortID truncates a memory ID to 8 characters for compact preview, mirroring
-// cmd/ghost/main.go's local `short` closure.
+// shortID truncates an ID to 8 characters for compact preview (used for both
+// memory and task IDs), mirroring cmd/ghost/main.go's local `short` closure.
 func shortID(id string) string {
 	if len(id) > 8 {
 		return id[:8]
@@ -1065,7 +1065,7 @@ func (s *Server) registerTools() {
 		}
 		var sb strings.Builder
 		for _, t := range tasks {
-			fmt.Fprintf(&sb, "- [%s] P%d `%s` %s\n", t.Status, t.Priority, t.ID[:8], t.Title)
+			fmt.Fprintf(&sb, "- [%s] P%d `%s` %s\n", t.Status, t.Priority, shortID(t.ID), t.Title)
 			if t.Description != "" {
 				fmt.Fprintf(&sb, "  %s\n", t.Description)
 			}
@@ -1568,7 +1568,7 @@ func (s *Server) registerResources() {
 			}
 			for _, t := range tasks {
 				hasContent = true
-				fmt.Fprintf(&sb, "- [%s] P%d `%s` %s\n", t.Status, t.Priority, t.ID[:8], t.Title)
+				fmt.Fprintf(&sb, "- [%s] P%d `%s` %s\n", t.Status, t.Priority, shortID(t.ID), t.Title)
 				if t.Description != "" {
 					fmt.Fprintf(&sb, "  %s\n", t.Description)
 				}

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/wcatz/ghost/internal/memory"
+	"github.com/wcatz/ghost/internal/provider"
 )
 
 // testStore creates an in-memory Store suitable for testing.
@@ -1519,5 +1520,116 @@ func TestTruncateUTF8(t *testing.T) {
 		if !utf8.ValidString(got) {
 			t.Errorf("truncateUTF8(%q, %d) produced invalid UTF-8: %q", tc.in, tc.maxBytes, got)
 		}
+	}
+}
+
+func TestShortID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{"shorter than 8", "abc", "abc"},
+		{"exactly 8", "12345678", "12345678"},
+		{"longer than 8", "123456789abcdef", "12345678"},
+		{"empty", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shortID(tc.id); got != tc.want {
+				t.Errorf("shortID(%q) = %q, want %q", tc.id, got, tc.want)
+			}
+		})
+	}
+}
+
+// shortTaskListStore wraps a real store but overrides ListTasks to return a
+// fixed, caller-supplied task instead of querying SQLite. CreateTask always
+// mints a 32-char hex ID (hex(randomblob(16)), see internal/memory/schema.go),
+// so a task ID shorter than 8 characters can never occur through the public
+// Store API — this wrapper is the only way to get one in front of the
+// ghost_task_list tool and the project-tasks resource template, to prove
+// their output formatting doesn't panic on one.
+type shortTaskListStore struct {
+	provider.MemoryStore
+	task memory.Task
+}
+
+func (s shortTaskListStore) ListTasks(ctx context.Context, projectID, status string, limit int) ([]memory.Task, error) {
+	if status != "" && status != s.task.Status {
+		return nil, nil
+	}
+	return []memory.Task{s.task}, nil
+}
+
+// TestGhostTaskList_ShortTaskID proves the ghost_task_list tool formats a
+// task ID via shortID rather than an unguarded t.ID[:8] slice. Before the
+// fix, t.ID[:8] on this 3-character ID panics with "slice bounds out of
+// range"; shortID returns it unchanged.
+func TestGhostTaskList_ShortTaskID(t *testing.T) {
+	store := testStore(t)
+	wrapped := shortTaskListStore{
+		MemoryStore: store,
+		task: memory.Task{
+			ID:        "abc",
+			ProjectID: "abc123",
+			Title:     "short id task",
+			Status:    "pending",
+			Priority:  1,
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(wrapped, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_task_list",
+		Arguments: map[string]any{"project_id": "abc123"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_task_list: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("ghost_task_list returned an error result: %+v", result.Content)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	if !strings.Contains(text.Text, "`abc`") {
+		t.Errorf("expected output to contain the short task id `abc`, got: %s", text.Text)
+	}
+}
+
+// TestProjectTasksResource_ShortTaskID is the resource-template counterpart
+// of TestGhostTaskList_ShortTaskID: it exercises the second t.ID[:8] call
+// site, in the ghost://project/{project_id}/tasks resource template.
+func TestProjectTasksResource_ShortTaskID(t *testing.T) {
+	store := testStore(t)
+	wrapped := shortTaskListStore{
+		MemoryStore: store,
+		task: memory.Task{
+			ID:        "abc",
+			ProjectID: "abc123",
+			Title:     "short id task",
+			Status:    "pending",
+			Priority:  1,
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(wrapped, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	result, err := session.ReadResource(ctx, &mcp.ReadResourceParams{URI: "ghost://project/abc123/tasks"})
+	if err != nil {
+		t.Fatalf("ReadResource tasks: %v", err)
+	}
+	if len(result.Contents) == 0 {
+		t.Fatal("expected resource contents")
+	}
+	if !strings.Contains(result.Contents[0].Text, "`abc`") {
+		t.Errorf("expected output to contain the short task id `abc`, got: %s", result.Contents[0].Text)
 	}
 }


### PR DESCRIPTION
Fixes #292

## Bug

`internal/mcpserver/mcpserver.go` has a `shortID(id string) string` helper that safely truncates an ID to 8 characters for compact display (returns the ID unchanged if it's already 8 chars or shorter). It was used for memory IDs, but two task-ID call sites truncated with a raw `t.ID[:8]` slice instead — unsafe if a task ID is ever shorter than 8 chars, and an inconsistent, less grep-able pattern between memory-ID and task-ID output.

In practice `tasks.id` is always `hex(randomblob(16))` (32 hex chars, see `internal/memory/schema.go`), so this never panicked in production. It's a latent bug plus a consistency issue.

## Fix

Replaced both raw slices with `shortID(t.ID)`:

- `internal/mcpserver/mcpserver.go:1068` — the `ghost_task_list` tool
- `internal/mcpserver/mcpserver.go:1571` — the `ghost://project/{project_id}/tasks` resource template

Generalized `shortID`'s doc comment (previously said "truncates a memory ID"; now notes it's used for both memory and task IDs).

## Tests

- `TestShortID` — direct boundary test of the helper itself (len < 8, == 8, > 8, empty). This one is a **regression guard, not a bug reproduction**: `shortID` always had the length guard and was never buggy — the bug lived only at the raw `t.ID[:8]` call sites, which never called through `shortID` at all.
- `TestGhostTaskList_ShortTaskID` and `TestProjectTasksResource_ShortTaskID` — real bug reproductions. Since `CreateTask` can never produce a task shorter than 8 chars through the public `Store` API, these use a small `shortTaskListStore` test wrapper (embeds `provider.MemoryStore`, overrides only `ListTasks`) to inject a `Task{ID: "abc", ...}` in front of the real tool/resource handlers via the existing `connectedClient` MCP test harness.

  Run against the pre-fix code, both tests genuinely panicked:
  ```
  panic: runtime error: slice bounds out of range [:8] with length 3
  .../mcpserver.go:1068 ...   (tool)
  .../mcpserver.go:1571 ...   (resource template)
  ```
  Post-fix, both pass cleanly and assert the output contains the untruncated short ID.

## Verification

- `go vet ./...` — clean
- `go build ./...` and `go build -o /dev/null ./cmd/ghost` — clean
- `go test ./...` and `go test -race -count=1 ./...` (matching CI's Test step) — all packages pass
- `go mod tidy && git diff --exit-code go.mod go.sum` — no drift
- `golangci-lint` (pinned v2.12.2, `--new-from-rev=origin/main`, matching CI) — 0 issues

## Out of scope (noted, not touched)

- `internal/mcpserver/mcpserver.go:1213` — `p.ID[:min(len(p.ID), 8)]` for a **project** ID in the `ghost_health` tool. Already panic-safe (via `min()`), just a different style from `shortID`. Not a task ID, not the issue's complaint.
- `cmd/ghost/main.go:581,664` — two local `short` closures (in `runSupersede`/`runResolve`) that already implement the identical safe length-guard as `shortID`, duplicated across two call sites in a separate binary entry point. They're used only for memory/decision IDs, never task IDs, so they don't have the inconsistency this issue is about — a possible future de-duplication cleanup, but a separate concern from this fix.

## CI note

CI's `build-and-test` may show an unrelated `govulncheck` failure (go1.26.5 stdlib CVEs) — already fixed in not-yet-merged PR #294, unrelated to this change.