### PR TITLE
fix(memory): narrow FTS trigger to content changes (schema v4)

### DIFF
--- a/internal/memory/migrate.go
+++ b/internal/memory/migrate.go
@@ -11,7 +11,7 @@ import (
 // Bump it and append to migrations whenever initSQL changes in a way that
 // CREATE TABLE IF NOT EXISTS cannot deliver to existing databases (new columns,
 // CHECK values, foreign keys, dropped tables).
-const schemaVersion = 3
+const schemaVersion = 4
 
 // migrations[i] upgrades a database from user_version i to i+1. Each step is
 // frozen in time — it must keep working against the schema as it existed when
@@ -22,6 +22,7 @@ var migrations = []func(*sql.Tx) error{
 	migrateV1,
 	migrateV2,
 	migrateV3,
+	migrateV4,
 }
 
 // migrate brings an existing database up to schemaVersion. Fresh databases
@@ -175,6 +176,37 @@ FROM memory_links`,
 	return nil
 }
 
+// migrateV4 narrows memories_au to only fire when an UPDATE actually changes
+// content. The trigger previously ran unconditionally on every UPDATE —
+// including SET resolved_at, SET pinned, SET access_count — none of which
+// touch content, so it did a harmless but wasteful FTS delete+re-insert on
+// every such write (#286). SQLite has no ALTER TRIGGER, so this drops and
+// recreates memories_au with a WHEN guard; unlike migrateV1/migrateV3 this
+// needs no table rebuild — a trigger carries no rows or FK dependencies of
+// its own, so replacing it is a plain DROP+CREATE.
+func migrateV4(tx *sql.Tx) error {
+	stale, err := triggerDDLLacks(tx, "memories_au", "old.content != new.content")
+	if err != nil {
+		return err
+	}
+	if !stale {
+		return nil // hand-migrated DB (or a fresh initSQL create) already has the guard
+	}
+	stmts := []string{
+		`DROP TRIGGER IF EXISTS memories_au`,
+		`CREATE TRIGGER memories_au AFTER UPDATE ON memories WHEN old.content != new.content BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content) VALUES('delete', old.rowid, old.content);
+    INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+END`,
+	}
+	for _, s := range stmts {
+		if _, err := tx.Exec(s); err != nil {
+			return fmt.Errorf("%q: %w", s[:min(40, len(s))], err)
+		}
+	}
+	return nil
+}
+
 // columnExists reports whether table has a column named column, matching
 // case-insensitively — SQLite itself treats column identifiers as
 // case-insensitive, so a hand-migrated RESOLVED_AT column must be recognized
@@ -215,6 +247,25 @@ func tableDDLLacks(tx *sql.Tx, table, marker string) (bool, error) {
 	}
 	if err != nil {
 		return false, fmt.Errorf("read %s DDL: %w", table, err)
+	}
+	return !strings.Contains(ddl, marker), nil
+}
+
+// triggerDDLLacks reports whether the named trigger exists and its stored DDL
+// does NOT contain marker — mirrors tableDDLLacks but queries sqlite_master
+// for a trigger instead of a table. A missing trigger needs no recreate here:
+// initSQL's CREATE TRIGGER IF NOT EXISTS will already have created it in
+// current form before migrate() ever runs.
+func triggerDDLLacks(tx *sql.Tx, trigger, marker string) (bool, error) {
+	var ddl string
+	err := tx.QueryRow(
+		`SELECT sql FROM sqlite_master WHERE type='trigger' AND name=?`, trigger,
+	).Scan(&ddl)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read %s DDL: %w", trigger, err)
 	}
 	return !strings.Contains(ddl, marker), nil
 }

--- a/internal/memory/migrate_test.go
+++ b/internal/memory/migrate_test.go
@@ -1,9 +1,11 @@
 package memory
 
 import (
+	"context"
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -165,6 +167,20 @@ func TestMigrateLegacyDB(t *testing.T) {
 		`SELECT count(*) FROM memories_fts WHERE memories_fts MATCH 'zanzibar'`,
 	).Scan(&n); err != nil || n != 1 {
 		t.Errorf("fts trigger after migration: n=%d err=%v, want 1", n, err)
+	}
+
+	// migrateV1's rebuild is frozen in time and reinstalls the old unguarded
+	// memories_au body; migrateV4 must re-narrow it afterward so a legacy DB
+	// that runs the full V1->V4 chain ends up guarded too, not just DBs that
+	// start at v3.
+	var auSQL string
+	if err := db.QueryRow(
+		`SELECT sql FROM sqlite_master WHERE type='trigger' AND name='memories_au'`,
+	).Scan(&auSQL); err != nil {
+		t.Fatalf("read memories_au trigger SQL: %v", err)
+	}
+	if !strings.Contains(auSQL, "old.content != new.content") {
+		t.Errorf("memories_au trigger missing content-change guard after full migration chain: %s", auSQL)
 	}
 
 	// The snapshots FK cascades on project delete.
@@ -448,5 +464,180 @@ func TestMigrateV3AddsDuplicateRelation(t *testing.T) {
 		`INSERT INTO memory_links (source_id, target_id, relation, strength, source) VALUES ('m2', 'm1', 'duplicate', 0.8, 'auto')`,
 	); err != nil {
 		t.Errorf("insert with relation='duplicate' still fails: %v", err)
+	}
+}
+
+// v3SQL is a schemaVersion-3 database: current-shape memories/memories_fts
+// and all three FTS triggers, but memories_au still lacks the content-change
+// guard — the shape every database created before the v4 migration has.
+const v3SQL = `
+CREATE TABLE projects (
+    id          TEXT PRIMARY KEY,
+    path        TEXT NOT NULL UNIQUE,
+    name        TEXT NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE memories (
+    id            TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    category      TEXT NOT NULL DEFAULT 'fact'
+                  CHECK (category IN (
+                      'architecture', 'decision', 'pattern', 'convention',
+                      'gotcha', 'dependency', 'preference', 'fact'
+                  )),
+    content       TEXT NOT NULL,
+    importance    REAL NOT NULL DEFAULT 0.5,
+    access_count  INTEGER NOT NULL DEFAULT 0,
+    last_accessed TEXT,
+    source        TEXT NOT NULL DEFAULT 'reflection'
+                  CHECK (source IN ('reflection', 'chat', 'manual', 'tool', 'mcp', 'onboarding', 'decision_log')),
+    tags          TEXT DEFAULT '[]',
+    pinned        INTEGER NOT NULL DEFAULT 0,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    resolved_at   TEXT
+);
+
+CREATE VIRTUAL TABLE memories_fts USING fts5(
+    content,
+    content=memories,
+    content_rowid=rowid,
+    tokenize='porter unicode61'
+);
+
+CREATE TRIGGER memories_ai AFTER INSERT ON memories BEGIN
+    INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+CREATE TRIGGER memories_ad AFTER DELETE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content) VALUES('delete', old.rowid, old.content);
+END;
+
+CREATE TRIGGER memories_au AFTER UPDATE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content) VALUES('delete', old.rowid, old.content);
+    INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+`
+
+// newV3DB writes a schemaVersion-3 database with one memory row, stamped at
+// user_version=3, and returns its path.
+func newV3DB(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "ghost.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open v3 db: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+	if _, err := db.Exec(v3SQL); err != nil {
+		t.Fatalf("create v3 schema: %v", err)
+	}
+	seed := []string{
+		`INSERT INTO projects (id, path, name) VALUES ('p1', '/tmp/v3-p1', 'p1')`,
+		`INSERT INTO memories (id, project_id, category, content, source) VALUES ('m1', 'p1', 'fact', 'original content here', 'mcp')`,
+		`PRAGMA user_version = 3`,
+	}
+	for _, s := range seed {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("seed v3 db: %v", err)
+		}
+	}
+	return dbPath
+}
+
+// totalChanges reads SQLite's total_changes() counter on the given pinned
+// connection: the count of rows written since the connection opened,
+// including rows written by trigger bodies (unlike changes(), which counts
+// only the outermost statement and excludes trigger-driven writes). This is
+// the only reliable way to observe whether memories_au's body actually ran —
+// a delete+re-insert of byte-identical FTS content is otherwise invisible
+// from the row data alone, since the shadow tables end up in the same state
+// whether or not the trigger fired.
+func totalChanges(t *testing.T, ctx context.Context, conn *sql.Conn) int64 {
+	t.Helper()
+	var n int64
+	if err := conn.QueryRowContext(ctx, `SELECT total_changes()`).Scan(&n); err != nil {
+		t.Fatalf("total_changes: %v", err)
+	}
+	return n
+}
+
+// TestMigrateV4NarrowsUpdateTrigger: a schemaVersion-3 database's memories_au
+// trigger fires unconditionally on every UPDATE, doing a wasteful FTS
+// delete+re-insert even when content is untouched — e.g. SET pinned, SET
+// resolved_at, SET access_count (#286). Migrating to v4 must narrow it with a
+// WHEN old.content != new.content guard, while a genuine content change must
+// still refresh FTS exactly as before (don't regress the trigger's purpose).
+func TestMigrateV4NarrowsUpdateTrigger(t *testing.T) {
+	dbPath := newV3DB(t)
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB on v3 db: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	if v := schemaVersionOf(t, db); v != schemaVersion {
+		t.Errorf("user_version = %d, want %d", v, schemaVersion)
+	}
+
+	// Pin a single connection: total_changes() is per-connection, and
+	// SetMaxOpenConns(1) makes reuse overwhelmingly likely but not
+	// contractual, so pin explicitly rather than rely on pool behavior.
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin conn: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	// Primary evidence: a non-content UPDATE must cost exactly the 1 row
+	// write of the UPDATE itself, with no extra trigger-driven FTS writes.
+	before := totalChanges(t, ctx, conn)
+	if _, err := conn.ExecContext(ctx, `UPDATE memories SET pinned = 1 WHERE id = 'm1'`); err != nil {
+		t.Fatalf("update pinned: %v", err)
+	}
+	pinnedDelta := totalChanges(t, ctx, conn) - before
+	if pinnedDelta != 1 {
+		t.Errorf("pinned-only update total_changes delta = %d, want 1 (trigger fired when it should not have)", pinnedDelta)
+	}
+
+	// A genuine content change must still cost strictly more: the trigger
+	// firing and rewriting the FTS shadow tables on top of the base update.
+	before = totalChanges(t, ctx, conn)
+	if _, err := conn.ExecContext(ctx, `UPDATE memories SET content = 'updated content here' WHERE id = 'm1'`); err != nil {
+		t.Fatalf("update content: %v", err)
+	}
+	contentDelta := totalChanges(t, ctx, conn) - before
+	if contentDelta <= pinnedDelta {
+		t.Errorf("content-changing update total_changes delta = %d, want > %d (trigger should have fired)", contentDelta, pinnedDelta)
+	}
+
+	// FTS actually reflects the new content, not just "some write happened".
+	var n int
+	if err := conn.QueryRowContext(ctx, `SELECT count(*) FROM memories_fts WHERE memories_fts MATCH 'updated'`).Scan(&n); err != nil || n != 1 {
+		t.Errorf("fts match on updated content: n=%d err=%v, want 1", n, err)
+	}
+	if err := conn.QueryRowContext(ctx, `SELECT count(*) FROM memories_fts WHERE memories_fts MATCH 'original'`).Scan(&n); err != nil || n != 0 {
+		t.Errorf("fts still matches stale content: n=%d err=%v, want 0", n, err)
+	}
+
+	// Secondary evidence: the trigger definition itself carries the guard.
+	// If this fails while the delta assertions above pass, that points to a
+	// marker/whitespace mismatch in this check rather than a real regression.
+	// Uses the pinned conn, not db: db's pool has exactly 1 connection (see
+	// OpenDB's SetMaxOpenConns(1)), which conn is still holding, so a db.*
+	// call here would block forever waiting for a connection that only this
+	// same, still-running function could ever release.
+	var auSQL string
+	if err := conn.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='trigger' AND name='memories_au'`,
+	).Scan(&auSQL); err != nil {
+		t.Fatalf("read memories_au trigger SQL: %v", err)
+	}
+	if !strings.Contains(auSQL, "old.content != new.content") {
+		t.Errorf("memories_au trigger missing content-change guard, got: %s", auSQL)
 	}
 }

--- a/internal/memory/schema.go
+++ b/internal/memory/schema.go
@@ -59,7 +59,7 @@ CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
     INSERT INTO memories_fts(memories_fts, rowid, content) VALUES('delete', old.rowid, old.content);
 END;
 
-CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories WHEN old.content != new.content BEGIN
     INSERT INTO memories_fts(memories_fts, rowid, content) VALUES('delete', old.rowid, old.content);
     INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
 END;


### PR DESCRIPTION
Fixes #286

## Problem
`memories_au` (`internal/memory/schema.go`) fired on every UPDATE to `memories` — including `SET resolved_at`, `SET pinned`, `SET access_count` — none of which touch `content`. Each such write did a harmless but wasteful FTS delete+re-insert (write amplification, not a correctness bug per the issue).

## Fix
- `schema.go`: `initSQL`'s `memories_au` trigger now carries `WHEN old.content != new.content`, so fresh databases get the narrowed behavior immediately.
- `migrate.go`: **bumps `schemaVersion` to 4** and adds `migrateV4`, which drops and recreates `memories_au` with the same guard for existing databases — `CREATE TRIGGER IF NOT EXISTS` alone is a no-op for any database that already has the old trigger baked in, so this needed a real migration, not just an `schema.go` edit. `migrateV4` follows `migrateV3`'s introspect-and-skip style (`triggerDDLLacks`, mirroring `tableDDLLacks`) so a hand-migrated or already-guarded DB is left alone.

## Schema version note (please read before merging either PR)
`docs/superpowers/plans/2026-08-06-remove-dead-conversation-logging.md` is an existing, not-yet-implemented plan that *also* claims `schemaVersion = 4` / `migrateV4` (for dropping the dead `conversations`/`messages` tables). Both changes can't both be v4. I'm not attempting to resolve that here — flagging it so whichever of the two lands second gets renumbered to v5 (migrations are strictly ordered by the `migrations` slice index, so this can't be reconciled after the fact without care).

## Testing
TDD: wrote failing tests first, confirmed genuine red, then implemented.
- `TestMigrateV4NarrowsUpdateTrigger` (new): builds a schemaVersion-3 fixture (`newV3DB`, current-shape schema, unguarded trigger, stamped `user_version = 3`) — i.e. a simulated pre-v4 database, not a fresh one. After `OpenDB` runs the migration, asserts via `total_changes()` deltas (not `changes()`, which only reflects the outer statement and misses trigger-driven writes) that:
  - a `pinned`-only UPDATE costs exactly 1 write (trigger did **not** fire)
  - a `content`-changing UPDATE costs strictly more (trigger **did** fire and FTS actually reflects the new content, old content no longer matches)
  - the trigger's stored SQL in `sqlite_master` carries the `WHEN old.content != new.content` guard
- Extended the existing `TestMigrateLegacyDB` to also assert the guard is present after the **full** V1→V4 chain — `migrateV1`'s rebuild is frozen in time and reinstalls the *old* unguarded trigger body by design, so this specifically exercises V4 re-narrowing it afterward, not just the v3-fixture path in isolation.
- Confirmed `TestMigrateHandMigratedDB` (fresh DB, version stamp reset to 0, reopened) still passes — the one existing test whose behavior migrateV4 could plausibly have altered.
- Red phase (pre-fix, schemaVersion still 3): `pinned-only update total_changes delta = 9, want 1` and `content-changing update total_changes delta = 9, want > 9` (both equal, proving the trigger fired unconditionally either way) plus the legacy-chain guard assertion failing. Green phase (post-fix): all pass.

```
go vet ./...    -> clean
go build ./...  -> clean
go test ./...   -> ok, all packages (internal/memory 0.28s, full repo suite green)
```

## Out of scope (noticed, not touched)
- `gofmt -l` currently flags `internal/mcpinit/init.go` and `internal/memory/vector.go` — pre-existing, unrelated to this change, left alone.
- CI's `build-and-test` may show a `govulncheck` failure unrelated to this change (go1.26 stdlib CVEs) — already fixed in not-yet-merged #294.

Not merging — leaving for review.