### PR TITLE
feat(embedding): surface Ollama-down duration in mcp status

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -100,7 +100,19 @@ func runMCP() {
 
 	if cfg.Embedding.Enabled {
 		embedClient := embedding.NewClient(cfg.Embedding.OllamaURL, cfg.Embedding.Model, cfg.Embedding.Dimensions)
-		embedWorker := embedding.NewWorker(embedClient, store, logger, 2*time.Minute)
+		// A second config.DataDir() call here is deliberate and cheap (an
+		// idempotent MkdirAll, same precedent as internal/mcpinit/hook.go): it
+		// gives the embedding worker the data directory to write its
+		// Ollama-down marker into without threading dataDir through
+		// bootstrap()'s return values. If it fails, dataDir stays "" and the
+		// worker just skips that bookkeeping (see embedding.NewWorker) — worth
+		// warning about but never fatal, since bootstrap() already succeeded
+		// with its own DataDir() call.
+		dataDir, err := config.DataDir()
+		if err != nil {
+			logger.Warn("mcp: cannot resolve data dir, Ollama-down marker disabled", "error", err)
+		}
+		embedWorker := embedding.NewWorker(embedClient, store, logger, 2*time.Minute, dataDir)
 		projectCh := make(chan string, 16)
 		go embedWorker.Run(ctx, projectCh)
 		srv.SetEmbedder(embedClient, projectCh)

--- a/internal/embedding/worker.go
+++ b/internal/embedding/worker.go
@@ -3,6 +3,8 @@ package embedding
 import (
 	"context"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/wcatz/ghost/internal/memory"
@@ -16,22 +18,74 @@ type memoryStore interface {
 	StoreEmbedding(ctx context.Context, memoryID string, vec []float32, model string) error
 }
 
+// OllamaDownMarkerFilename is the sentinel file checkAlive writes into
+// dataDir the first time it observes Ollama unreachable, and removes once
+// Ollama answers reachable again. `ghost mcp status` (internal/mcpinit) reads
+// it to report outage duration (see issue #287). It's a plain file rather
+// than a ghost_state database column because Ollama connectivity is a single
+// global infra fact, not project-scoped data, and because `ghost mcp status`
+// runs as a separate, short-lived CLI process from the long-lived MCP server
+// that hosts this worker — an in-process-only counter here would be
+// invisible to it, so the fact has to be persisted to disk. The file holds an
+// RFC3339 UTC timestamp of when Ollama was first observed down.
+const OllamaDownMarkerFilename = "ollama-down-since"
+
 // Worker periodically embeds memories that don't yet have vectors.
 type Worker struct {
 	client   *Client
 	store    memoryStore
 	logger   *slog.Logger
 	interval time.Duration
+	dataDir  string
 }
 
-// NewWorker creates a background embedding worker.
-func NewWorker(client *Client, store memoryStore, logger *slog.Logger, interval time.Duration) *Worker {
+// NewWorker creates a background embedding worker. dataDir is the ghost data
+// directory (config.DataDir()) where the Ollama-down marker file (see
+// OllamaDownMarkerFilename and checkAlive) is written and removed as
+// reachability changes; pass "" to disable that bookkeeping entirely (e.g.
+// tests that don't exercise it, or a caller whose own config.DataDir() call
+// failed).
+func NewWorker(client *Client, store memoryStore, logger *slog.Logger, interval time.Duration, dataDir string) *Worker {
 	return &Worker{
 		client:   client,
 		store:    store,
 		logger:   logger,
 		interval: interval,
+		dataDir:  dataDir,
 	}
+}
+
+// checkAlive reports whether Ollama is currently reachable and, as a side
+// effect, maintains the on-disk down-since marker (OllamaDownMarkerFilename)
+// that `ghost mcp status` reads to report outage duration: the marker is
+// written — only if one doesn't already exist, so a still-down Ollama
+// doesn't keep resetting its own "down since" clock on every poll — the
+// first time Alive() is observed false, and removed once Alive() is observed
+// true again. A blank dataDir (set by callers that don't care about the
+// marker) disables this bookkeeping and behaves exactly like calling
+// client.Alive(ctx) directly. Best-effort: a failure to write or remove the
+// marker is logged at debug level and never changes the reported liveness.
+func (w *Worker) checkAlive(ctx context.Context) bool {
+	alive := w.client.Alive(ctx)
+	if w.dataDir == "" {
+		return alive
+	}
+
+	markerPath := filepath.Join(w.dataDir, OllamaDownMarkerFilename)
+	if alive {
+		if err := os.Remove(markerPath); err != nil && !os.IsNotExist(err) {
+			w.logger.Debug("embed: remove ollama-down marker", "error", err)
+		}
+		return true
+	}
+
+	if _, err := os.Stat(markerPath); os.IsNotExist(err) {
+		ts := time.Now().UTC().Format(time.RFC3339)
+		if err := os.WriteFile(markerPath, []byte(ts), 0o600); err != nil {
+			w.logger.Debug("embed: write ollama-down marker", "error", err)
+		}
+	}
+	return false
 }
 
 // Run starts the worker loop. Blocks until ctx is cancelled.
@@ -61,7 +115,7 @@ func (w *Worker) Run(ctx context.Context, projectIDs <-chan string) {
 
 // SweepOnce embeds unembedded memories across all projects.
 func (w *Worker) SweepOnce(ctx context.Context) {
-	if !w.client.Alive(ctx) {
+	if !w.checkAlive(ctx) {
 		return
 	}
 	projects, err := w.store.ListProjects(ctx)
@@ -98,7 +152,7 @@ func (w *Worker) EmbedOne(ctx context.Context, memoryID string) {
 
 func (w *Worker) processProject(ctx context.Context, projectID string) {
 	// Check if Ollama is alive first.
-	if !w.client.Alive(ctx) {
+	if !w.checkAlive(ctx) {
 		return
 	}
 
@@ -133,7 +187,7 @@ func (w *Worker) processProject(ctx context.Context, projectID string) {
 			lastErr = err
 			w.logger.Debug("embed: ollama", "error", err, "memory_id", id)
 			// If Ollama went down mid-batch, stop.
-			if !w.client.Alive(ctx) {
+			if !w.checkAlive(ctx) {
 				w.logger.Info("ollama unavailable, pausing embedding", "embedded", embedded)
 				return
 			}

--- a/internal/embedding/worker_test.go
+++ b/internal/embedding/worker_test.go
@@ -154,7 +154,7 @@ func TestWorkerRun_SurvivesPanicInTickerSweep(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	client := NewClient(srv.URL, "test-model", 3)
-	worker := NewWorker(client, store, logger, 20*time.Millisecond)
+	worker := NewWorker(client, store, logger, 20*time.Millisecond, "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	projectIDs := make(chan string)
@@ -194,7 +194,7 @@ func TestWorkerRun_SurvivesPanicInChannelProcessProject(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	client := NewClient(srv.URL, "test-model", 3)
-	worker := NewWorker(client, store, logger, 24*time.Hour) // ticker must not fire
+	worker := NewWorker(client, store, logger, 24*time.Hour, "") // ticker must not fire
 
 	ctx, cancel := context.WithCancel(context.Background())
 	projectIDs := make(chan string, 2)

--- a/internal/embedding/worker_test.go
+++ b/internal/embedding/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -94,7 +95,7 @@ func TestEmbedOne_HappyPath(t *testing.T) {
 
 	// Create a worker with a real client pointing at a fake URL.
 	client := NewClient("http://localhost:0", "nomic-embed-text", 3)
-	worker := NewWorker(client, store, logger, 5*time.Minute)
+	worker := NewWorker(client, store, logger, 5*time.Minute, t.TempDir())
 
 	// EmbedOne with unreachable server will fail gracefully (no panic).
 	worker.EmbedOne(context.Background(), "mem-1")
@@ -114,7 +115,7 @@ func TestEmbedOne_MissingMemory(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	client := NewClient("http://localhost:0", "nomic-embed-text", 3)
-	worker := NewWorker(client, store, logger, 5*time.Minute)
+	worker := NewWorker(client, store, logger, 5*time.Minute, t.TempDir())
 
 	// Should not panic on missing memory.
 	worker.EmbedOne(context.Background(), "nonexistent")
@@ -124,8 +125,9 @@ func TestNewWorker(t *testing.T) {
 	store := newMockStore()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	client := NewClient("http://localhost:11434", "nomic-embed-text", 768)
+	dataDir := t.TempDir()
 
-	worker := NewWorker(client, store, logger, 30*time.Second)
+	worker := NewWorker(client, store, logger, 30*time.Second, dataDir)
 	if worker == nil {
 		t.Fatal("NewWorker returned nil")
 	}
@@ -135,13 +137,16 @@ func TestNewWorker(t *testing.T) {
 	if worker.interval != 30*time.Second {
 		t.Errorf("interval = %v, want 30s", worker.interval)
 	}
+	if worker.dataDir != dataDir {
+		t.Errorf("dataDir = %q, want %q", worker.dataDir, dataDir)
+	}
 }
 
 func TestWorkerRun_ContextCancellation(t *testing.T) {
 	store := newMockStore()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	client := NewClient("http://localhost:0", "nomic-embed-text", 3)
-	worker := NewWorker(client, store, logger, 24*time.Hour) // long interval so ticker doesn't fire
+	worker := NewWorker(client, store, logger, 24*time.Hour, t.TempDir()) // long interval so ticker doesn't fire
 
 	ctx, cancel := context.WithCancel(context.Background())
 	projectIDs := make(chan string, 1)
@@ -166,7 +171,7 @@ func TestWorkerRun_ChannelClose(t *testing.T) {
 	store := newMockStore()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	client := NewClient("http://localhost:0", "nomic-embed-text", 3)
-	worker := NewWorker(client, store, logger, 24*time.Hour)
+	worker := NewWorker(client, store, logger, 24*time.Hour, t.TempDir())
 
 	ctx := context.Background()
 	projectIDs := make(chan string)
@@ -193,7 +198,7 @@ func TestWorkerRun_ProcessesProject(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	client := NewClient("http://localhost:0", "nomic-embed-text", 3)
-	worker := NewWorker(client, store, logger, 24*time.Hour)
+	worker := NewWorker(client, store, logger, 24*time.Hour, t.TempDir())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	projectIDs := make(chan string, 1)
@@ -255,7 +260,7 @@ func TestProcessProject_NoUnembedded(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	client := NewClient("http://localhost:0", "nomic-embed-text", 3)
-	worker := NewWorker(client, store, logger, 5*time.Minute)
+	worker := NewWorker(client, store, logger, 5*time.Minute, t.TempDir())
 
 	// Should return early without error (no unembedded memories, plus Ollama not alive).
 	worker.processProject(context.Background(), "test-project")
@@ -285,7 +290,7 @@ func TestSweepOnce_BackfillsWithoutSaves(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	client := NewClient(srv.URL, "test-model", 3)
-	worker := NewWorker(client, store, logger, time.Minute)
+	worker := NewWorker(client, store, logger, time.Minute, t.TempDir())
 
 	// No channel sends — the sweep alone must find and embed the memory.
 	worker.SweepOnce(context.Background())
@@ -296,4 +301,112 @@ func TestSweepOnce_BackfillsWithoutSaves(t *testing.T) {
 	if !hasEmb {
 		t.Fatal("sweep did not embed a memory in a project never seen on the channel")
 	}
+}
+
+// markerPath returns the path checkAlive uses for the Ollama-down marker
+// inside dataDir, mirroring the join in checkAlive itself.
+func markerPath(dataDir string) string {
+	return filepath.Join(dataDir, OllamaDownMarkerFilename)
+}
+
+// TestCheckAlive_WritesMarkerWhenDown verifies that observing Ollama
+// unreachable for the first time writes the down-since marker file, with a
+// parseable RFC3339 timestamp close to "now" — this is the signal `ghost mcp
+// status` reads to report outage duration (issue #287).
+func TestCheckAlive_WritesMarkerWhenDown(t *testing.T) {
+	dataDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewClient("http://localhost:0", "nomic-embed-text", 3) // unreachable
+	worker := NewWorker(client, newMockStore(), logger, time.Minute, dataDir)
+
+	if alive := worker.checkAlive(context.Background()); alive {
+		t.Fatal("checkAlive = true, want false for an unreachable client")
+	}
+
+	data, err := os.ReadFile(markerPath(dataDir))
+	if err != nil {
+		t.Fatalf("marker file was not created: %v", err)
+	}
+	since, err := time.Parse(time.RFC3339, string(data))
+	if err != nil {
+		t.Fatalf("marker file content %q is not a valid RFC3339 timestamp: %v", data, err)
+	}
+	if age := time.Since(since); age < 0 || age > 10*time.Second {
+		t.Errorf("marker timestamp %v is not close to now (age %v)", since, age)
+	}
+}
+
+// TestCheckAlive_RemovesMarkerWhenReachableAgain verifies that once Ollama
+// answers alive, a previously-written down-since marker is removed so a
+// resolved outage stops being reported.
+func TestCheckAlive_RemovesMarkerWhenReachableAgain(t *testing.T) {
+	dataDir := t.TempDir()
+	if err := os.WriteFile(markerPath(dataDir), []byte("2020-01-01T00:00:00Z"), 0o600); err != nil {
+		t.Fatalf("seed marker file: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewClient(srv.URL, "nomic-embed-text", 3)
+	worker := NewWorker(client, newMockStore(), logger, time.Minute, dataDir)
+
+	if alive := worker.checkAlive(context.Background()); !alive {
+		t.Fatal("checkAlive = false, want true for a reachable client")
+	}
+
+	if _, err := os.Stat(markerPath(dataDir)); !os.IsNotExist(err) {
+		t.Errorf("marker file still present after Ollama became reachable: err=%v", err)
+	}
+}
+
+// TestCheckAlive_DoesNotClobberExistingMarker is the regression test for the
+// actual bug behind #287: if checkAlive rewrote the marker on every poll, a
+// still-down Ollama would keep resetting its own "down since" clock and the
+// reported duration would never grow past one poll interval. Observing "down"
+// repeatedly must leave an existing marker's timestamp untouched. Exercises
+// SweepOnce (one of the two real call sites named in the issue) rather than
+// checkAlive directly, so the regression is pinned at the entry point the bug
+// report describes.
+func TestCheckAlive_DoesNotClobberExistingMarker(t *testing.T) {
+	dataDir := t.TempDir()
+	const backdated = "2020-01-01T00:00:00Z"
+	if err := os.WriteFile(markerPath(dataDir), []byte(backdated), 0o600); err != nil {
+		t.Fatalf("seed marker file: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewClient("http://localhost:0", "nomic-embed-text", 3) // unreachable
+	store := newMockStore()
+	worker := NewWorker(client, store, logger, time.Minute, dataDir)
+
+	worker.SweepOnce(context.Background())
+
+	data, err := os.ReadFile(markerPath(dataDir))
+	if err != nil {
+		t.Fatalf("marker file missing after sweep: %v", err)
+	}
+	if string(data) != backdated {
+		t.Errorf("marker timestamp = %q, want unchanged %q (sweep clobbered it)", data, backdated)
+	}
+}
+
+// TestCheckAlive_BlankDataDirDisablesMarker verifies that a Worker built with
+// dataDir == "" (the fallback when config.DataDir() itself fails at startup —
+// see cmd/ghost/main.go) behaves exactly like calling client.Alive directly,
+// without attempting to write anywhere.
+func TestCheckAlive_BlankDataDirDisablesMarker(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewClient("http://localhost:0", "nomic-embed-text", 3) // unreachable
+	worker := NewWorker(client, newMockStore(), logger, time.Minute, "")
+
+	if alive := worker.checkAlive(context.Background()); alive {
+		t.Error("checkAlive = true, want false for an unreachable client")
+	}
+	// No dataDir means no marker path to check — the assertion above not
+	// panicking (no filepath.Join(\"\", ...) misuse causing a write to an
+	// unexpected location) is the behavior under test.
 }

--- a/internal/mcpinit/ollama.go
+++ b/internal/mcpinit/ollama.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/wcatz/ghost/internal/config"
 	"github.com/wcatz/ghost/internal/embedding"
@@ -15,23 +19,83 @@ import (
 // RunOpencode so the logic and message strings live in one place. The caller
 // feeds its own check closure; on failure it prints the fail text via that
 // closure (e.g. Status's closure also flags the run unhealthy).
-func checkOllama(w io.Writer, cfg *config.Config, check func(ok bool, pass, fail string)) {
+//
+// The returned bool reports whether Ollama itself was actually probed and
+// answered reachable: false both when embedding is disabled (never probed)
+// and when the probe found it unreachable, true whenever Ollama answered —
+// regardless of whether the configured model happens to be installed.
+// checkStoreHealth uses it to gate the "Ollama down since" duration line onto
+// a currently unreachable Ollama, and to suppress it while disabled.
+func checkOllama(w io.Writer, cfg *config.Config, check func(ok bool, pass, fail string)) bool {
 	if !cfg.Embedding.Enabled {
 		_, _ = fmt.Fprintln(w, "  - embedding disabled in config (FTS-only search)")
-		return
+		return false
 	}
 	client := embedding.NewClient(cfg.Embedding.OllamaURL, cfg.Embedding.Model, cfg.Embedding.Dimensions)
 	ctx := context.Background()
 	if !client.Alive(ctx) {
 		check(false, "", fmt.Sprintf("Ollama unreachable at %s — embeddings paused", cfg.Embedding.OllamaURL))
-		return
+		return false
 	}
 	present, err := client.HasModel(ctx)
 	if err != nil {
 		check(false, "", fmt.Sprintf("Ollama model check failed: %v", err))
-		return
+		return true
 	}
 	check(present,
 		fmt.Sprintf("Ollama model %s installed", cfg.Embedding.Model),
 		fmt.Sprintf("Ollama model %s missing — run: ollama pull %s", cfg.Embedding.Model, cfg.Embedding.Model))
+	return true
+}
+
+// reportOllamaDownDuration prints how long Ollama has been unreachable, based
+// on the down-since marker file the embedding worker (internal/embedding.Worker)
+// maintains at filepath.Join(dataDir, embedding.OllamaDownMarkerFilename) — see
+// that constant's doc comment for why the fact is persisted to a plain file
+// rather than a database column. It is purely informational, printed
+// alongside (not instead of) checkOllama's own pass/fail line, and never
+// fails the run itself: a missing or unparseable marker simply produces no
+// output.
+//
+// The caller must only invoke this once it has independently confirmed via
+// checkOllama's live probe that Ollama is *currently* unreachable. The marker
+// can otherwise outlive an outage — it's only cleared the next time some
+// worker instance's own Alive() probe observes Ollama reachable again, which
+// never happens if that MCP server process has since exited — and printing a
+// stale duration next to a passing Ollama check would contradict the check
+// directly above it. This function stays a read-only reporter (it does not
+// delete a stale marker itself even when it declines to print); the marker is
+// harmless clutter until a future worker run clears it.
+func reportOllamaDownDuration(w io.Writer, dataDir string) {
+	data, err := os.ReadFile(filepath.Join(dataDir, embedding.OllamaDownMarkerFilename))
+	if err != nil {
+		return
+	}
+	since, err := time.Parse(time.RFC3339, strings.TrimSpace(string(data)))
+	if err != nil {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "  ! Ollama down since %s (%s)\n",
+		since.UTC().Format("2006-01-02 15:04 UTC"), formatDownDuration(time.Since(since)))
+}
+
+// formatDownDuration renders d as a compact human string truncated to minute
+// granularity: "2h 3m" style under a day, "3d 4h" once the outage spans a
+// full day (minutes stop being useful precision at that point).
+func formatDownDuration(d time.Duration) string {
+	d = d.Truncate(time.Minute)
+	days := d / (24 * time.Hour)
+	d -= days * 24 * time.Hour
+	hours := d / time.Hour
+	d -= hours * time.Hour
+	minutes := d / time.Minute
+
+	switch {
+	case days > 0:
+		return fmt.Sprintf("%dd %dh", days, hours)
+	case hours > 0:
+		return fmt.Sprintf("%dh %dm", hours, minutes)
+	default:
+		return fmt.Sprintf("%dm", minutes)
+	}
 }

--- a/internal/mcpinit/ollama_test.go
+++ b/internal/mcpinit/ollama_test.go
@@ -5,10 +5,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wcatz/ghost/internal/config"
+	"github.com/wcatz/ghost/internal/embedding"
 )
 
 // ollamaStub returns an httptest server stubbing Ollama's root and /api/tags
@@ -48,12 +52,15 @@ func TestCheckOllama(t *testing.T) {
 		var out bytes.Buffer
 		var gotOK bool
 		check := func(ok bool, pass, fail string) { gotOK = ok }
-		checkOllama(&out, &config.Config{Embedding: config.EmbeddingConfig{Enabled: false}}, check)
+		alive := checkOllama(&out, &config.Config{Embedding: config.EmbeddingConfig{Enabled: false}}, check)
 		if !strings.Contains(out.String(), "  - embedding disabled in config (FTS-only search)") {
 			t.Errorf("expected disabled line, got:\n%s", out.String())
 		}
 		if gotOK {
 			t.Error("disabled config must not report a passing check")
+		}
+		if alive {
+			t.Error("checkOllama returned alive=true for a disabled config, want false (never probed)")
 		}
 	})
 
@@ -66,12 +73,15 @@ func TestCheckOllama(t *testing.T) {
 		var fail string
 		check := func(b bool, p, f string) { ok, fail = b, f }
 		cfg := &config.Config{Embedding: config.EmbeddingConfig{Enabled: true, OllamaURL: url, Model: model, Dimensions: 768}}
-		checkOllama(&out, cfg, check)
+		alive := checkOllama(&out, cfg, check)
 		if ok {
 			t.Error("unreachable Ollama must fail the check")
 		}
 		if want := "Ollama unreachable at " + url + " — embeddings paused"; fail != want {
 			t.Errorf("fail text = %q, want %q", fail, want)
+		}
+		if alive {
+			t.Error("checkOllama returned alive=true for an unreachable server, want false")
 		}
 	})
 
@@ -83,12 +93,15 @@ func TestCheckOllama(t *testing.T) {
 		var pass string
 		check := func(b bool, p, f string) { ok, pass = b, p }
 		cfg := &config.Config{Embedding: config.EmbeddingConfig{Enabled: true, OllamaURL: srv.URL, Model: model, Dimensions: 768}}
-		checkOllama(&out, cfg, check)
+		alive := checkOllama(&out, cfg, check)
 		if !ok {
 			t.Error("installed model must pass the check")
 		}
 		if want := "Ollama model " + model + " installed"; pass != want {
 			t.Errorf("pass text = %q, want %q", pass, want)
+		}
+		if !alive {
+			t.Error("checkOllama returned alive=false for a reachable server, want true")
 		}
 	})
 
@@ -100,12 +113,89 @@ func TestCheckOllama(t *testing.T) {
 		var fail string
 		check := func(b bool, p, f string) { ok, fail = b, f }
 		cfg := &config.Config{Embedding: config.EmbeddingConfig{Enabled: true, OllamaURL: srv.URL, Model: model, Dimensions: 768}}
-		checkOllama(&out, cfg, check)
+		alive := checkOllama(&out, cfg, check)
 		if ok {
 			t.Error("missing model must fail the check")
 		}
 		if want := "Ollama model " + model + " missing — run: ollama pull " + model; fail != want {
 			t.Errorf("fail text = %q, want %q", fail, want)
 		}
+		if !alive {
+			t.Error("checkOllama returned alive=false for a reachable server with a missing model, want true (Ollama itself answered)")
+		}
 	})
+}
+
+// TestFormatDownDuration pins the rendering of an outage duration: minute
+// precision under an hour, hour+minute precision under a day, and day+hour
+// precision (minutes dropped) once the outage spans a full day — matching the
+// "HH:MM" granularity the marker timestamp itself is displayed at.
+func TestFormatDownDuration(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{0, "0m"},
+		{30 * time.Second, "0m"}, // sub-minute truncates away
+		{3 * time.Minute, "3m"},
+		{59 * time.Minute, "59m"},
+		{59*time.Minute + 59*time.Second, "59m"},
+		{time.Hour, "1h 0m"},
+		{2*time.Hour + 3*time.Minute, "2h 3m"},
+		{23*time.Hour + 59*time.Minute, "23h 59m"},
+		{24 * time.Hour, "1d 0h"},
+		{25*time.Hour + 30*time.Minute, "1d 1h"}, // day boundary drops minutes
+		{76 * time.Hour, "3d 4h"},
+	}
+	for _, c := range cases {
+		if got := formatDownDuration(c.d); got != c.want {
+			t.Errorf("formatDownDuration(%v) = %q, want %q", c.d, got, c.want)
+		}
+	}
+}
+
+// TestReportOllamaDownDuration_Absent verifies that a data directory with no
+// down-marker file produces no output at all — a healthy or never-down
+// Ollama must not print anything extra.
+func TestReportOllamaDownDuration_Absent(t *testing.T) {
+	var out bytes.Buffer
+	reportOllamaDownDuration(&out, t.TempDir())
+	if out.Len() != 0 {
+		t.Errorf("expected no output for an absent marker, got:\n%s", out.String())
+	}
+}
+
+// TestReportOllamaDownDuration_Malformed verifies that unparseable marker
+// content is ignored rather than panicking or printing garbage — the marker
+// file is best-effort bookkeeping, not a trusted format.
+func TestReportOllamaDownDuration_Malformed(t *testing.T) {
+	dataDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dataDir, embedding.OllamaDownMarkerFilename), []byte("not a timestamp"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	var out bytes.Buffer
+	reportOllamaDownDuration(&out, dataDir)
+	if out.Len() != 0 {
+		t.Errorf("expected no output for a malformed marker, got:\n%s", out.String())
+	}
+}
+
+// TestReportOllamaDownDuration_Present verifies that a valid marker renders
+// both the down-since timestamp and a compact duration.
+func TestReportOllamaDownDuration_Present(t *testing.T) {
+	dataDir := t.TempDir()
+	since := time.Now().Add(-(2*time.Hour + 3*time.Minute))
+	marker := since.UTC().Format(time.RFC3339)
+	if err := os.WriteFile(filepath.Join(dataDir, embedding.OllamaDownMarkerFilename), []byte(marker), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	var out bytes.Buffer
+	reportOllamaDownDuration(&out, dataDir)
+
+	want := fmt.Sprintf("Ollama down since %s (2h 3m)", since.UTC().Format("2006-01-02 15:04 UTC"))
+	if !strings.Contains(out.String(), want) {
+		t.Errorf("expected output to contain %q, got:\n%s", want, out.String())
+	}
 }

--- a/internal/mcpinit/status.go
+++ b/internal/mcpinit/status.go
@@ -227,7 +227,15 @@ func checkStoreHealth(w io.Writer, check func(ok bool, pass, fail string)) *memo
 	// search and memory linking inactive. Ollama checks run regardless of
 	// whether a database exists.
 	if cfg, cfgErr := config.Load(); cfgErr == nil {
-		checkOllama(w, cfg, check)
+		// reportOllamaDownDuration only fires when embedding is enabled AND
+		// checkOllama's live probe just found Ollama unreachable — see that
+		// function's doc comment for why a stale marker must never be printed
+		// next to a currently-passing Ollama check.
+		if alive := checkOllama(w, cfg, check); cfg.Embedding.Enabled && !alive {
+			if dataDir, ddErr := config.DataDir(); ddErr == nil {
+				reportOllamaDownDuration(w, dataDir)
+			}
+		}
 	}
 
 	dataDir, err := config.DataDir()

--- a/internal/mcpinit/status_test.go
+++ b/internal/mcpinit/status_test.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/wcatz/ghost/internal/embedding"
 	"github.com/wcatz/ghost/internal/memory"
 )
 
@@ -395,5 +397,107 @@ func TestCheckEmbeddingStats(t *testing.T) {
 		if text != c.wantText {
 			t.Errorf("embedded=%d total=%d: want text %q, got %q", c.embedded, c.total, c.wantText, text)
 		}
+	}
+}
+
+// TestStatus_OllamaDownDurationReported verifies that a down-since marker
+// written by the embedding worker (internal/embedding.Worker) is surfaced as
+// a duration alongside a currently-unreachable Ollama — the core behavior
+// requested by issue #287.
+func TestStatus_OllamaDownDurationReported(t *testing.T) {
+	statusEnv(t)
+	t.Setenv("PATH", writeStubGhost(t))
+
+	srv := ollamaStub()
+	url := srv.URL
+	srv.Close() // unreachable — Status's own live check must see it down too
+
+	writeGhostConfigFile(t, fmt.Sprintf(`embedding:
+  ollama_url: %s
+  model: nomic-embed-text:v1.5
+  dimensions: 768
+  enabled: true
+`, url))
+	t.Setenv("GHOST_EMBEDDING_ENABLED", "true")
+
+	ghostDir := filepath.Join(os.Getenv("XDG_DATA_HOME"), "ghost")
+	if err := os.MkdirAll(ghostDir, 0o700); err != nil {
+		t.Fatalf("mkdir ghost dir: %v", err)
+	}
+	since := time.Now().Add(-(2*time.Hour + 3*time.Minute))
+	marker := since.UTC().Format(time.RFC3339)
+	if err := os.WriteFile(filepath.Join(ghostDir, embedding.OllamaDownMarkerFilename), []byte(marker), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	var out bytes.Buffer
+	if _, err := Status(&out); err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+
+	want := fmt.Sprintf("Ollama down since %s (2h 3m)", since.UTC().Format("2006-01-02 15:04 UTC"))
+	if !strings.Contains(out.String(), want) {
+		t.Errorf("expected output to contain %q, got:\n%s", want, out.String())
+	}
+}
+
+// TestStatus_OllamaDownDurationSuppressedWhenReachable is the regression test
+// for the stale-marker failure mode: if the embedding worker's MCP server
+// process exits while Ollama is down, nothing removes the marker file until
+// a new worker instance later observes Ollama reachable again. `ghost mcp
+// status` must not print a contradictory "Ollama down since ..." line next
+// to a passing, live "Ollama model installed" check just because a stale
+// marker happens to still be sitting on disk.
+func TestStatus_OllamaDownDurationSuppressedWhenReachable(t *testing.T) {
+	statusEnv(t)
+	t.Setenv("PATH", writeStubGhost(t))
+
+	model := "nomic-embed-text:v1.5"
+	ollama := ollamaStub(model)
+	defer ollama.Close()
+
+	writeGhostConfigFile(t, fmt.Sprintf(`embedding:
+  ollama_url: %s
+  model: %s
+  dimensions: 768
+  enabled: true
+`, ollama.URL, model))
+	t.Setenv("GHOST_EMBEDDING_ENABLED", "true")
+
+	ghostDir := filepath.Join(os.Getenv("XDG_DATA_HOME"), "ghost")
+	if err := os.MkdirAll(ghostDir, 0o700); err != nil {
+		t.Fatalf("mkdir ghost dir: %v", err)
+	}
+	stale := time.Now().Add(-5 * time.Hour).UTC().Format(time.RFC3339)
+	if err := os.WriteFile(filepath.Join(ghostDir, embedding.OllamaDownMarkerFilename), []byte(stale), 0o600); err != nil {
+		t.Fatalf("write stale marker: %v", err)
+	}
+
+	var out bytes.Buffer
+	if _, err := Status(&out); err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+
+	if strings.Contains(out.String(), "Ollama down since") {
+		t.Errorf("a currently-reachable Ollama must not report a stale down-duration, got:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "✓ Ollama model "+model+" installed") {
+		t.Errorf("expected the live Ollama check to still pass, got:\n%s", out.String())
+	}
+}
+
+// TestStatus_NoOllamaDownDurationWhenAbsent pins the no-marker baseline: a
+// clean install with embedding disabled (statusEnv's default) never prints an
+// Ollama-down duration line.
+func TestStatus_NoOllamaDownDurationWhenAbsent(t *testing.T) {
+	statusEnv(t)
+	t.Setenv("PATH", writeStubGhost(t))
+
+	var out bytes.Buffer
+	if _, err := Status(&out); err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if strings.Contains(out.String(), "Ollama down since") {
+		t.Errorf("expected no Ollama-down line without a marker file, got:\n%s", out.String())
 	}
 }


### PR DESCRIPTION
Fixes #287.

## Problem
`internal/embedding/worker.go`'s `SweepOnce`/`processProject` silently return when Ollama is unreachable, logged at DEBUG/WARN only. No way to see "how long has this been down" without grepping logs.

## Design
Persists a down-since marker to a plain file in the data directory (`embedding.OllamaDownMarkerFilename`), **not** a SQLite/`ghost_state` column:
- Ollama connectivity is a single global infra fact, not project-scoped data.
- `ghost mcp status` runs as a separate, short-lived CLI process from the long-lived MCP server hosting the embedding worker — an in-process-only counter would be invisible to it, so the fact has to be persisted to disk.
- Follows the existing sentinel-file precedent in this codebase (`internal/mcpinit`'s `obsidian-sync.pid`, `resolve-<project>.pid`), rather than introducing a schema migration for an ephemeral operational signal.

## What changed
- `embedding.Worker` gains a `dataDir` field and `checkAlive(ctx)`, which wraps `client.Alive(ctx)` and maintains the marker: written (RFC3339 UTC timestamp) the first time Ollama is observed down, removed once reachable again.
- `cmd/ghost/main.go` threads `config.DataDir()` through to `NewWorker`; a failure to resolve it just disables the marker (logged, non-fatal).
- `internal/mcpinit/status.go`/`ollama.go`: `ghost mcp status` reports `Ollama down since <time> (<duration>)` — but only when its own live probe currently finds Ollama unreachable, never printed next to a passing check based on a possibly-stale marker from a since-exited process.

## Verification
- `go vet ./...`, `go build ./...` — clean
- `go test ./internal/embedding/... ./internal/mcpinit/... -v` — all pass, including new `TestStatus_OllamaDownDurationReported`, `TestStatus_OllamaDownDurationSuppressedWhenReachable`, `TestStatus_NoOllamaDownDurationWhenAbsent`
- Full `go test ./...` — all packages pass