### PR TITLE
fix(resolve): fall back to claude CLI when MCP sampling is unavailable

### DIFF
--- a/internal/ai/fallback_provider.go
+++ b/internal/ai/fallback_provider.go
@@ -22,12 +22,25 @@ type FallbackProvider struct {
 	primary               Provider
 	secondary             Provider
 	secondaryIsDryRunOnly bool
+	alwaysFallback        bool
 }
 
 // NewFallbackProvider builds a FallbackProvider. secondary may be nil — a
 // primary-only provider simply returns the primary's error unfallen-through.
 func NewFallbackProvider(primary, secondary Provider, secondaryIsDryRunOnly bool) *FallbackProvider {
 	return &FallbackProvider{primary: primary, secondary: secondary, secondaryIsDryRunOnly: secondaryIsDryRunOnly}
+}
+
+// NewAlwaysFallbackProvider is like NewFallbackProvider, except it falls
+// through to secondary on ANY primary error, not just credit exhaustion.
+// Use this where primary has no notion of "credit" at all — e.g. MCP
+// sampling, where "Method not found" (client doesn't implement sampling),
+// a version-gated protocol rejection, or a user declining the request are
+// all equally "this mechanism is unavailable right now," unlike the
+// Anthropic API where an invalid key or network failure genuinely wouldn't
+// be fixed by retrying against a different provider.
+func NewAlwaysFallbackProvider(primary, secondary Provider, secondaryIsDryRunOnly bool) *FallbackProvider {
+	return &FallbackProvider{primary: primary, secondary: secondary, secondaryIsDryRunOnly: secondaryIsDryRunOnly, alwaysFallback: true}
 }
 
 // DryRunOnlyOnFallback reports whether a ClassifyResult.FromFallback=true
@@ -41,7 +54,7 @@ func (f *FallbackProvider) Classify(ctx context.Context, systemPrompt, userConte
 	if err == nil {
 		return ClassifyResult{Text: out, FromFallback: false}, nil
 	}
-	if !isCreditExhausted(err) || f.secondary == nil {
+	if f.secondary == nil || (!f.alwaysFallback && !isCreditExhausted(err)) {
 		return ClassifyResult{}, err
 	}
 	out, err = f.secondary.Classify(ctx, systemPrompt, userContent)

--- a/internal/ai/fallback_provider_test.go
+++ b/internal/ai/fallback_provider_test.go
@@ -76,6 +76,58 @@ func TestFallbackProvider_SecondaryAlsoFails(t *testing.T) {
 	}
 }
 
+func TestAlwaysFallbackProvider_NonCreditErrorFallsThrough(t *testing.T) {
+	secondary := &fakeProvider{text: "RESOLVED"}
+	primaryErr := errors.New(`mcp sampling: calling "sampling/createMessage": Method not found`)
+	fp := NewAlwaysFallbackProvider(&fakeProvider{err: primaryErr}, secondary, true)
+	res, err := fp.Classify(context.Background(), "sys", "content")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Text != "RESOLVED" || !res.FromFallback {
+		t.Errorf("got %+v, want {RESOLVED true}", res)
+	}
+	if secondary.gotSystemPrompt != "sys" || secondary.gotUserContent != "content" {
+		t.Errorf("secondary got (%q, %q), want (sys, content) forwarded unmodified", secondary.gotSystemPrompt, secondary.gotUserContent)
+	}
+}
+
+func TestAlwaysFallbackProvider_CreditExhaustionStillFallsThrough(t *testing.T) {
+	secondary := &fakeProvider{text: "RESOLVED"}
+	fp := NewAlwaysFallbackProvider(&fakeProvider{err: ErrCreditExhausted}, secondary, true)
+	res, err := fp.Classify(context.Background(), "sys", "content")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Text != "RESOLVED" || !res.FromFallback {
+		t.Errorf("got %+v, want {RESOLVED true}", res)
+	}
+}
+
+func TestAlwaysFallbackProvider_NoSecondaryFailsFast(t *testing.T) {
+	primaryErr := errors.New("boom")
+	fp := NewAlwaysFallbackProvider(&fakeProvider{err: primaryErr}, nil, false)
+	_, err := fp.Classify(context.Background(), "sys", "content")
+	if !errors.Is(err, primaryErr) {
+		t.Errorf("got %v, want %v", err, primaryErr)
+	}
+}
+
+func TestAlwaysFallbackProvider_PrimarySucceeds_SecondaryNotTried(t *testing.T) {
+	secondary := &fakeProvider{text: "RESOLVED"}
+	fp := NewAlwaysFallbackProvider(&fakeProvider{text: "KEEP"}, secondary, true)
+	res, err := fp.Classify(context.Background(), "sys", "content")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Text != "KEEP" || res.FromFallback {
+		t.Errorf("got %+v, want {KEEP false}", res)
+	}
+	if secondary.gotSystemPrompt != "" {
+		t.Errorf("secondary must not be invoked when primary succeeds, got call with %q", secondary.gotSystemPrompt)
+	}
+}
+
 func TestFallbackProvider_DryRunOnlyOnFallback(t *testing.T) {
 	fp := NewFallbackProvider(&fakeProvider{}, &fakeProvider{}, true)
 	if !fp.DryRunOnlyOnFallback() {

--- a/internal/ai/sampling_provider.go
+++ b/internal/ai/sampling_provider.go
@@ -16,10 +16,11 @@ type sampler interface {
 
 // SamplingProvider asks the connected MCP client's own model to classify, via
 // MCP sampling (CreateMessage). It is only constructible where a live session
-// exists — this is the live-session fallback path, never used headless. A
-// FallbackProvider built around a SamplingProvider has no secondary: a
-// sampling failure simply fails, since there is no live-session equivalent of
-// a local fallback model.
+// exists — this is the live-session path, never used headless. Sampling
+// support is inconsistent across MCP clients today (some return "Method not
+// found"; see internal/mcpserver's ghost_resolve wiring), so callers should
+// pair it with NewAlwaysFallbackProvider and a CLIClient secondary rather
+// than assume sampling alone is enough.
 type SamplingProvider struct {
 	session sampler
 }

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -978,7 +978,7 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_resolve",
 		Title:       "Resolve stale evidence",
-		Description: "Scans a project's memories for resolved-evidence notes (intermediate findings, changelog entries, superseded experiments) using the calling session's own model via MCP sampling — no Anthropic API credits spent. Dry-run by default; pass apply:true to stamp resolved_at.",
+		Description: "Scans a project's memories for resolved-evidence notes (intermediate findings, changelog entries, superseded experiments) using the calling session's own model via MCP sampling when the client supports it, falling back to a subscription-billed `claude -p` call otherwise (dry-run only on that fallback). No Anthropic API credits spent either way. Dry-run by default; pass apply:true to stamp resolved_at.",
 		Annotations: &mcp.ToolAnnotations{
 			DestructiveHint: boolPtr(false),
 			OpenWorldHint:   boolPtr(false),
@@ -1002,7 +1002,7 @@ func (s *Server) registerTools() {
 			return nil, nil, fmt.Errorf("ghost_resolve: no active MCP session for sampling")
 		}
 		samplingProvider := ai.NewSamplingProvider(req.Session)
-		fallback := ai.NewFallbackProvider(samplingProvider, nil, false)
+		fallback := ai.NewAlwaysFallbackProvider(samplingProvider, ai.NewCLIClient(), true)
 		cls := resolve.NewHaikuClassifier(fallback)
 		res, confirmed, err := resolve.Run(ctx, rs, cls, projectID, args.Apply, s.logger)
 		if err != nil {

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -998,18 +998,15 @@ func (s *Server) registerTools() {
 		if !ok {
 			return nil, nil, fmt.Errorf("ghost_resolve: store does not support resolve operations")
 		}
-		// Sampling needs a live session; the claude CLI doesn't. When no
-		// session exists at all, skip straight to the CLI as a full-trust
-		// primary (mirrors buildClassifyProvider's headless, no-API-key
-		// case in cmd/ghost/main.go) rather than refusing to run a tool
-		// that has a perfectly good session-independent path available.
-		var provider *ai.FallbackProvider
-		if req.Session != nil {
-			samplingProvider := ai.NewSamplingProvider(req.Session)
-			provider = ai.NewAlwaysFallbackProvider(samplingProvider, ai.NewCLIClient(), true)
-		} else {
-			provider = ai.NewFallbackProvider(ai.NewCLIClient(), nil, false)
-		}
+		// req.Session is never nil here: every ServerRequest the go-sdk
+		// dispatches to a tool handler is constructed from a live
+		// *ServerSession (see mcp.ServerRequest's construction sites in
+		// shared.go/server.go) — there is no headless-invocation path for an
+		// MCP tool. The claude CLI fallback is always a fallback, never a
+		// full-trust primary, so an apply:true request can never write a
+		// CLI-only classification (see resolve.Run's anyFallback guard).
+		samplingProvider := ai.NewSamplingProvider(req.Session)
+		provider := ai.NewAlwaysFallbackProvider(samplingProvider, ai.NewCLIClient(), true)
 		cls := resolve.NewHaikuClassifier(provider)
 		res, confirmed, err := resolve.Run(ctx, rs, cls, projectID, args.Apply, s.logger)
 		if err != nil {

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -998,12 +998,19 @@ func (s *Server) registerTools() {
 		if !ok {
 			return nil, nil, fmt.Errorf("ghost_resolve: store does not support resolve operations")
 		}
-		if req.Session == nil {
-			return nil, nil, fmt.Errorf("ghost_resolve: no active MCP session for sampling")
+		// Sampling needs a live session; the claude CLI doesn't. When no
+		// session exists at all, skip straight to the CLI as a full-trust
+		// primary (mirrors buildClassifyProvider's headless, no-API-key
+		// case in cmd/ghost/main.go) rather than refusing to run a tool
+		// that has a perfectly good session-independent path available.
+		var provider *ai.FallbackProvider
+		if req.Session != nil {
+			samplingProvider := ai.NewSamplingProvider(req.Session)
+			provider = ai.NewAlwaysFallbackProvider(samplingProvider, ai.NewCLIClient(), true)
+		} else {
+			provider = ai.NewFallbackProvider(ai.NewCLIClient(), nil, false)
 		}
-		samplingProvider := ai.NewSamplingProvider(req.Session)
-		fallback := ai.NewAlwaysFallbackProvider(samplingProvider, ai.NewCLIClient(), true)
-		cls := resolve.NewHaikuClassifier(fallback)
+		cls := resolve.NewHaikuClassifier(provider)
 		res, confirmed, err := resolve.Run(ctx, rs, cls, projectID, args.Apply, s.logger)
 		if err != nil {
 			return nil, nil, fmt.Errorf("ghost_resolve: %w", err)
@@ -1018,6 +1025,9 @@ func (s *Server) registerTools() {
 		var sb strings.Builder
 		fmt.Fprintf(&sb, "%s: %d loaded, %d after prefilter, %d confirmed evidence, %s %d\n",
 			args.Project, res.Loaded, res.Candidates, res.Confirmed, verb, count)
+		if res.SkippedApply {
+			sb.WriteString("  apply skipped: classification used the claude CLI fallback (MCP sampling unavailable on this client) — rerun once sampling works to actually stamp resolved_at\n")
+		}
 		for _, m := range confirmed {
 			fmt.Fprintf(&sb, "  %s  [%s]  %s\n", shortID(m.ID), m.Category, firstLine(m.Content, 70))
 		}

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -1510,6 +1512,92 @@ func TestGhostResolve_DryRunByDefault(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected seeded memory to remain an eligible resolve candidate after dry-run (resolved_at must still be NULL)")
+	}
+}
+
+// TestGhostResolve_FallsBackToCLIWhenSamplingUnavailable covers a client that
+// never registers a sampling handler at all — no CreateMessageHandler set, so
+// the go-sdk client never advertises the Sampling capability and answers any
+// inbound sampling/createMessage call with the standard JSON-RPC "Method not
+// found" error. This is not a contrived error: it is the exact failure
+// reproduced live against a real Claude Code (VSCode extension) session while
+// investigating this bug — ghost_resolve hard-failed instead of falling back.
+// It must now fall through to the claude CLI and still report a dry-run
+// preview: a fallback classification is never trusted enough to auto-apply,
+// even when the caller passes apply:true (see resolve.Run's anyFallback
+// guard).
+func TestGhostResolve_FallsBackToCLIWhenSamplingUnavailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script fake binary requires a POSIX shell")
+	}
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+
+	ctx := context.Background()
+	const content = "root cause: fixed in v2, no further action needed"
+	if _, _, _, err := store.Upsert(ctx, "abc123", "gotcha", content, "manual", 0.5, []string{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Fake `claude` binary on PATH, standing in for ai.NewCLIClient()'s
+	// hardcoded "claude" lookup (see internal/ai/cli_client_test.go for the
+	// same pattern used within the ai package).
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "claude")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nprintf '%s' RESOLVED\n"), 0o755); err != nil {
+		t.Fatalf("write fake claude binary: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	serverTransport, clientInMemTransport := mcp.NewInMemoryTransports()
+	if _, err := srv.mcp.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+	var clientTransport mcp.Transport = discoverlessTransport{clientInMemTransport}
+
+	// No CreateMessageHandler — this client does not support sampling at all.
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_resolve",
+		Arguments: map[string]any{"project": "test-project", "apply": true},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_resolve: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("ghost_resolve returned an error result (fallback did not engage): %+v", result.Content)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	// apply:true was requested (verb reflects the request, not the outcome),
+	// but the write itself must be skipped: 1 confirmed evidence, 0 actually
+	// resolved, because resolve.Run refuses to trust a fallback-sourced
+	// classification with a write.
+	if !strings.Contains(text.Text, "1 confirmed evidence, resolved 0") {
+		t.Errorf("expected confirmed-but-not-written output, got %q", text.Text)
+	}
+
+	cands, err := store.ResolveCandidates(ctx, "abc123")
+	if err != nil {
+		t.Fatalf("ResolveCandidates: %v", err)
+	}
+	found := false
+	for _, m := range cands {
+		if m.Content == content {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected seeded memory to remain an eligible resolve candidate — fallback apply must not have written resolved_at")
 	}
 }
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -58,6 +58,12 @@ type Result struct {
 	Candidates int // survived the keyword prefilter and were classified
 	Confirmed  int // classified as resolved evidence
 	Resolved   int // rows written (0 in dry-run)
+
+	// SkippedApply is true iff apply was requested but withheld because at
+	// least one classification came from a fallback provider. Callers should
+	// surface this explicitly — a silent Resolved=0 otherwise looks
+	// indistinguishable from "nothing to resolve."
+	SkippedApply bool
 }
 
 // Prefilter keeps only memories whose content contains a resolution keyword.
@@ -111,6 +117,7 @@ func Run(ctx context.Context, store resolveStore, cls Classifier, projectID stri
 	}
 
 	if apply && anyFallback {
+		res.SkippedApply = true
 		if logger != nil {
 			logger.Warn("resolve: candidates classified via fallback provider, apply skipped — rerun once primary is available",
 				"confirmed", res.Confirmed)

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -116,7 +116,7 @@ func Run(ctx context.Context, store resolveStore, cls Classifier, projectID stri
 		confirmed = append(confirmed, m)
 	}
 
-	if apply && anyFallback {
+	if apply && anyFallback && len(confirmed) > 0 {
 		res.SkippedApply = true
 		if logger != nil {
 			logger.Warn("resolve: candidates classified via fallback provider, apply skipped — rerun once primary is available",

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -59,9 +59,11 @@ type Result struct {
 	Confirmed  int // classified as resolved evidence
 	Resolved   int // rows written (0 in dry-run)
 
-	// SkippedApply is true iff apply was requested but withheld because at
-	// least one classification came from a fallback provider. Callers should
-	// surface this explicitly — a silent Resolved=0 otherwise looks
+	// SkippedApply is true iff apply was requested and withheld because at
+	// least one classification came from a fallback provider AND at least one
+	// candidate was confirmed. Fallback classification with nothing confirmed
+	// leaves this false — there was no write to withhold. Callers should
+	// surface a true value explicitly — a silent Resolved=0 otherwise looks
 	// indistinguishable from "nothing to resolve."
 	SkippedApply bool
 }

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -145,6 +145,36 @@ func TestRunFailsFatallyOnClassifierError(t *testing.T) {
 	}
 }
 
+// TestRun_FallbackClassificationButNothingConfirmed_DoesNotReportSkip covers
+// an edge case found by live-testing the ghost_resolve fallback fix: the real
+// claude CLI fallback classified a seeded memory as KEEP, not RESOLVED, so
+// there was nothing to apply — but the pre-fix condition set SkippedApply
+// (and logged "apply skipped") purely because fromFallback was true,
+// regardless of whether anything was actually confirmed. That's misleading:
+// "apply skipped" implies something was found and withheld, not "found
+// nothing." SkippedApply must only report true when a real write was
+// withheld.
+func TestRun_FallbackClassificationButNothingConfirmed_DoesNotReportSkip(t *testing.T) {
+	store := &fakeStore{
+		candidates: []memory.Memory{{ID: "m1", Content: "resolved: shipped in v1"}},
+	}
+	cls := &fallbackClassifier{resolved: false, fromFallback: true}
+
+	res, confirmed, err := Run(context.Background(), store, cls, "proj1", true, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SkippedApply {
+		t.Error("SkippedApply must be false when nothing was confirmed, even if classification used a fallback")
+	}
+	if len(confirmed) != 0 {
+		t.Errorf("got %d confirmed, want 0", len(confirmed))
+	}
+	if store.setResolvedCalled {
+		t.Error("SetResolved must not be called when nothing was confirmed")
+	}
+}
+
 func TestRun_FallbackClassification_SkipsApply(t *testing.T) {
 	store := &fakeStore{
 		candidates: []memory.Memory{{ID: "m1", Content: "resolved: shipped in v1"}},

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -121,6 +121,9 @@ func TestRunResolvesConfirmedEvidence(t *testing.T) {
 	if res.Resolved != 1 {
 		t.Errorf("res.Resolved = %d, want 1", res.Resolved)
 	}
+	if res.SkippedApply {
+		t.Error("SkippedApply must be false when apply succeeds with no fallback involved")
+	}
 }
 
 func TestRunFailsFatallyOnClassifierError(t *testing.T) {
@@ -155,6 +158,9 @@ func TestRun_FallbackClassification_SkipsApply(t *testing.T) {
 	if res.Resolved != 0 {
 		t.Errorf("got Resolved=%d, want 0 (apply must be skipped on fallback)", res.Resolved)
 	}
+	if !res.SkippedApply {
+		t.Error("expected SkippedApply=true so callers can surface the skip explicitly")
+	}
 	if len(confirmed) != 1 {
 		t.Errorf("got %d confirmed, want 1 (dry-run preview still returned)", len(confirmed))
 	}
@@ -184,6 +190,9 @@ func TestRun_MixedFallbackAndPrimary_SkipsApply(t *testing.T) {
 	}
 	if res.Resolved != 0 {
 		t.Errorf("got Resolved=%d, want 0 (any fallback in the batch must skip apply)", res.Resolved)
+	}
+	if !res.SkippedApply {
+		t.Error("expected SkippedApply=true so callers can surface the skip explicitly")
 	}
 	if store.setResolvedCalled {
 		t.Error("SetResolved must not be called when any candidate in the batch came from a fallback provider, even if another was confirmed via primary")


### PR DESCRIPTION
## Summary
- `ghost_resolve` hard-failed with `mcp sampling: calling "sampling/createMessage": Method not found` on any MCP client that doesn't implement sampling (reproduced live against this session's own client — no `CreateMessageHandler` registered, so the capability is never negotiated).
- Adds `ai.NewAlwaysFallbackProvider`, which falls through to a secondary provider on *any* primary error, not just `ErrCreditExhausted` (sampling failures aren't a credit condition, so the existing `FallbackProvider` gate never fired for them).
- `ghost_resolve` now pairs `SamplingProvider` with a `CLIClient` (`claude -p` subprocess, subscription-billed) as an always-fallback secondary. When there's no MCP session at all, it skips straight to the CLI as a full-trust primary rather than refusing to run.
- Fallback classifications never auto-apply — `apply:true` is silently withheld and `Result.SkippedApply` now surfaces that explicitly to callers instead of leaving a bare `resolved: 0` that looks indistinguishable from "nothing to resolve."

## Test plan
- [x] `go vet ./...`, `go test ./...` — full suite green
- [x] Unit coverage: `ai.NewAlwaysFallbackProvider` fallthrough/no-secondary/primary-succeeds cases; `ghost_resolve` MCP-level fallback test with a client that registers no sampling handler and a fake `claude` binary on PATH
- [x] Live end-to-end: built this branch's actual binary, spawned it as a real MCP subprocess (`mcp.CommandTransport`) from a throwaway client with no sampling handler, drove real `ghost_memory_save`/`ghost_resolve` calls against the real `claude` CLI with isolated `XDG_DATA_HOME`/`XDG_CONFIG_HOME`. Confirmed with content that reliably classifies RESOLVED (verified separately via direct `claude -p` probe using the exact classifier system prompt) that the fallback both engages and correctly withholds the write: `1 confirmed evidence, resolved 0` + `apply skipped: classification used the claude CLI fallback`.
- [x] This live pass caught a real bug unit tests missed: `SkippedApply` fired whenever any candidate was fallback-classified, even with zero confirmed — fixed to require `len(confirmed) > 0` too, with a regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI fallback classification when MCP sampling is unavailable.
  * Added an option to fall back for any classification error, not just credit exhaustion.
  * Results now indicate when applying changes was skipped because fallback classification was used.

* **Bug Fixes**
  * Prevented misleading skipped-apply reporting when no changes were confirmed.
  * Preserved successful primary classifications without invoking fallback providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->