### PR TITLE
feat: add delete-project (CLI + MCP tool)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 - MCP server via modelcontextprotocol/go-sdk (stdio transport)
 
 ## Architecture
-- `cmd/ghost/main.go` — CLI entrypoint; subcommands: mcp, hook, reflect, resolve, supersede, obsidian, bench, upgrade, version
+- `cmd/ghost/main.go` — CLI entrypoint; subcommands: mcp, hook, reflect, resolve, supersede, project, obsidian, bench, upgrade, version
 - `internal/ai/` — Claude API client (non-streaming Reflect call, used by reflection + resolve + supersede); `Provider` seam (`anthropicClient`/`SamplingProvider`) with `FallbackProvider` credit-exhaustion fallover for resolve/supersede
 - `internal/memory/` — SQLite CRUD, FTS5 search, vector search, time-decay scoring
 - `internal/mcpserver/` — MCP server: 20 tools + 4 resources + 2 prompts (`recall_project`, `record_decision`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 - `cmd/ghost/main.go` — CLI entrypoint; subcommands: mcp, hook, reflect, resolve, supersede, obsidian, bench, upgrade, version
 - `internal/ai/` — Claude API client (non-streaming Reflect call, used by reflection + resolve + supersede); `Provider` seam (`anthropicClient`/`SamplingProvider`) with `FallbackProvider` credit-exhaustion fallover for resolve/supersede
 - `internal/memory/` — SQLite CRUD, FTS5 search, vector search, time-decay scoring
-- `internal/mcpserver/` — MCP server: 19 tools + 4 resources + 2 prompts (`recall_project`, `record_decision`)
+- `internal/mcpserver/` — MCP server: 20 tools + 4 resources + 2 prompts (`recall_project`, `record_decision`)
 - `internal/mcpinit/` — `ghost mcp init`, `ghost mcp status`, `ghost hook session-start`, `ghost hook stop`
 - `internal/claudeimport/` — One-time import of Claude Code auto-memory on first contact
 - `internal/embedding/` — Ollama async vectorization worker

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ ghost hook stop              # Stop hook — blocks stop once if a tool-using se
 ghost reflect <project>      # Memory consolidation (dry-run by default; --apply, --restore, --tier)
 ghost resolve <project>      # De-weight resolved-evidence memories from injection (dry-run by default; --apply)
 ghost supersede <project>    # Link superseded memories (dry-run by default; --apply, --threshold)
+ghost project delete <name>  # Permanently delete a project (dry-run by default; --apply + re-type name to confirm)
 ghost bench [--sweep]        # Retrieval-quality benchmark on the built-in dataset
 ghost obsidian export        # Mirror memories to an Obsidian vault (one-way; --out, --project)
 ghost obsidian sync          # Keep the vault mirror fresh (--interval; polls for DB changes)

--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ Because the mirror is one-way, edits inside the vault are informational only and
 
 ## MCP surface
 
-19 tools, 4 resources:
+20 tools, 4 resources:
 
 | Group | Tools |
 |---|---|
 | Memory | `ghost_memory_save` `ghost_memory_search` `ghost_search_all` `ghost_memories_list` `ghost_memory_update` `ghost_memory_delete` `ghost_memory_pin` `ghost_memory_promote` `ghost_save_global` `ghost_resolve` |
-| Context | `ghost_project_context` `ghost_list_projects` `ghost_health` |
+| Context | `ghost_project_context` `ghost_list_projects` `ghost_health` `ghost_project_delete` |
 | Tasks | `ghost_task_create` `ghost_task_list` `ghost_task_update` `ghost_task_complete` |
 | Decisions | `ghost_decision_record` `ghost_decisions_list` |
 

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"database/sql"
@@ -69,6 +70,13 @@ func main() {
 		case "resolve":
 			runResolve()
 			return
+		case "project":
+			if len(os.Args) > 2 && os.Args[2] == "delete" {
+				runProjectDelete()
+				return
+			}
+			fmt.Fprintln(os.Stderr, "Usage: ghost project delete <name-or-id> [--apply]")
+			os.Exit(1)
 		case "upgrade":
 			runUpgrade()
 			return
@@ -689,6 +697,92 @@ subscription-billed 'claude' CLI call — requires one of the two.`)
 	}
 }
 
+// confirmProjectDeleteName reports whether typed (a raw scanned line, not
+// yet trimmed) matches expected exactly once surrounding whitespace is
+// stripped. Pulled out of runProjectDelete as its own pure function so the
+// actual confirmation decision is unit-testable without stdin/os.Exit
+// plumbing.
+func confirmProjectDeleteName(typed, expected string) bool {
+	return strings.TrimSpace(typed) == expected
+}
+
+// runProjectDelete implements `ghost project delete <name-or-id> [--apply]`.
+// Always prints the dry-run summary first. Without --apply it stops there.
+// With --apply, it re-prints the summary and requires re-typing the
+// project's name at a prompt before anything is actually deleted — this is
+// irreversible and there is no undo, so the flag alone is not enough.
+func runProjectDelete() {
+	var projectName string
+	apply := false
+	for i := 3; i < len(os.Args); i++ {
+		switch {
+		case os.Args[i] == "--apply":
+			apply = true
+		case !strings.HasPrefix(os.Args[i], "-"):
+			if projectName != "" {
+				fmt.Fprintln(os.Stderr, "error: expected exactly one project")
+				os.Exit(1)
+			}
+			projectName = os.Args[i]
+		default:
+			fmt.Fprintf(os.Stderr, "error: unknown flag %q\n", os.Args[i])
+			os.Exit(1)
+		}
+	}
+	if projectName == "" {
+		fmt.Fprintln(os.Stderr, `Usage: ghost project delete <name-or-id> [flags]
+
+Flags:
+  --apply   Actually delete (default is dry-run/preview)
+
+Permanently removes a project: memories, tags, embeddings, links, tasks,
+decisions, and cost/audit history. Irreversible. Refuses to delete _global.`)
+		os.Exit(1)
+	}
+
+	_, logger, store := bootstrap()
+	defer store.Close() //nolint:errcheck
+	ctx := context.Background()
+	_ = logger
+
+	printDeleteSummary := func(summary memory.DeleteProjectSummary, verb string) {
+		fmt.Printf("%s %q (%s):\n", verb, summary.ProjectName, summary.ProjectID)
+		fmt.Printf("  memories:     %d\n", summary.Memories)
+		fmt.Printf("  memory_links: %d\n", summary.MemoryLinks)
+		fmt.Printf("  tasks:        %d\n", summary.Tasks)
+		fmt.Printf("  decisions:    %d\n", summary.Decisions)
+		fmt.Printf("  token_usage:  %d\n", summary.TokenUsage)
+		fmt.Printf("  audit_log:    %d\n", summary.AuditLog)
+	}
+
+	summary, err := store.DeleteProject(ctx, projectName, false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	printDeleteSummary(summary, "Would delete")
+
+	if !apply {
+		fmt.Println("\nRe-run with --apply to actually delete.")
+		return
+	}
+
+	fmt.Printf("\nType the project name (%q) to confirm deletion: ", summary.ProjectName)
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Scan()
+	if !confirmProjectDeleteName(scanner.Text(), summary.ProjectName) {
+		fmt.Fprintln(os.Stderr, "error: confirmation did not match project name — nothing deleted")
+		os.Exit(1)
+	}
+
+	summary, err = store.DeleteProject(ctx, projectName, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	printDeleteSummary(summary, "Deleted")
+}
+
 // firstLine returns the first line of s, truncated to at most n runes with an
 // ellipsis, for compact CLI preview.
 func firstLine(s string, n int) string {
@@ -948,6 +1042,8 @@ Commands:
   reflect <project> [flags]   Memory consolidation (dry-run by default, --apply to save)
   supersede <project> [flags] Link superseded memories (dry-run by default, --apply to write)
   resolve <project> [flags]   Mark resolved evidence memories (dry-run by default, --apply to write)
+  project delete <name> [flags]  Permanently delete a project and everything under it
+                              (dry-run by default, --apply + name re-type to confirm)
   obsidian export [flags]     Mirror memories to an Obsidian vault (one-way)
   obsidian sync [flags]       Keep the vault mirror fresh (polls for DB changes)
   bench [--sweep]             Run the retrieval-quality benchmark (built-in dataset);

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -707,15 +707,31 @@ func confirmProjectDeleteName(typed, expected string) bool {
 }
 
 // printDeleteSummary writes a DeleteProjectSummary to out in the fixed-width
-// format shared by both the dry-run preview and the post-apply report.
-func printDeleteSummary(out io.Writer, summary memory.DeleteProjectSummary, verb string) {
-	fmt.Fprintf(out, "%s %q (%s):\n", verb, summary.ProjectName, summary.ProjectID)
-	fmt.Fprintf(out, "  memories:     %d\n", summary.Memories)
-	fmt.Fprintf(out, "  memory_links: %d\n", summary.MemoryLinks)
-	fmt.Fprintf(out, "  tasks:        %d\n", summary.Tasks)
-	fmt.Fprintf(out, "  decisions:    %d\n", summary.Decisions)
-	fmt.Fprintf(out, "  token_usage:  %d\n", summary.TokenUsage)
-	fmt.Fprintf(out, "  audit_log:    %d\n", summary.AuditLog)
+// format shared by both the dry-run preview and the post-apply report. It
+// returns the first write error encountered, if any.
+func printDeleteSummary(out io.Writer, summary memory.DeleteProjectSummary, verb string) error {
+	if _, err := fmt.Fprintf(out, "%s %q (%s):\n", verb, summary.ProjectName, summary.ProjectID); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "  memories:     %d\n", summary.Memories); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "  memory_links: %d\n", summary.MemoryLinks); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "  tasks:        %d\n", summary.Tasks); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "  decisions:    %d\n", summary.Decisions); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "  token_usage:  %d\n", summary.TokenUsage); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "  audit_log:    %d\n", summary.AuditLog); err != nil {
+		return err
+	}
+	return nil
 }
 
 // runProjectDeleteCore implements the confirmation-gated delete against an
@@ -730,25 +746,37 @@ func runProjectDeleteCore(ctx context.Context, store *memory.Store, out io.Write
 	if err != nil {
 		return err
 	}
-	printDeleteSummary(out, summary, "Would delete")
+	if err := printDeleteSummary(out, summary, "Would delete"); err != nil {
+		return err
+	}
 
 	if !apply {
-		fmt.Fprintln(out, "\nRe-run with --apply to actually delete.")
+		if _, err := fmt.Fprintln(out, "\nRe-run with --apply to actually delete."); err != nil {
+			return err
+		}
 		return nil
 	}
 
-	fmt.Fprintf(out, "\nType the project name (%q) to confirm deletion: ", summary.ProjectName)
+	if _, err := fmt.Fprintf(out, "\nType the project name (%q) to confirm deletion: ", summary.ProjectName); err != nil {
+		return err
+	}
 	scanner := bufio.NewScanner(in)
 	scanner.Scan()
 	if !confirmProjectDeleteName(scanner.Text(), summary.ProjectName) {
 		return errors.New("confirmation did not match project name — nothing deleted")
 	}
 
-	summary, err = store.DeleteProject(ctx, projectName, true)
+	// Reuse the ID resolved by the preview above rather than re-resolving
+	// projectName: the confirmation prompt waits on a human, and re-resolving
+	// a mutable name/path in that window could silently hit a different
+	// project if it was renamed or recreated in the meantime.
+	summary, err = store.DeleteProject(ctx, summary.ProjectID, true)
 	if err != nil {
 		return err
 	}
-	printDeleteSummary(out, summary, "Deleted")
+	if err := printDeleteSummary(out, summary, "Deleted"); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -736,7 +736,8 @@ Flags:
   --apply   Actually delete (default is dry-run/preview)
 
 Permanently removes a project: memories, tags, embeddings, links, tasks,
-decisions, and cost/audit history. Irreversible. Refuses to delete _global.`)
+decisions, learned context, reflection snapshots, and cost/audit history.
+Irreversible. Refuses to delete _global.`)
 		os.Exit(1)
 	}
 

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -706,6 +706,52 @@ func confirmProjectDeleteName(typed, expected string) bool {
 	return strings.TrimSpace(typed) == expected
 }
 
+// printDeleteSummary writes a DeleteProjectSummary to out in the fixed-width
+// format shared by both the dry-run preview and the post-apply report.
+func printDeleteSummary(out io.Writer, summary memory.DeleteProjectSummary, verb string) {
+	fmt.Fprintf(out, "%s %q (%s):\n", verb, summary.ProjectName, summary.ProjectID)
+	fmt.Fprintf(out, "  memories:     %d\n", summary.Memories)
+	fmt.Fprintf(out, "  memory_links: %d\n", summary.MemoryLinks)
+	fmt.Fprintf(out, "  tasks:        %d\n", summary.Tasks)
+	fmt.Fprintf(out, "  decisions:    %d\n", summary.Decisions)
+	fmt.Fprintf(out, "  token_usage:  %d\n", summary.TokenUsage)
+	fmt.Fprintf(out, "  audit_log:    %d\n", summary.AuditLog)
+}
+
+// runProjectDeleteCore implements the confirmation-gated delete against an
+// already-open store: prints the dry-run summary, stops there unless apply
+// is set, and otherwise requires re-typing the project's name (read from in)
+// before calling store.DeleteProject with apply=true. Pulled out of
+// runProjectDelete — which owns CLI arg parsing, bootstrap(), and os.Exit —
+// so the confirmation gate is unit-testable against a real store with
+// injected stdin, without exercising process-exit paths.
+func runProjectDeleteCore(ctx context.Context, store *memory.Store, out io.Writer, in io.Reader, projectName string, apply bool) error {
+	summary, err := store.DeleteProject(ctx, projectName, false)
+	if err != nil {
+		return err
+	}
+	printDeleteSummary(out, summary, "Would delete")
+
+	if !apply {
+		fmt.Fprintln(out, "\nRe-run with --apply to actually delete.")
+		return nil
+	}
+
+	fmt.Fprintf(out, "\nType the project name (%q) to confirm deletion: ", summary.ProjectName)
+	scanner := bufio.NewScanner(in)
+	scanner.Scan()
+	if !confirmProjectDeleteName(scanner.Text(), summary.ProjectName) {
+		return errors.New("confirmation did not match project name — nothing deleted")
+	}
+
+	summary, err = store.DeleteProject(ctx, projectName, true)
+	if err != nil {
+		return err
+	}
+	printDeleteSummary(out, summary, "Deleted")
+	return nil
+}
+
 // runProjectDelete implements `ghost project delete <name-or-id> [--apply]`.
 // Always prints the dry-run summary first. Without --apply it stops there.
 // With --apply, it re-prints the summary and requires re-typing the
@@ -745,42 +791,10 @@ Irreversible. Refuses to delete _global.`)
 	defer store.Close() //nolint:errcheck
 	ctx := context.Background()
 
-	printDeleteSummary := func(summary memory.DeleteProjectSummary, verb string) {
-		fmt.Printf("%s %q (%s):\n", verb, summary.ProjectName, summary.ProjectID)
-		fmt.Printf("  memories:     %d\n", summary.Memories)
-		fmt.Printf("  memory_links: %d\n", summary.MemoryLinks)
-		fmt.Printf("  tasks:        %d\n", summary.Tasks)
-		fmt.Printf("  decisions:    %d\n", summary.Decisions)
-		fmt.Printf("  token_usage:  %d\n", summary.TokenUsage)
-		fmt.Printf("  audit_log:    %d\n", summary.AuditLog)
-	}
-
-	summary, err := store.DeleteProject(ctx, projectName, false)
-	if err != nil {
+	if err := runProjectDeleteCore(ctx, store, os.Stdout, os.Stdin, projectName, apply); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-	printDeleteSummary(summary, "Would delete")
-
-	if !apply {
-		fmt.Println("\nRe-run with --apply to actually delete.")
-		return
-	}
-
-	fmt.Printf("\nType the project name (%q) to confirm deletion: ", summary.ProjectName)
-	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Scan()
-	if !confirmProjectDeleteName(scanner.Text(), summary.ProjectName) {
-		fmt.Fprintln(os.Stderr, "error: confirmation did not match project name — nothing deleted")
-		os.Exit(1)
-	}
-
-	summary, err = store.DeleteProject(ctx, projectName, true)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-	printDeleteSummary(summary, "Deleted")
 }
 
 // firstLine returns the first line of s, truncated to at most n runes with an

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -740,10 +740,9 @@ decisions, and cost/audit history. Irreversible. Refuses to delete _global.`)
 		os.Exit(1)
 	}
 
-	_, logger, store := bootstrap()
+	_, _, store := bootstrap()
 	defer store.Close() //nolint:errcheck
 	ctx := context.Background()
-	_ = logger
 
 	printDeleteSummary := func(summary memory.DeleteProjectSummary, verb string) {
 		fmt.Printf("%s %q (%s):\n", verb, summary.ProjectName, summary.ProjectID)

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -222,7 +222,7 @@ func TestConfirmProjectDeleteName_RejectsMismatch(t *testing.T) {
 // fails this test instead of passing silently.
 func TestPrintDeleteSummary_FieldsNotTransposed(t *testing.T) {
 	var out bytes.Buffer
-	printDeleteSummary(&out, memory.DeleteProjectSummary{
+	if err := printDeleteSummary(&out, memory.DeleteProjectSummary{
 		ProjectID:   "proj",
 		ProjectName: "test-project",
 		Memories:    1,
@@ -231,7 +231,9 @@ func TestPrintDeleteSummary_FieldsNotTransposed(t *testing.T) {
 		Decisions:   4,
 		TokenUsage:  5,
 		AuditLog:    6,
-	}, "Would delete")
+	}, "Would delete"); err != nil {
+		t.Fatalf("printDeleteSummary: %v", err)
+	}
 
 	want := `Would delete "test-project" (proj):
   memories:     1

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -173,3 +173,21 @@ func TestRODSNEscapesPath(t *testing.T) {
 		})
 	}
 }
+
+func TestConfirmProjectDeleteName_MatchesExactly(t *testing.T) {
+	if !confirmProjectDeleteName("my-project\n", "my-project") {
+		t.Error("expected trimmed exact match to confirm")
+	}
+	if !confirmProjectDeleteName("  my-project  ", "my-project") {
+		t.Error("expected surrounding whitespace to be trimmed before comparing")
+	}
+}
+
+func TestConfirmProjectDeleteName_RejectsMismatch(t *testing.T) {
+	if confirmProjectDeleteName("my-projec", "my-project") {
+		t.Error("expected a partial/typo'd name not to confirm")
+	}
+	if confirmProjectDeleteName("", "my-project") {
+		t.Error("expected an empty input not to confirm")
+	}
+}

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -10,6 +13,26 @@ import (
 
 	"github.com/wcatz/ghost/internal/memory"
 )
+
+// testDeleteStore returns a real in-memory Store with one project ("proj",
+// name "test-project") already created, for exercising runProjectDeleteCore
+// against real DeleteProject behavior rather than a mock.
+func testDeleteStore(t *testing.T) *memory.Store {
+	t.Helper()
+	db, err := memory.OpenDB(":memory:")
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := memory.NewStore(db, logger)
+
+	if err := s.EnsureProject(context.Background(), "proj", "/tmp/proj", "test-project"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+	return s
+}
 
 func TestParseObsidianFlags(t *testing.T) {
 	t.Run("both forms and all flags", func(t *testing.T) {
@@ -189,5 +212,131 @@ func TestConfirmProjectDeleteName_RejectsMismatch(t *testing.T) {
 	}
 	if confirmProjectDeleteName("", "my-project") {
 		t.Error("expected an empty input not to confirm")
+	}
+}
+
+// TestPrintDeleteSummary_FieldsNotTransposed pins the label-to-value mapping
+// with six distinct values (one per field) and a whole-string comparison, so
+// swapping any two summary.X arguments inside printDeleteSummary — the same
+// bug class the memory-layer fixture in store_test.go was hardened against —
+// fails this test instead of passing silently.
+func TestPrintDeleteSummary_FieldsNotTransposed(t *testing.T) {
+	var out bytes.Buffer
+	printDeleteSummary(&out, memory.DeleteProjectSummary{
+		ProjectID:   "proj",
+		ProjectName: "test-project",
+		Memories:    1,
+		MemoryLinks: 2,
+		Tasks:       3,
+		Decisions:   4,
+		TokenUsage:  5,
+		AuditLog:    6,
+	}, "Would delete")
+
+	want := `Would delete "test-project" (proj):
+  memories:     1
+  memory_links: 2
+  tasks:        3
+  decisions:    4
+  token_usage:  5
+  audit_log:    6
+`
+	if out.String() != want {
+		t.Errorf("printDeleteSummary output mismatch:\ngot:\n%s\nwant:\n%s", out.String(), want)
+	}
+}
+
+// TestRunProjectDeleteCore_MismatchAborts exercises the full confirmation
+// gate against a real store: apply=true with a wrong re-typed name at the
+// prompt must return an error and leave the project (and its memory)
+// completely untouched. This is the spec's "wrong re-typed name aborts
+// without deleting" requirement.
+func TestRunProjectDeleteCore_MismatchAborts(t *testing.T) {
+	store := testDeleteStore(t)
+	ctx := context.Background()
+
+	if _, err := store.Create(ctx, "proj", memory.Memory{
+		Category: "fact", Content: "must survive an aborted delete", Source: "manual", Importance: 0.5, Tags: []string{},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var out bytes.Buffer
+	err := runProjectDeleteCore(ctx, store, &out, strings.NewReader("wrong-name\n"), "test-project", true)
+	if err == nil {
+		t.Fatal("expected an error for a mismatched confirmation, got nil")
+	}
+	if !strings.Contains(err.Error(), "did not match") {
+		t.Errorf("expected mismatch error, got: %v", err)
+	}
+
+	id, _, rErr := store.ResolveProject(ctx, "test-project")
+	if rErr != nil || id == "" {
+		t.Errorf("expected project to still exist after aborted delete: id=%q err=%v", id, rErr)
+	}
+	mems, gErr := store.GetAll(ctx, "proj", 100)
+	if gErr != nil {
+		t.Fatalf("GetAll: %v", gErr)
+	}
+	if len(mems) != 1 {
+		t.Errorf("expected the seeded memory to survive an aborted delete, got %d memories", len(mems))
+	}
+	if !strings.Contains(out.String(), "Would delete") {
+		t.Errorf("expected dry-run summary in output, got %q", out.String())
+	}
+	if strings.Contains(out.String(), "\nDeleted ") {
+		t.Errorf("did not expect the post-apply 'Deleted' report after an aborted confirmation, got %q", out.String())
+	}
+}
+
+// TestRunProjectDeleteCore_MatchProceeds is the positive counterpart: the
+// correct re-typed name must let the delete proceed and actually remove the
+// project and its memories.
+func TestRunProjectDeleteCore_MatchProceeds(t *testing.T) {
+	store := testDeleteStore(t)
+	ctx := context.Background()
+
+	if _, err := store.Create(ctx, "proj", memory.Memory{
+		Category: "fact", Content: "should be deleted", Source: "manual", Importance: 0.5, Tags: []string{},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var out bytes.Buffer
+	err := runProjectDeleteCore(ctx, store, &out, strings.NewReader("test-project\n"), "test-project", true)
+	if err != nil {
+		t.Fatalf("expected a correctly re-typed name to proceed, got error: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "Deleted ") {
+		t.Errorf("expected the post-apply 'Deleted' report, got %q", out.String())
+	}
+	id, _, rErr := store.ResolveProject(ctx, "test-project")
+	if rErr != nil {
+		t.Fatalf("ResolveProject: %v", rErr)
+	}
+	if id != "" {
+		t.Error("expected project to be gone after a correctly confirmed delete")
+	}
+}
+
+// TestRunProjectDeleteCore_DryRunNeverPrompts confirms apply=false stops
+// after the preview and never reads from in or deletes anything, regardless
+// of what stdin contains.
+func TestRunProjectDeleteCore_DryRunNeverPrompts(t *testing.T) {
+	store := testDeleteStore(t)
+	ctx := context.Background()
+
+	var out bytes.Buffer
+	err := runProjectDeleteCore(ctx, store, &out, strings.NewReader(""), "test-project", false)
+	if err != nil {
+		t.Fatalf("dry-run should not error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Would delete") || !strings.Contains(out.String(), "Re-run with --apply") {
+		t.Errorf("expected dry-run preview and re-run hint, got %q", out.String())
+	}
+	id, _, rErr := store.ResolveProject(ctx, "test-project")
+	if rErr != nil || id == "" {
+		t.Errorf("expected project to still exist after dry-run: id=%q err=%v", id, rErr)
 	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,7 @@ internal/
     vector.go              Cosine similarity, hybrid RRF search
     links.go               Memory links: edge CRUD (related/supersedes)
   mcpserver/               MCP server (stdio transport)
-    mcpserver.go           18 tools + 4 resources via go-sdk
+    mcpserver.go           20 tools + 4 resources via go-sdk
   mcpinit/                 Claude Code integration setup
     init.go                ghost mcp init — registers server, imports memories, writes redirects
     status.go              ghost mcp status — health check
@@ -84,7 +84,7 @@ Claude Code / Cursor → stdio JSON-RPC → mcpserver
                           ghost_task_create/update/complete → store.CreateTask()...
                           ghost_decision_record → store.RecordDecision()
                           ghost_health        → store metadata query
-                          ... 18 tools total
+                          ... 20 tools total
                                           ↓
                         Resources (pinnable, survive context compaction):
                           ghost://project/{id}/context   → GetTopMemories + GetLearnedContext

--- a/docs/superpowers/plans/2026-08-17-delete-project.md
+++ b/docs/superpowers/plans/2026-08-17-delete-project.md
@@ -388,10 +388,21 @@ func TestDeleteProject_IsolatesOtherProjects(t *testing.T) {
 		t.Fatalf("DeleteProject: %v", err)
 	}
 
-	for _, table := range []string{"memories", "tasks", "decisions", "token_usage", "audit_log"} {
-		if n := countRows(t, s, table, otherProject); n != 1 && !(table == "memories" && n == 3) {
-			t.Errorf("%s for %s after deleting %s = %d, unexpected (should be untouched)", table, otherProject, testProject, n)
+	expected := map[string]int{"memories": 3, "tasks": 1, "decisions": 1, "token_usage": 1, "audit_log": 1}
+	for table, want := range expected {
+		if n := countRows(t, s, table, otherProject); n != want {
+			t.Errorf("%s for %s after deleting %s = %d, want %d (should be untouched)", table, otherProject, testProject, n, want)
 		}
+	}
+	var links int
+	if err := s.db.QueryRow(`
+		SELECT count(*) FROM memory_links l
+		JOIN memories m ON m.id = l.source_id
+		WHERE m.project_id = ?`, otherProject).Scan(&links); err != nil {
+		t.Fatalf("count memory_links: %v", err)
+	}
+	if links != 1 {
+		t.Errorf("memory_links for %s = %d, want 1", otherProject, links)
 	}
 	if id, _, err := s.ResolveProject(ctx, otherProject); err != nil || id == "" {
 		t.Errorf("expected %s to still exist, ResolveProject: id=%q err=%v", otherProject, id, err)

--- a/docs/superpowers/plans/2026-08-17-delete-project.md
+++ b/docs/superpowers/plans/2026-08-17-delete-project.md
@@ -942,13 +942,20 @@ Run:
 ```bash
 go build -o /tmp/ghost-final-check ./cmd/ghost
 mkdir -p /tmp/ghost-final-check-data
-XDG_DATA_HOME=/tmp/ghost-final-check-data /tmp/ghost-final-check reflect smoketest --apply >/dev/null 2>&1
+XDG_DATA_HOME=/tmp/ghost-final-check-data /tmp/ghost-final-check project delete nonexistent >/dev/null 2>&1  # touch bootstrap() once so ghost.db exists with schema applied
+sqlite3 /tmp/ghost-final-check-data/ghost/ghost.db <<'SQL'
+INSERT INTO projects (id, path, name) VALUES ('smoketest', 'smoketest', 'smoketest');
+INSERT INTO memories (project_id, category, content, source, importance, tags)
+VALUES ('smoketest', 'fact', 'smoke test seed memory', 'manual', 0.5, '[]');
+SQL
 XDG_DATA_HOME=/tmp/ghost-final-check-data /tmp/ghost-final-check project delete smoketest
 echo "smoketest" | XDG_DATA_HOME=/tmp/ghost-final-check-data /tmp/ghost-final-check project delete smoketest --apply
 XDG_DATA_HOME=/tmp/ghost-final-check-data /tmp/ghost-final-check project delete smoketest
 rm -rf /tmp/ghost-final-check /tmp/ghost-final-check-data
 ```
-Expected: first call prints a dry-run summary with 1 memory (the preference-style memory `reflect --apply` leaves behind, if any — 0 is also fine, this is just proving the command runs end-to-end); second call (apply, with matching typed confirmation) prints "Deleted ..." with counts; third call (post-delete) errors `project "smoketest" not found`, proving the project is actually gone.
+Note: the originally-drafted bootstrap line here, `ghost reflect smoketest --apply`, can never work — `runReflect` resolves the project via `resolveProjectOrExit`/`ResolveProject`, which only looks projects up and never creates one, and nothing in `bootstrap()` or the session-start hook creates a project named `smoketest` either (`loadSessionContext` explicitly refuses to: "no store yet — never create a phantom empty DB"). This isn't an environment gap (no API key/Ollama) — it's structural, so no tier of `reflect` could ever bootstrap a project that doesn't exist yet. The `sqlite3` seed above inserts exactly what `ghost_memory_save`'s create-on-first-save path (`EnsureProject` + `Create` in `internal/memory/store.go`) would have written for `project_id="smoketest"` (path normalized to id, one `fact` memory), without requiring a live MCP client or an LLM.
+
+Expected: first call prints a dry-run summary with 1 memory; second call (apply, with matching typed confirmation) prints "Deleted ..." with counts; third call (post-delete) errors `project "smoketest" not found`, proving the project is actually gone.
 
 - [ ] **Step 3: Final commit if anything is outstanding**
 

--- a/docs/superpowers/plans/2026-08-17-delete-project.md
+++ b/docs/superpowers/plans/2026-08-17-delete-project.md
@@ -1,0 +1,945 @@
+# Delete Project Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `Store.DeleteProject` method, backing both a `ghost project delete <name>` CLI subcommand and a `ghost_project_delete` MCP tool, that permanently removes a project and everything under it (memories, tags, embeddings, links, tasks, decisions, plus the two tables that don't cascade: token_usage, audit_log) — dry-run by default, explicit apply required, `_global` always refused.
+
+**Architecture:** One `Store.DeleteProject(ctx, input string, apply bool) (DeleteProjectSummary, error)` method is the single source of truth for both surfaces, following the same dry-run/apply convention `resolve.Run`/`supersede.Run` already use. It resolves the project via the existing `ResolveProject` (id/name/path/basename), refuses `_global` unconditionally, computes row counts across every affected table (the dry-run view), and — only when `apply` is true — deletes inside one transaction: two explicit `DELETE`s for the non-cascading tables, then one `DELETE FROM projects` that cascades to everything else via the `ON DELETE CASCADE` foreign keys already in `schema.go`.
+
+**Tech Stack:** Go 1.26+, SQLite (modernc.org/sqlite, pure Go), `go test`/`go vet`, modelcontextprotocol/go-sdk (MCP tool registration).
+
+**Spec:** `docs/superpowers/specs/2026-08-17-delete-project-design.md`
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `internal/memory/store.go` | Add `DeleteProjectSummary` type + `DeleteProject` method |
+| `internal/memory/store_test.go` | Add `TestDeleteProject_*` tests |
+| `internal/provider/provider.go` | Add `DeleteProject` to `MemoryStore` interface |
+| `cmd/ghost/main.go` | Add `ghost project delete` subcommand + printUsage entry |
+| `cmd/ghost/main_test.go` | Add `TestConfirmProjectDeleteName_*` tests |
+| `internal/mcpserver/mcpserver.go` | Add `ghost_project_delete` MCP tool |
+| `internal/mcpserver/mcpserver_test.go` | Add `TestGhostProjectDelete_*` tests |
+| `README.md` | Tool count 19→20, add `ghost_project_delete` to the tool table |
+| `CLAUDE.md` | Tool count 19→20 |
+| `docs/architecture.md` | Tool count (already-stale) 18→20 in both places it appears |
+
+---
+
+### Task 1: `Store.DeleteProject` — resolution guards, dry-run counts, apply
+
+**Files:**
+- Modify: `internal/memory/store.go` (add after `MergeProject`/`mergeProjectLocked`, i.e. right before the `ResolveProject` doc comment block, so all project-management methods stay grouped)
+- Test: `internal/memory/store_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/memory/store_test.go`, right after `TestMergeProject` and its helpers (or at the end of the file if easier to locate — anywhere in the file works, `package memory` sees all of it):
+
+```go
+// seedFullProject creates one memory-link pair, one task, one decision (which
+// also creates its own linked memory row, source='decision_log'), one
+// token_usage row, and one audit_log row for projectID — one of everything
+// DeleteProject must account for. Returns the two linked memory IDs.
+func seedFullProject(t *testing.T, s *Store, ctx context.Context, projectID string) (mem1, mem2 string) {
+	t.Helper()
+
+	var err error
+	mem1, err = s.Create(ctx, projectID, Memory{
+		Category: "fact", Content: "seed memory one", Source: "manual", Importance: 0.5, Tags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("seed mem1: %v", err)
+	}
+	mem2, err = s.Create(ctx, projectID, Memory{
+		Category: "fact", Content: "seed memory two", Source: "manual", Importance: 0.5, Tags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("seed mem2: %v", err)
+	}
+	if err := s.CreateLink(ctx, mem1, mem2, "related", 0.8, "auto"); err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+	if _, err := s.CreateTask(ctx, projectID, "seed task", "desc", 1); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	if _, _, err := s.RecordDecision(ctx, projectID, "seed decision", "did the thing", "because", nil, nil); err != nil {
+		t.Fatalf("seed decision: %v", err)
+	}
+	if err := s.RecordUsage(ctx, projectID, "claude-opus-4-6", TokenUsage{InputTokens: 10, OutputTokens: 5}); err != nil {
+		t.Fatalf("seed token_usage: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO audit_log (action, project_id) VALUES ('test-action', ?)`, projectID,
+	); err != nil {
+		t.Fatalf("seed audit_log: %v", err)
+	}
+	return mem1, mem2
+}
+
+// countRows returns the number of rows in table matching a project_id column,
+// queried directly so the assertion doesn't depend on DeleteProject's own
+// counting logic being correct.
+func countRows(t *testing.T, s *Store, table, projectID string) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(`SELECT count(*) FROM `+table+` WHERE project_id = ?`, projectID).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+func TestDeleteProject_NotFound(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	_, err := s.DeleteProject(ctx, "no-such-project", false)
+	if err == nil {
+		t.Fatal("expected error for nonexistent project")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected %q in error, got: %v", "not found", err)
+	}
+}
+
+func TestDeleteProject_RefusesGlobal(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	if err := s.SeedGlobalMemories(ctx); err != nil {
+		t.Fatalf("SeedGlobalMemories: %v", err)
+	}
+
+	for _, apply := range []bool{false, true} {
+		_, err := s.DeleteProject(ctx, "_global", apply)
+		if err == nil {
+			t.Fatalf("expected error deleting _global (apply=%v)", apply)
+		}
+	}
+
+	// The seeded global preference must have survived both attempts.
+	mems, err := s.GetAll(ctx, "_global", 100)
+	if err != nil {
+		t.Fatalf("GetAll _global: %v", err)
+	}
+	if len(mems) == 0 {
+		t.Error("expected _global memories to survive refused delete attempts")
+	}
+}
+
+func TestDeleteProject_DryRunCountsAndWritesNothing(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	seedFullProject(t, s, ctx, testProject)
+
+	summary, err := s.DeleteProject(ctx, testProject, false)
+	if err != nil {
+		t.Fatalf("DeleteProject dry-run: %v", err)
+	}
+
+	if summary.ProjectID != testProject {
+		t.Errorf("ProjectID = %q, want %q", summary.ProjectID, testProject)
+	}
+	// 3 memories: the 2 seeded directly + 1 from RecordDecision's decision_log row.
+	if summary.Memories != 3 {
+		t.Errorf("Memories = %d, want 3", summary.Memories)
+	}
+	if summary.MemoryLinks != 1 {
+		t.Errorf("MemoryLinks = %d, want 1", summary.MemoryLinks)
+	}
+	if summary.Tasks != 1 {
+		t.Errorf("Tasks = %d, want 1", summary.Tasks)
+	}
+	if summary.Decisions != 1 {
+		t.Errorf("Decisions = %d, want 1", summary.Decisions)
+	}
+	if summary.TokenUsage != 1 {
+		t.Errorf("TokenUsage = %d, want 1", summary.TokenUsage)
+	}
+	if summary.AuditLog != 1 {
+		t.Errorf("AuditLog = %d, want 1", summary.AuditLog)
+	}
+
+	// Dry-run must write nothing: every row must still be there.
+	if n := countRows(t, s, "memories", testProject); n != 3 {
+		t.Errorf("memories after dry-run = %d, want 3 (unchanged)", n)
+	}
+	if n := countRows(t, s, "tasks", testProject); n != 1 {
+		t.Errorf("tasks after dry-run = %d, want 1 (unchanged)", n)
+	}
+	if n := countRows(t, s, "token_usage", testProject); n != 1 {
+		t.Errorf("token_usage after dry-run = %d, want 1 (unchanged)", n)
+	}
+	if _, _, err := s.ResolveProject(ctx, testProject); err != nil {
+		t.Fatalf("ResolveProject after dry-run: %v", err)
+	}
+}
+
+func TestDeleteProject_ApplyRemovesEverythingIncludingOrphanTables(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	seedFullProject(t, s, ctx, testProject)
+
+	summary, err := s.DeleteProject(ctx, testProject, true)
+	if err != nil {
+		t.Fatalf("DeleteProject apply: %v", err)
+	}
+	if summary.Memories != 3 || summary.MemoryLinks != 1 || summary.Tasks != 1 ||
+		summary.Decisions != 1 || summary.TokenUsage != 1 || summary.AuditLog != 1 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+
+	for _, table := range []string{"memories", "tasks", "decisions", "token_usage", "audit_log"} {
+		if n := countRows(t, s, table, testProject); n != 0 {
+			t.Errorf("%s after apply = %d, want 0", table, n)
+		}
+	}
+	var linkCount int
+	if err := s.db.QueryRow(`
+		SELECT count(*) FROM memory_links
+		WHERE source_id NOT IN (SELECT id FROM memories) OR target_id NOT IN (SELECT id FROM memories)
+	`).Scan(&linkCount); err != nil {
+		t.Fatalf("check dangling links: %v", err)
+	}
+	if linkCount != 0 {
+		t.Errorf("expected no dangling memory_links pointing at deleted memories, got %d", linkCount)
+	}
+
+	// The project row itself is gone.
+	id, _, err := s.ResolveProject(ctx, testProject)
+	if err != nil {
+		t.Fatalf("ResolveProject after apply: %v", err)
+	}
+	if id != "" {
+		t.Errorf("expected project to be gone, ResolveProject still returns id %q", id)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/memory/... -run TestDeleteProject -v`
+Expected: FAIL — `s.DeleteProject` and `s.CreateLink`'s companion type don't compile yet (`undefined: DeleteProjectSummary` / `s.DeleteProject undefined`).
+
+- [ ] **Step 3: Implement `DeleteProjectSummary` and `DeleteProject`**
+
+In `internal/memory/store.go`, add immediately after `mergeProjectLocked`'s closing brace (i.e. right before the `// ResolveProject resolves an identifier...` doc comment):
+
+```go
+// DeleteProjectSummary reports what DeleteProject found (dry-run) or removed
+// (apply) for one project, across every table that references it.
+type DeleteProjectSummary struct {
+	ProjectID   string
+	ProjectName string
+	Memories    int
+	MemoryLinks int
+	Tasks       int
+	Decisions   int
+	TokenUsage  int
+	AuditLog    int
+}
+
+// DeleteProject permanently removes a project and everything under it.
+// memories (and their tags, embeddings, and links), tasks, decisions,
+// ghost_state, and memory_snapshots all cascade from the projects row via
+// ON DELETE CASCADE (see schema.go). token_usage and audit_log carry a
+// project_id column but no foreign key, so they're deleted explicitly in the
+// same transaction.
+//
+// input is resolved exactly like every other command resolves a project (see
+// ResolveProject): id, name, path-prefix, or basename all work.
+//
+// apply=false computes and returns the summary without writing anything.
+// apply=true performs the same computation, then actually deletes everything
+// in one transaction, returning the summary of what was removed. _global can
+// never be deleted, in either mode — it's shared across every project's
+// context injection.
+//
+// ResolveProject takes its own RLock internally, so it's called here before
+// this method takes s.mu itself — taking s.mu first and then calling
+// ResolveProject would deadlock against sync.RWMutex's non-reentrant lock.
+func (s *Store) DeleteProject(ctx context.Context, input string, apply bool) (DeleteProjectSummary, error) {
+	id, name, err := s.ResolveProject(ctx, input)
+	if err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("resolve project: %w", err)
+	}
+	if id == "" {
+		return DeleteProjectSummary{}, fmt.Errorf("project %q not found", input)
+	}
+	if id == "_global" {
+		return DeleteProjectSummary{}, fmt.Errorf("refusing to delete the _global project")
+	}
+
+	if apply {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+	} else {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
+
+	summary := DeleteProjectSummary{ProjectID: id, ProjectName: name}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM memories WHERE project_id = ?`, id,
+	).Scan(&summary.Memories); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count memories: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT count(*) FROM memory_links
+		WHERE source_id IN (SELECT id FROM memories WHERE project_id = ?)
+		   OR target_id IN (SELECT id FROM memories WHERE project_id = ?)
+	`, id, id).Scan(&summary.MemoryLinks); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count memory_links: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM tasks WHERE project_id = ?`, id,
+	).Scan(&summary.Tasks); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count tasks: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM decisions WHERE project_id = ?`, id,
+	).Scan(&summary.Decisions); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count decisions: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM token_usage WHERE project_id = ?`, id,
+	).Scan(&summary.TokenUsage); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count token_usage: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM audit_log WHERE project_id = ?`, id,
+	).Scan(&summary.AuditLog); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count audit_log: %w", err)
+	}
+
+	if !apply {
+		return summary, nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("begin delete tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM token_usage WHERE project_id = ?`, id); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("delete token_usage: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM audit_log WHERE project_id = ?`, id); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("delete audit_log: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM projects WHERE id = ?`, id); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("delete project: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("commit delete: %w", err)
+	}
+
+	s.logger.Info("deleted project", "project_id", id, "project_name", name,
+		"memories", summary.Memories, "tasks", summary.Tasks, "decisions", summary.Decisions)
+	return summary, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/memory/... -run TestDeleteProject -v`
+Expected: `PASS` for all 4 new tests.
+
+- [ ] **Step 5: Run the full package test suite and vet**
+
+Run: `go vet ./internal/memory/... && go test ./internal/memory/...`
+Expected: both clean, no regressions in the rest of the package.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/memory/store.go internal/memory/store_test.go
+git commit -m "feat(memory): add Store.DeleteProject with dry-run/apply"
+```
+
+---
+
+### Task 2: Isolation test — deleting one project must not touch another's rows
+
+**Files:**
+- Test: `internal/memory/store_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/memory/store_test.go`:
+
+```go
+func TestDeleteProject_IsolatesOtherProjects(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	const otherProject = "other-project"
+	if err := s.EnsureProject(ctx, otherProject, "/tmp/other-project", "other-project"); err != nil {
+		t.Fatalf("EnsureProject other: %v", err)
+	}
+
+	seedFullProject(t, s, ctx, testProject)
+	seedFullProject(t, s, ctx, otherProject)
+
+	if _, err := s.DeleteProject(ctx, testProject, true); err != nil {
+		t.Fatalf("DeleteProject: %v", err)
+	}
+
+	for _, table := range []string{"memories", "tasks", "decisions", "token_usage", "audit_log"} {
+		if n := countRows(t, s, table, otherProject); n != 1 && !(table == "memories" && n == 3) {
+			t.Errorf("%s for %s after deleting %s = %d, unexpected (should be untouched)", table, otherProject, testProject, n)
+		}
+	}
+	if id, _, err := s.ResolveProject(ctx, otherProject); err != nil || id == "" {
+		t.Errorf("expected %s to still exist, ResolveProject: id=%q err=%v", otherProject, id, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/memory/... -run TestDeleteProject_IsolatesOtherProjects -v`
+Expected: FAIL if Task 1's implementation has any bug scoping deletes to the wrong project (it shouldn't, but this is the check that proves it). If Task 1 is correct, this may pass immediately — that's fine, TDD's "verify it fails first" step here is really "verify the assertions are meaningful," so read the failure output carefully if it does fail before moving on.
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `go test ./internal/memory/... -run TestDeleteProject -v`
+Expected: `PASS` for all 5 `TestDeleteProject_*` tests now.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/memory/store_test.go
+git commit -m "test(memory): verify DeleteProject doesn't leak across projects"
+```
+
+---
+
+### Task 3: Wire `DeleteProject` into `provider.MemoryStore`
+
+**Files:**
+- Modify: `internal/provider/provider.go:76` (the "Project management" group, right after `MergeProject`)
+
+- [ ] **Step 1: Add the method to the interface**
+
+In `internal/provider/provider.go`, change:
+
+```go
+	// Project management
+	ListProjects(ctx context.Context) ([]memory.Project, error)
+	EnsureProject(ctx context.Context, id, path, name string) error
+	ResolveProject(ctx context.Context, input string) (id, name string, err error)
+	ListProjectNames(ctx context.Context) ([]string, error)
+	MergeProject(ctx context.Context, oldID, newID string) error
+```
+
+to:
+
+```go
+	// Project management
+	ListProjects(ctx context.Context) ([]memory.Project, error)
+	EnsureProject(ctx context.Context, id, path, name string) error
+	ResolveProject(ctx context.Context, input string) (id, name string, err error)
+	ListProjectNames(ctx context.Context) ([]string, error)
+	MergeProject(ctx context.Context, oldID, newID string) error
+	DeleteProject(ctx context.Context, input string, apply bool) (memory.DeleteProjectSummary, error)
+```
+
+- [ ] **Step 2: Verify the build**
+
+Run: `go build ./... && go vet ./...`
+Expected: both clean — `*Store` already satisfies the wider interface since `DeleteProject` was added in Task 1.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/provider/provider.go
+git commit -m "feat(provider): expose DeleteProject on MemoryStore"
+```
+
+---
+
+### Task 4: CLI — `ghost project delete <name-or-id> [--apply]`
+
+**Files:**
+- Modify: `cmd/ghost/main.go` (top-level switch around line 47-77, new `runProjectDelete` function, `printUsage` around line 938-968)
+- Test: `cmd/ghost/main_test.go`
+
+- [ ] **Step 1: Write the failing test for the confirmation-match helper**
+
+The confirmation-prompt gate's actual decision logic (does what the user typed match the project name?) is pulled into its own pure function so it's unit-testable without subprocess/stdin plumbing — `runProjectDelete` itself, like every other `run*` function in this file, calls `os.Exit` and isn't unit tested directly (matching the existing convention for `runResolve`/`runSupersede`/`resolveProjectOrExit`).
+
+Add to `cmd/ghost/main_test.go`:
+
+```go
+func TestConfirmProjectDeleteName_MatchesExactly(t *testing.T) {
+	if !confirmProjectDeleteName("my-project\n", "my-project") {
+		t.Error("expected trimmed exact match to confirm")
+	}
+	if !confirmProjectDeleteName("  my-project  ", "my-project") {
+		t.Error("expected surrounding whitespace to be trimmed before comparing")
+	}
+}
+
+func TestConfirmProjectDeleteName_RejectsMismatch(t *testing.T) {
+	if confirmProjectDeleteName("my-projec", "my-project") {
+		t.Error("expected a partial/typo'd name not to confirm")
+	}
+	if confirmProjectDeleteName("", "my-project") {
+		t.Error("expected an empty input not to confirm")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/ghost/... -run TestConfirmProjectDeleteName -v`
+Expected: FAIL — `undefined: confirmProjectDeleteName`.
+
+- [ ] **Step 3: Add the `project` case to the top-level switch**
+
+In `cmd/ghost/main.go`, change:
+
+```go
+		case "resolve":
+			runResolve()
+			return
+		case "upgrade":
+```
+
+to:
+
+```go
+		case "resolve":
+			runResolve()
+			return
+		case "project":
+			if len(os.Args) > 2 && os.Args[2] == "delete" {
+				runProjectDelete()
+				return
+			}
+			fmt.Fprintln(os.Stderr, "Usage: ghost project delete <name-or-id> [--apply]")
+			os.Exit(1)
+		case "upgrade":
+```
+
+- [ ] **Step 4: Add `confirmProjectDeleteName` and `runProjectDelete`**
+
+Add both right after `runResolve` (after its closing brace, before the `firstLine` helper — both because they belong with the other `run*` command functions and because `runProjectDelete` uses `firstLine`-adjacent conventions):
+
+```go
+// confirmProjectDeleteName reports whether typed (a raw scanned line, not
+// yet trimmed) matches expected exactly once surrounding whitespace is
+// stripped. Pulled out of runProjectDelete as its own pure function so the
+// actual confirmation decision is unit-testable without stdin/os.Exit
+// plumbing.
+func confirmProjectDeleteName(typed, expected string) bool {
+	return strings.TrimSpace(typed) == expected
+}
+
+// runProjectDelete implements `ghost project delete <name-or-id> [--apply]`.
+// Always prints the dry-run summary first. Without --apply it stops there.
+// With --apply, it re-prints the summary and requires re-typing the
+// project's name at a prompt before anything is actually deleted — this is
+// irreversible and there is no undo, so the flag alone is not enough.
+func runProjectDelete() {
+	var projectName string
+	apply := false
+	for i := 3; i < len(os.Args); i++ {
+		switch {
+		case os.Args[i] == "--apply":
+			apply = true
+		case !strings.HasPrefix(os.Args[i], "-"):
+			if projectName != "" {
+				fmt.Fprintln(os.Stderr, "error: expected exactly one project")
+				os.Exit(1)
+			}
+			projectName = os.Args[i]
+		default:
+			fmt.Fprintf(os.Stderr, "error: unknown flag %q\n", os.Args[i])
+			os.Exit(1)
+		}
+	}
+	if projectName == "" {
+		fmt.Fprintln(os.Stderr, `Usage: ghost project delete <name-or-id> [flags]
+
+Flags:
+  --apply   Actually delete (default is dry-run/preview)
+
+Permanently removes a project: memories, tags, embeddings, links, tasks,
+decisions, and cost/audit history. Irreversible. Refuses to delete _global.`)
+		os.Exit(1)
+	}
+
+	_, logger, store := bootstrap()
+	defer store.Close() //nolint:errcheck
+	ctx := context.Background()
+	_ = logger
+
+	printDeleteSummary := func(summary memory.DeleteProjectSummary, verb string) {
+		fmt.Printf("%s %q (%s):\n", verb, summary.ProjectName, summary.ProjectID)
+		fmt.Printf("  memories:     %d\n", summary.Memories)
+		fmt.Printf("  memory_links: %d\n", summary.MemoryLinks)
+		fmt.Printf("  tasks:        %d\n", summary.Tasks)
+		fmt.Printf("  decisions:    %d\n", summary.Decisions)
+		fmt.Printf("  token_usage:  %d\n", summary.TokenUsage)
+		fmt.Printf("  audit_log:    %d\n", summary.AuditLog)
+	}
+
+	summary, err := store.DeleteProject(ctx, projectName, false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	printDeleteSummary(summary, "Would delete")
+
+	if !apply {
+		fmt.Println("\nRe-run with --apply to actually delete.")
+		return
+	}
+
+	fmt.Printf("\nType the project name (%q) to confirm deletion: ", summary.ProjectName)
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Scan()
+	if !confirmProjectDeleteName(scanner.Text(), summary.ProjectName) {
+		fmt.Fprintln(os.Stderr, "error: confirmation did not match project name — nothing deleted")
+		os.Exit(1)
+	}
+
+	summary, err = store.DeleteProject(ctx, projectName, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	printDeleteSummary(summary, "Deleted")
+}
+```
+
+Note: `logger` from `bootstrap()` is unused in this function (unlike `runResolve`, there's no classify provider to build here) — `_ = logger` keeps the compiler happy without changing `bootstrap`'s signature for every caller. Add `"bufio"` to the import block (it's not currently imported in `cmd/ghost/main.go`):
+
+```go
+import (
+	"bufio"
+	"bytes"
+	"context"
+```
+
+- [ ] **Step 5: Run the confirmation-helper tests to verify they pass**
+
+Run: `go test ./cmd/ghost/... -run TestConfirmProjectDeleteName -v`
+Expected: `PASS` for both tests.
+
+- [ ] **Step 6: Add the `printUsage` entry**
+
+In `cmd/ghost/main.go`'s `printUsage`, change:
+
+```go
+  resolve <project> [flags]   Mark resolved evidence memories (dry-run by default, --apply to write)
+  obsidian export [flags]     Mirror memories to an Obsidian vault (one-way)
+```
+
+to:
+
+```go
+  resolve <project> [flags]   Mark resolved evidence memories (dry-run by default, --apply to write)
+  project delete <name> [flags]  Permanently delete a project and everything under it
+                              (dry-run by default, --apply + name re-type to confirm)
+  obsidian export [flags]     Mirror memories to an Obsidian vault (one-way)
+```
+
+- [ ] **Step 7: Build and smoke-test manually**
+
+Run:
+```bash
+go build -o /tmp/ghost-delete-check ./cmd/ghost
+mkdir -p /tmp/ghost-delete-check-data
+XDG_DATA_HOME=/tmp/ghost-delete-check-data /tmp/ghost-delete-check reflect smoketest --apply >/dev/null 2>&1
+XDG_DATA_HOME=/tmp/ghost-delete-check-data /tmp/ghost-delete-check project delete no-such-project
+XDG_DATA_HOME=/tmp/ghost-delete-check-data /tmp/ghost-delete-check project delete global
+echo "no-name" | XDG_DATA_HOME=/tmp/ghost-delete-check-data /tmp/ghost-delete-check project delete global --apply
+rm -rf /tmp/ghost-delete-check /tmp/ghost-delete-check-data
+```
+Expected: first delete errors `project "no-such-project" not found`; second (dry-run on `_global`, resolved via its name `global`) errors `refusing to delete the _global project`; third (apply on `_global` with a deliberately wrong confirmation) also refuses before ever reaching the confirmation prompt, since `DeleteProject`'s `_global` guard fires on the initial dry-run call before the prompt is even shown.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/ghost/main.go cmd/ghost/main_test.go
+git commit -m "feat(cli): add ghost project delete subcommand"
+```
+
+---
+
+### Task 5: MCP tool — `ghost_project_delete`
+
+**Files:**
+- Modify: `internal/mcpserver/mcpserver.go` (new tool registration, near `ghost_list_projects` around line 1257 — same "project management" neighborhood)
+- Test: `internal/mcpserver/mcpserver_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/mcpserver/mcpserver_test.go`:
+
+```go
+func TestGhostProjectDelete_DryRunByDefault(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	if _, err := store.Create(ctx, "test-project", memory.Memory{
+		Category: "fact", Content: "will this survive a dry run", Source: "manual", Importance: 0.5, Tags: []string{},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_project_delete",
+		Arguments: map[string]any{"project": "test-project"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_project_delete: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error result: %+v", result.Content)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	if !strings.Contains(text.Text, "Would delete") {
+		t.Errorf("expected dry-run framing %q in response, got %q", "Would delete", text.Text)
+	}
+
+	all, err := store.GetAll(ctx, "test-project", 100)
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("expected memory to survive dry-run, got %d memories", len(all))
+	}
+}
+
+func TestGhostProjectDelete_ApplyRemovesProject(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	if _, err := store.Create(ctx, "test-project", memory.Memory{
+		Category: "fact", Content: "will this survive apply", Source: "manual", Importance: 0.5, Tags: []string{},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_project_delete",
+		Arguments: map[string]any{"project": "test-project", "apply": true},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_project_delete: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error result: %+v", result.Content)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	if !strings.Contains(text.Text, "Deleted") {
+		t.Errorf("expected apply framing %q in response, got %q", "Deleted", text.Text)
+	}
+
+	id, _, err := store.ResolveProject(ctx, "test-project")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "" {
+		t.Error("expected project to be gone after apply")
+	}
+}
+
+func TestGhostProjectDelete_RejectsGlobal(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+	ctx := context.Background()
+	if err := store.SeedGlobalMemories(ctx); err != nil {
+		t.Fatalf("SeedGlobalMemories: %v", err)
+	}
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_project_delete",
+		Arguments: map[string]any{"project": "_global", "apply": true},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_project_delete: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected an error result deleting _global, got success")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/mcpserver/... -run TestGhostProjectDelete -v`
+Expected: FAIL — `unknown tool "ghost_project_delete"` (or equivalent "tool not found" error from the go-sdk).
+
+- [ ] **Step 3: Register the tool**
+
+In `internal/mcpserver/mcpserver.go`, add near `ghost_list_projects` (after its closing `})`, before the `ghost_memory_pin` registration — matching the file's existing grouping of project-management tools):
+
+```go
+	// ghost_project_delete — permanently delete a project and everything
+	// under it. Dry-run by default; apply:true actually deletes. _global is
+	// always refused, in both modes.
+	type projectDeleteArgs struct {
+		Project string `json:"project" jsonschema:"the project to delete (id, name, or path)"`
+		Apply   bool   `json:"apply,omitempty" jsonschema:"actually delete (default false: dry-run preview only)"`
+	}
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:        "ghost_project_delete",
+		Title:       "Delete Project",
+		Description: "Permanently deletes a project: memories, tags, embeddings, links, tasks, decisions, and cost/audit history. Irreversible — there is no undo. Dry-run by default (returns counts of what would be removed); pass apply:true to actually delete. Always refuses to delete the _global project. Only use when the user has explicitly and unambiguously asked to delete an entire project, never as a side effect of another request.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(true),
+			OpenWorldHint:   boolPtr(false),
+		},
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args projectDeleteArgs) (*mcp.CallToolResult, any, error) {
+		if args.Project == "" {
+			return nil, nil, fmt.Errorf("project is required")
+		}
+		summary, err := s.store.DeleteProject(ctx, args.Project, args.Apply)
+		if err != nil {
+			return nil, nil, fmt.Errorf("ghost_project_delete: %w", err)
+		}
+		verb := "Would delete"
+		if args.Apply {
+			verb = "Deleted"
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%s %q (%s):\n", verb, summary.ProjectName, summary.ProjectID)
+		fmt.Fprintf(&sb, "  memories:     %d\n", summary.Memories)
+		fmt.Fprintf(&sb, "  memory_links: %d\n", summary.MemoryLinks)
+		fmt.Fprintf(&sb, "  tasks:        %d\n", summary.Tasks)
+		fmt.Fprintf(&sb, "  decisions:    %d\n", summary.Decisions)
+		fmt.Fprintf(&sb, "  token_usage:  %d\n", summary.TokenUsage)
+		fmt.Fprintf(&sb, "  audit_log:    %d\n", summary.AuditLog)
+		if !args.Apply {
+			sb.WriteString("\nRe-run with apply:true to actually delete.")
+		}
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: sb.String()}}}, nil, nil
+	})
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/mcpserver/... -run TestGhostProjectDelete -v`
+Expected: `PASS` for all 3 new tests.
+
+- [ ] **Step 5: Run the full test suite and vet**
+
+Run: `go vet ./... && go test ./...`
+Expected: everything clean, no regressions anywhere.
+
+- [ ] **Step 6: Update tool-count references**
+
+In `README.md`, change:
+
+```
+19 tools, 4 resources:
+
+| Group | Tools |
+|---|---|
+| Memory | `ghost_memory_save` `ghost_memory_search` `ghost_search_all` `ghost_memories_list` `ghost_memory_update` `ghost_memory_delete` `ghost_memory_pin` `ghost_memory_promote` `ghost_save_global` `ghost_resolve` |
+| Context | `ghost_project_context` `ghost_list_projects` `ghost_health` |
+```
+
+to:
+
+```
+20 tools, 4 resources:
+
+| Group | Tools |
+|---|---|
+| Memory | `ghost_memory_save` `ghost_memory_search` `ghost_search_all` `ghost_memories_list` `ghost_memory_update` `ghost_memory_delete` `ghost_memory_pin` `ghost_memory_promote` `ghost_save_global` `ghost_resolve` |
+| Context | `ghost_project_context` `ghost_list_projects` `ghost_health` `ghost_project_delete` |
+```
+
+In `CLAUDE.md`, change:
+
+```
+- `internal/mcpserver/` — MCP server: 19 tools + 4 resources + 2 prompts (`recall_project`, `record_decision`)
+```
+
+to:
+
+```
+- `internal/mcpserver/` — MCP server: 20 tools + 4 resources + 2 prompts (`recall_project`, `record_decision`)
+```
+
+In `docs/architecture.md`, change (this was already stale at 18 before this feature — fixing both references to the correct current count in the same edit):
+
+```
+    mcpserver.go           18 tools + 4 resources via go-sdk
+```
+
+to:
+
+```
+    mcpserver.go           20 tools + 4 resources via go-sdk
+```
+
+and:
+
+```
+                          ... 18 tools total
+```
+
+to:
+
+```
+                          ... 20 tools total
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/mcpserver/mcpserver.go internal/mcpserver/mcpserver_test.go README.md CLAUDE.md docs/architecture.md
+git commit -m "feat(mcpserver): add ghost_project_delete tool, update tool counts"
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Full build, vet, test**
+
+Run: `go build ./... && go vet ./... && go test ./...`
+Expected: all clean.
+
+- [ ] **Step 2: Manual MCP smoke test via CLI-equivalent path**
+
+Run:
+```bash
+go build -o /tmp/ghost-final-check ./cmd/ghost
+mkdir -p /tmp/ghost-final-check-data
+XDG_DATA_HOME=/tmp/ghost-final-check-data /tmp/ghost-final-check reflect smoketest --apply >/dev/null 2>&1
+XDG_DATA_HOME=/tmp/ghost-final-check-data /tmp/ghost-final-check project delete smoketest
+echo "smoketest" | XDG_DATA_HOME=/tmp/ghost-final-check-data /tmp/ghost-final-check project delete smoketest --apply
+XDG_DATA_HOME=/tmp/ghost-final-check-data /tmp/ghost-final-check project delete smoketest
+rm -rf /tmp/ghost-final-check /tmp/ghost-final-check-data
+```
+Expected: first call prints a dry-run summary with 1 memory (the preference-style memory `reflect --apply` leaves behind, if any — 0 is also fine, this is just proving the command runs end-to-end); second call (apply, with matching typed confirmation) prints "Deleted ..." with counts; third call (post-delete) errors `project "smoketest" not found`, proving the project is actually gone.
+
+- [ ] **Step 3: Final commit if anything is outstanding**
+
+Run: `git status --short`
+Expected: clean (everything already committed per-task). If anything is outstanding, `git add` and commit it with an appropriately scoped message before moving to review/PR.

--- a/docs/superpowers/specs/2026-08-17-delete-project-design.md
+++ b/docs/superpowers/specs/2026-08-17-delete-project-design.md
@@ -1,0 +1,93 @@
+# Delete Project — Design
+
+## Context
+
+Ghost has no way to remove a project and everything under it. `ghost_memory_delete` only removes one memory at a time; `ghost_list_projects` is read-only. There is no CLI or MCP path that wipes a project's memories, tags, links, tasks, decisions, or cost/audit history in one operation.
+
+At the schema level (`internal/memory/schema.go`), most child tables already cascade from `projects` via `ON DELETE CASCADE`, and every connection opens with `foreign_keys(ON)` (`OpenDB`, schema.go), so cascades actually fire:
+
+- Cascades automatically from `projects(id)`: `memories` (tags live as a JSON column on the memory row, not a separate table, so they go with it), `memory_embeddings` and `memory_links`/`link_scans` (both cascade from `memories(id)`, which itself cascades from `projects(id)`), `tasks`, `decisions`, `ghost_state`, `memory_snapshots`.
+- Does **not** cascade: `token_usage` and `audit_log` both carry a `project_id` column with no foreign key constraint at all. A raw `DELETE FROM projects` leaves both tables holding rows that reference a project ID that no longer exists.
+
+So a real delete-project feature is mostly "delete the project row and let the FKs do their job," plus two explicit cleanup statements for the tables that don't cascade.
+
+## Goals
+
+- A CLI subcommand, `ghost project delete <name-or-id>`, and an MCP tool, `ghost_project_delete`, both backed by one `Store.DeleteProject` method — no duplicated deletion logic between the two surfaces.
+- Dry-run by default; an explicit `apply` (MCP) / `--apply` (CLI) is required to actually delete, following the same convention `ghost resolve`/`ghost supersede` already use.
+- The CLI additionally requires re-typing the project's name at a confirmation prompt when `--apply` is passed, since this is irreversible and has no undo.
+- `_global` can never be deleted, regardless of flags — it's a shared, seeded project every other project's context injection depends on.
+- Project identification works exactly like every other command: `Store.ResolveProject` (id → name → path-prefix → basename), so a user can pass whatever they'd type anywhere else in Ghost.
+- The two non-cascading tables (`token_usage`, `audit_log`) are explicitly cleaned up as part of the same apply, so nothing is left orphaned.
+
+## Non-goals
+
+- No Obsidian vault cleanup. The vault mirror (`internal/obsidian`) is a separate one-way export; a deleted project's exported notes are left in place for the user (or a future `ghost obsidian sync` pass) to deal with. Wiring vault deletion into this feature couples two independently-versioned subsystems for a cosmetic gain.
+- No backup/export-before-delete step. The CLI's dry-run summary plus the re-type confirmation is the safety net; this is not a substitute for `sqlite3 <db> ".dump"` if the user actually needs a backup first.
+- No bulk/multi-project delete. One project per invocation.
+- No change to `ResolveProject`, `MergeProject`, or any other existing store method.
+
+## Design
+
+### `Store.DeleteProject`
+
+```go
+type DeleteProjectSummary struct {
+	ProjectID   string
+	ProjectName string
+	Memories    int
+	MemoryLinks int
+	Tasks       int
+	Decisions   int
+	TokenUsage  int
+	AuditLog    int
+}
+
+func (s *Store) DeleteProject(ctx context.Context, input string, apply bool) (DeleteProjectSummary, error)
+```
+
+1. Resolve `input` via `s.ResolveProject(ctx, input)`. An empty `id` result (Ghost's existing "not found" convention — see every `ResolveProject` call site in `mcpserver.go`/`main.go`) becomes `fmt.Errorf("project %q not found", input)`.
+2. If the resolved `id == "_global"`, return an error immediately — `fmt.Errorf("refusing to delete the _global project")` — before computing anything else. This check runs whether or not `apply` is set, so even a dry-run on `_global` reports the refusal rather than a misleading count.
+3. Compute the summary counts, always (this is the dry-run view):
+   - `SELECT count(*) FROM memories WHERE project_id = ?`
+   - `SELECT count(*) FROM memory_links WHERE source_id IN (SELECT id FROM memories WHERE project_id = ?) OR target_id IN (SELECT id FROM memories WHERE project_id = ?)` — links reference `memories(id)`, not `projects(id)`, so this has to join through memories rather than filter directly.
+   - `SELECT count(*) FROM tasks WHERE project_id = ?`
+   - `SELECT count(*) FROM decisions WHERE project_id = ?`
+   - `SELECT count(*) FROM token_usage WHERE project_id = ?`
+   - `SELECT count(*) FROM audit_log WHERE project_id = ?`
+4. If `apply` is false, return the summary with no writes.
+5. If `apply` is true, run inside one transaction (mirroring `mergeProjectLocked`'s existing tx pattern in the same file):
+   - `DELETE FROM token_usage WHERE project_id = ?`
+   - `DELETE FROM audit_log WHERE project_id = ?`
+   - `DELETE FROM projects WHERE id = ?` — cascades to memories, memory_embeddings, memory_links, link_scans, tasks, decisions, ghost_state, memory_snapshots.
+   - Commit. Return the same summary computed in step 3 (it reflects what was actually removed, since nothing else can write to a project mid-call under `s.mu.Lock()`).
+
+`DeleteProject` takes `s.mu.Lock()` for the apply path (mutating) and `s.mu.RLock()` for the dry-run-only path (read-only), matching the existing lock-per-method convention elsewhere in `store.go`.
+
+### `provider.MemoryStore` interface
+
+Add `DeleteProject(ctx context.Context, input string, apply bool) (memory.DeleteProjectSummary, error)` alongside the other project-management methods.
+
+### CLI: `ghost project delete <name-or-id>`
+
+New top-level `case "project":` in `cmd/ghost/main.go` (the first CLI use of a `project` verb group), with a `delete` subcommand and a `--apply` flag, following the existing flag-parsing style used by `reflect`/`resolve`/`supersede`.
+
+- Without `--apply`: resolve and print the summary (project name/id and each count), then exit 0. No prompt, nothing written.
+- With `--apply`: print the same summary, then prompt `Type the project name to confirm deletion: ` and read a line from stdin. If it doesn't match the resolved project's name exactly, abort with a non-zero exit and delete nothing. If it matches, call `DeleteProject(..., apply=true)` and print a final confirmation line with the counts actually removed.
+
+### MCP tool: `ghost_project_delete`
+
+Same shape as `ghost_resolve`: args `project` (required) and `apply` (default `false`). Tool description states plainly that this is irreversible and that `_global` is refused. Response text always includes the summary; when `apply` is false it's framed as a preview ("would delete: ..."), when `apply` is true it's framed as a result ("deleted: ..."). No interactive confirmation step over MCP — there's no terminal to prompt through, so the tool response itself carries the full weight of making the action legible before/after the fact.
+
+## Testing
+
+- `Store.DeleteProject` unit tests in `internal/memory/store_test.go`:
+  - Dry-run (`apply=false`) returns correct counts and leaves every row in place (assert row counts unchanged after the call).
+  - `apply=true` removes the project row and every cascaded table, plus explicitly empties `token_usage`/`audit_log` for that project — verified by direct `SELECT count(*)` against each table, not just checking the returned summary.
+  - Deleting `_global` errors in both dry-run and apply modes, and mutates nothing.
+  - A nonexistent project (bad id, bad name, bad path) errors with the same `%q not found` shape every other command uses.
+  - A project with rows in every table (memories with links between them, tasks, decisions, token_usage, audit_log) is deleted cleanly in one pass — this is the "all it's memories and tags, links etc" case from the original ask.
+  - Deleting one project doesn't touch another project's rows (basic isolation check, cheap to add).
+- CLI test(s) covering the confirmation-prompt gate: wrong re-typed name aborts without deleting; correct name proceeds.
+- MCP tool test(s) covering the dry-run/apply framing, mirroring the existing `ghost_resolve` MCP test style.
+- `go vet ./...` and `go test ./...` before and after, as with every change in this repo.

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -1284,6 +1284,47 @@ func (s *Server) registerTools() {
 		}, nil, nil
 	})
 
+	// ghost_project_delete — permanently delete a project and everything
+	// under it. Dry-run by default; apply:true actually deletes. _global is
+	// always refused, in both modes.
+	type projectDeleteArgs struct {
+		Project string `json:"project" jsonschema:"the project to delete (id, name, or path)"`
+		Apply   bool   `json:"apply,omitempty" jsonschema:"actually delete (default false: dry-run preview only)"`
+	}
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:        "ghost_project_delete",
+		Title:       "Delete Project",
+		Description: "Permanently deletes a project: memories, tags, embeddings, links, tasks, decisions, and cost/audit history. Irreversible — there is no undo. Dry-run by default (returns counts of what would be removed); pass apply:true to actually delete. Always refuses to delete the _global project. Only use when the user has explicitly and unambiguously asked to delete an entire project, never as a side effect of another request.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(true),
+			OpenWorldHint:   boolPtr(false),
+		},
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args projectDeleteArgs) (*mcp.CallToolResult, any, error) {
+		if args.Project == "" {
+			return nil, nil, fmt.Errorf("project is required")
+		}
+		summary, err := s.store.DeleteProject(ctx, args.Project, args.Apply)
+		if err != nil {
+			return nil, nil, fmt.Errorf("ghost_project_delete: %w", err)
+		}
+		verb := "Would delete"
+		if args.Apply {
+			verb = "Deleted"
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%s %q (%s):\n", verb, summary.ProjectName, summary.ProjectID)
+		fmt.Fprintf(&sb, "  memories:     %d\n", summary.Memories)
+		fmt.Fprintf(&sb, "  memory_links: %d\n", summary.MemoryLinks)
+		fmt.Fprintf(&sb, "  tasks:        %d\n", summary.Tasks)
+		fmt.Fprintf(&sb, "  decisions:    %d\n", summary.Decisions)
+		fmt.Fprintf(&sb, "  token_usage:  %d\n", summary.TokenUsage)
+		fmt.Fprintf(&sb, "  audit_log:    %d\n", summary.AuditLog)
+		if !args.Apply {
+			sb.WriteString("\nRe-run with apply:true to actually delete.")
+		}
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: sb.String()}}}, nil, nil
+	})
+
 	// ghost_memory_pin — pin or unpin a memory.
 	type pinArgs struct {
 		ProjectID string `json:"project_id" jsonschema:"Project name the memory belongs to (required for ownership check)"`

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -1294,7 +1294,7 @@ func (s *Server) registerTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "ghost_project_delete",
 		Title:       "Delete Project",
-		Description: "Permanently deletes a project: memories, tags, embeddings, links, tasks, decisions, and cost/audit history. Irreversible — there is no undo. Dry-run by default (returns counts of what would be removed); pass apply:true to actually delete. Always refuses to delete the _global project. Only use when the user has explicitly and unambiguously asked to delete an entire project, never as a side effect of another request.",
+		Description: "Permanently deletes a project: memories, tags, embeddings, links, tasks, decisions, learned context, reflection snapshots, and cost/audit history. Irreversible — there is no undo. Dry-run by default (returns counts of what would be removed); pass apply:true to actually delete. Always refuses to delete the _global project. Only use when the user has explicitly and unambiguously asked to delete an entire project, never as a side effect of another request.",
 		Annotations: &mcp.ToolAnnotations{
 			DestructiveHint: boolPtr(true),
 			OpenWorldHint:   boolPtr(false),

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -1307,6 +1307,19 @@ func (s *Server) registerTools() {
 		if err != nil {
 			return nil, nil, fmt.Errorf("ghost_project_delete: %w", err)
 		}
+		if args.Apply {
+			// notifyProjectResource's hash/name alias lookup queries
+			// ListProjects, which no longer has a row for this project once
+			// DeleteProject has committed — it would only ever emit the ID
+			// form. Emit both aliases directly from the summary instead,
+			// since DeleteProject already resolved and returned them.
+			for _, suffix := range []string{"context", "tasks", "decisions"} {
+				s.notifyResourceUpdated(ctx, "ghost://project/"+summary.ProjectID+"/"+suffix)
+				if summary.ProjectName != summary.ProjectID {
+					s.notifyResourceUpdated(ctx, "ghost://project/"+summary.ProjectName+"/"+suffix)
+				}
+			}
+		}
 		verb := "Would delete"
 		if args.Apply {
 			verb = "Deleted"

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -1866,6 +1866,9 @@ func TestGhostProjectDelete_DryRunByDefault(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
+	if _, err := store.CreateTask(ctx, "abc123", "Fix the bug", "needs triage", 1); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
 
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "ghost_project_delete",
@@ -1883,6 +1886,15 @@ func TestGhostProjectDelete_DryRunByDefault(t *testing.T) {
 	}
 	if !strings.Contains(text.Text, "Would delete") {
 		t.Errorf("expected dry-run framing %q in response, got %q", "Would delete", text.Text)
+	}
+	if !strings.Contains(text.Text, "memories:     1") {
+		t.Errorf("expected summary line %q in response, got %q", "memories:     1", text.Text)
+	}
+	if !strings.Contains(text.Text, "tasks:        1") {
+		t.Errorf("expected summary line %q in response, got %q", "tasks:        1", text.Text)
+	}
+	if !strings.Contains(text.Text, "decisions:    0") {
+		t.Errorf("expected summary line %q in response, got %q", "decisions:    0", text.Text)
 	}
 
 	all, err := store.GetAll(ctx, "abc123", 100)
@@ -1923,6 +1935,9 @@ func TestGhostProjectDelete_ApplyRemovesProject(t *testing.T) {
 	}
 	if !strings.Contains(text.Text, "Deleted") {
 		t.Errorf("expected apply framing %q in response, got %q", "Deleted", text.Text)
+	}
+	if !strings.Contains(text.Text, "memories:     1") {
+		t.Errorf("expected summary line %q in response, got %q", "memories:     1", text.Text)
 	}
 
 	id, _, err := store.ResolveProject(ctx, "test-project")

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -2053,6 +2053,34 @@ func TestGhostProjectDelete_NotifiesSubscribersOnApply(t *testing.T) {
 		t.Fatalf("Subscribe: %v", err)
 	}
 
+	// Subscribe's response only confirms the client's request round-trip
+	// completed; it races the server's own internal bookkeeping (see the
+	// identical note on TestResourceSubscription_NotifiesOnMemorySave).
+	// The deletion notifications below are emitted exactly once and can't
+	// be retried, so confirm each subscription actually registered — and
+	// drain these probe notifications — before triggering the real delete.
+	for _, uri := range []string{contextURI, tasksURI, decisionsURI} {
+		var seen bool
+		for attempt := 0; attempt < 10 && !seen; attempt++ {
+			srv.notifyResourceUpdated(ctx, uri)
+			select {
+			case <-updated:
+				seen = true
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+		if !seen {
+			t.Fatalf("subscription for %q never registered", uri)
+		}
+	}
+	for drained := true; drained; {
+		select {
+		case <-updated:
+		default:
+			drained = false
+		}
+	}
+
 	if _, err := session.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "ghost_project_delete",
 		Arguments: map[string]any{"project": "test-project", "apply": true},

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -2010,3 +2010,119 @@ func TestGhostProjectDelete_RejectsGlobal(t *testing.T) {
 		t.Fatal("expected an error result deleting _global, got success")
 	}
 }
+
+func TestGhostProjectDelete_NotifiesSubscribersOnApply(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+
+	ctx := context.Background()
+	if _, err := store.Create(ctx, "abc123", memory.Memory{
+		Category: "fact", Content: "subscriber should hear about this deletion", Source: "manual", Importance: 0.5, Tags: []string{},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	if _, err := srv.mcp.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+
+	updated := make(chan string, 8)
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, &mcp.ClientOptions{
+		ResourceUpdatedHandler: func(ctx context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
+			updated <- req.Params.URI
+		},
+	})
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	const contextURI = "ghost://project/test-project/context"
+	if err := session.Subscribe(ctx, &mcp.SubscribeParams{URI: contextURI}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	const tasksURI = "ghost://project/test-project/tasks"
+	if err := session.Subscribe(ctx, &mcp.SubscribeParams{URI: tasksURI}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	const decisionsURI = "ghost://project/test-project/decisions"
+	if err := session.Subscribe(ctx, &mcp.SubscribeParams{URI: decisionsURI}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if _, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_project_delete",
+		Arguments: map[string]any{"project": "test-project", "apply": true},
+	}); err != nil {
+		t.Fatalf("CallTool ghost_project_delete: %v", err)
+	}
+
+	want := map[string]bool{contextURI: false, tasksURI: false, decisionsURI: false}
+	deadline := time.After(2 * time.Second)
+	for remaining := len(want); remaining > 0; {
+		select {
+		case got := <-updated:
+			if seen, ok := want[got]; !ok {
+				t.Errorf("notified unexpected URI %q", got)
+			} else if seen {
+				// Duplicate notification for the same URI; ignore.
+			} else {
+				want[got] = true
+				remaining--
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for notifications, still missing: %+v", want)
+		}
+	}
+}
+
+func TestGhostProjectDelete_DryRunDoesNotNotify(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+
+	ctx := context.Background()
+	if _, err := store.Create(ctx, "abc123", memory.Memory{
+		Category: "fact", Content: "dry run must not notify anyone", Source: "manual", Importance: 0.5, Tags: []string{},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	if _, err := srv.mcp.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+
+	updated := make(chan string, 8)
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, &mcp.ClientOptions{
+		ResourceUpdatedHandler: func(ctx context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
+			updated <- req.Params.URI
+		},
+	})
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	const contextURI = "ghost://project/test-project/context"
+	if err := session.Subscribe(ctx, &mcp.SubscribeParams{URI: contextURI}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if _, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_project_delete",
+		Arguments: map[string]any{"project": "test-project"},
+	}); err != nil {
+		t.Fatalf("CallTool ghost_project_delete: %v", err)
+	}
+
+	select {
+	case got := <-updated:
+		t.Fatalf("expected no notification on dry-run, got %q", got)
+	case <-time.After(300 * time.Millisecond):
+	}
+}

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -1853,3 +1853,105 @@ func TestProjectTasksResource_ShortTaskID(t *testing.T) {
 		t.Errorf("expected output to contain the short task id `abc`, got: %s", result.Contents[0].Text)
 	}
 }
+
+func TestGhostProjectDelete_DryRunByDefault(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	if _, err := store.Create(ctx, "abc123", memory.Memory{
+		Category: "fact", Content: "will this survive a dry run", Source: "manual", Importance: 0.5, Tags: []string{},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_project_delete",
+		Arguments: map[string]any{"project": "test-project"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_project_delete: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error result: %+v", result.Content)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	if !strings.Contains(text.Text, "Would delete") {
+		t.Errorf("expected dry-run framing %q in response, got %q", "Would delete", text.Text)
+	}
+
+	all, err := store.GetAll(ctx, "abc123", 100)
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("expected memory to survive dry-run, got %d memories", len(all))
+	}
+}
+
+func TestGhostProjectDelete_ApplyRemovesProject(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+
+	ctx := context.Background()
+	if _, err := store.Create(ctx, "abc123", memory.Memory{
+		Category: "fact", Content: "will this survive apply", Source: "manual", Importance: 0.5, Tags: []string{},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_project_delete",
+		Arguments: map[string]any{"project": "test-project", "apply": true},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_project_delete: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error result: %+v", result.Content)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	if !strings.Contains(text.Text, "Deleted") {
+		t.Errorf("expected apply framing %q in response, got %q", "Deleted", text.Text)
+	}
+
+	id, _, err := store.ResolveProject(ctx, "test-project")
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "" {
+		t.Error("expected project to be gone after apply")
+	}
+}
+
+func TestGhostProjectDelete_RejectsGlobal(t *testing.T) {
+	store := testStore(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := New(store, logger, "test")
+	session := connectedClient(t, srv)
+	ctx := context.Background()
+	if err := store.SeedGlobalMemories(ctx); err != nil {
+		t.Fatalf("SeedGlobalMemories: %v", err)
+	}
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "ghost_project_delete",
+		Arguments: map[string]any{"project": "_global", "apply": true},
+	})
+	if err != nil {
+		t.Fatalf("CallTool ghost_project_delete: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected an error result deleting _global, got success")
+	}
+}

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -1861,33 +1861,44 @@ func TestGhostProjectDelete_DryRunByDefault(t *testing.T) {
 	session := connectedClient(t, srv)
 
 	ctx := context.Background()
-	mem1ID, err := store.Create(ctx, "abc123", memory.Memory{
-		Category: "fact", Content: "will this survive a dry run", Source: "manual", Importance: 0.5, Tags: []string{},
-	})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
+	var memIDs []string
+	for i := 0; i < 4; i++ {
+		id, err := store.Create(ctx, "abc123", memory.Memory{
+			Category: "fact", Content: "seed memory for delete test", Source: "manual", Importance: 0.5, Tags: []string{},
+		})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		memIDs = append(memIDs, id)
 	}
-	mem2ID, err := store.Create(ctx, "abc123", memory.Memory{
-		Category: "fact", Content: "second memory for the link", Source: "manual", Importance: 0.5, Tags: []string{},
-	})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	// Seed memory_links and token_usage too, not just memories/tasks, and
-	// with deliberately unequal counts (1 vs. 2), so a swap of e.g.
-	// summary.MemoryLinks/summary.TokenUsage in the tool's output formatting
-	// would be caught here the same way the store-layer mutation test
-	// catches a Tasks/Decisions swap.
-	if err := store.CreateLink(ctx, mem1ID, mem2ID, "related", 0.8, "auto"); err != nil {
-		t.Fatalf("CreateLink: %v", err)
-	}
-	for i := 0; i < 2; i++ {
-		if err := store.RecordUsage(ctx, "abc123", "claude-opus-4-6", memory.TokenUsage{InputTokens: 10, OutputTokens: 5}); err != nil {
-			t.Fatalf("RecordUsage: %v", err)
+	// Seed memory_links, tasks, decisions, and token_usage too, not just
+	// memories, with mutually distinct counts (memories=5 [4 seeded here + 1
+	// from RecordDecision's decision_log row], memory_links=3, tasks=2,
+	// decisions=1, token_usage=4) so a swap of any pair of summary fields in
+	// the tool's output formatting would be caught here the same way the
+	// store-layer mutation test catches a TokenUsage/AuditLog swap.
+	// audit_log can't be seeded from this package (no exported production API
+	// writes it outside internal/memory), so it stays at its default 0 — but
+	// seeding a nonzero decisions count leaves 0 distinct from all five
+	// seeded fields too, so the assertion below still catches a transposition
+	// involving audit_log.
+	for _, pair := range [][2]string{{memIDs[0], memIDs[1]}, {memIDs[0], memIDs[2]}, {memIDs[1], memIDs[2]}} {
+		if err := store.CreateLink(ctx, pair[0], pair[1], "related", 0.8, "auto"); err != nil {
+			t.Fatalf("CreateLink %v: %v", pair, err)
 		}
 	}
-	if _, err := store.CreateTask(ctx, "abc123", "Fix the bug", "needs triage", 1); err != nil {
-		t.Fatalf("CreateTask: %v", err)
+	for i := 0; i < 4; i++ {
+		if err := store.RecordUsage(ctx, "abc123", "claude-opus-4-6", memory.TokenUsage{InputTokens: 10, OutputTokens: 5}); err != nil {
+			t.Fatalf("RecordUsage %d: %v", i, err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := store.CreateTask(ctx, "abc123", "Fix the bug", "needs triage", 1); err != nil {
+			t.Fatalf("CreateTask %d: %v", i, err)
+		}
+	}
+	if _, _, err := store.RecordDecision(ctx, "abc123", "seed decision", "did the thing", "because", nil, nil); err != nil {
+		t.Fatalf("RecordDecision: %v", err)
 	}
 
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{
@@ -1907,27 +1918,30 @@ func TestGhostProjectDelete_DryRunByDefault(t *testing.T) {
 	if !strings.Contains(text.Text, "Would delete") {
 		t.Errorf("expected dry-run framing %q in response, got %q", "Would delete", text.Text)
 	}
-	if !strings.Contains(text.Text, "memories:     2") {
-		t.Errorf("expected summary line %q in response, got %q", "memories:     2", text.Text)
+	if !strings.Contains(text.Text, "memories:     5") {
+		t.Errorf("expected summary line %q in response, got %q", "memories:     5", text.Text)
 	}
-	if !strings.Contains(text.Text, "memory_links: 1") {
-		t.Errorf("expected summary line %q in response, got %q", "memory_links: 1", text.Text)
+	if !strings.Contains(text.Text, "memory_links: 3") {
+		t.Errorf("expected summary line %q in response, got %q", "memory_links: 3", text.Text)
 	}
-	if !strings.Contains(text.Text, "tasks:        1") {
-		t.Errorf("expected summary line %q in response, got %q", "tasks:        1", text.Text)
+	if !strings.Contains(text.Text, "tasks:        2") {
+		t.Errorf("expected summary line %q in response, got %q", "tasks:        2", text.Text)
 	}
-	if !strings.Contains(text.Text, "decisions:    0") {
-		t.Errorf("expected summary line %q in response, got %q", "decisions:    0", text.Text)
+	if !strings.Contains(text.Text, "decisions:    1") {
+		t.Errorf("expected summary line %q in response, got %q", "decisions:    1", text.Text)
 	}
-	if !strings.Contains(text.Text, "token_usage:  2") {
-		t.Errorf("expected summary line %q in response, got %q", "token_usage:  2", text.Text)
+	if !strings.Contains(text.Text, "token_usage:  4") {
+		t.Errorf("expected summary line %q in response, got %q", "token_usage:  4", text.Text)
+	}
+	if !strings.Contains(text.Text, "audit_log:    0") {
+		t.Errorf("expected summary line %q in response, got %q", "audit_log:    0", text.Text)
 	}
 
 	all, err := store.GetAll(ctx, "abc123", 100)
 	if err != nil {
 		t.Fatalf("GetAll: %v", err)
 	}
-	if len(all) != 2 {
+	if len(all) != 5 {
 		t.Errorf("expected memories to survive dry-run, got %d memories", len(all))
 	}
 }

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -1861,10 +1861,30 @@ func TestGhostProjectDelete_DryRunByDefault(t *testing.T) {
 	session := connectedClient(t, srv)
 
 	ctx := context.Background()
-	if _, err := store.Create(ctx, "abc123", memory.Memory{
+	mem1ID, err := store.Create(ctx, "abc123", memory.Memory{
 		Category: "fact", Content: "will this survive a dry run", Source: "manual", Importance: 0.5, Tags: []string{},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Create: %v", err)
+	}
+	mem2ID, err := store.Create(ctx, "abc123", memory.Memory{
+		Category: "fact", Content: "second memory for the link", Source: "manual", Importance: 0.5, Tags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Seed memory_links and token_usage too, not just memories/tasks, and
+	// with deliberately unequal counts (1 vs. 2), so a swap of e.g.
+	// summary.MemoryLinks/summary.TokenUsage in the tool's output formatting
+	// would be caught here the same way the store-layer mutation test
+	// catches a Tasks/Decisions swap.
+	if err := store.CreateLink(ctx, mem1ID, mem2ID, "related", 0.8, "auto"); err != nil {
+		t.Fatalf("CreateLink: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := store.RecordUsage(ctx, "abc123", "claude-opus-4-6", memory.TokenUsage{InputTokens: 10, OutputTokens: 5}); err != nil {
+			t.Fatalf("RecordUsage: %v", err)
+		}
 	}
 	if _, err := store.CreateTask(ctx, "abc123", "Fix the bug", "needs triage", 1); err != nil {
 		t.Fatalf("CreateTask: %v", err)
@@ -1887,8 +1907,11 @@ func TestGhostProjectDelete_DryRunByDefault(t *testing.T) {
 	if !strings.Contains(text.Text, "Would delete") {
 		t.Errorf("expected dry-run framing %q in response, got %q", "Would delete", text.Text)
 	}
-	if !strings.Contains(text.Text, "memories:     1") {
-		t.Errorf("expected summary line %q in response, got %q", "memories:     1", text.Text)
+	if !strings.Contains(text.Text, "memories:     2") {
+		t.Errorf("expected summary line %q in response, got %q", "memories:     2", text.Text)
+	}
+	if !strings.Contains(text.Text, "memory_links: 1") {
+		t.Errorf("expected summary line %q in response, got %q", "memory_links: 1", text.Text)
 	}
 	if !strings.Contains(text.Text, "tasks:        1") {
 		t.Errorf("expected summary line %q in response, got %q", "tasks:        1", text.Text)
@@ -1896,13 +1919,16 @@ func TestGhostProjectDelete_DryRunByDefault(t *testing.T) {
 	if !strings.Contains(text.Text, "decisions:    0") {
 		t.Errorf("expected summary line %q in response, got %q", "decisions:    0", text.Text)
 	}
+	if !strings.Contains(text.Text, "token_usage:  2") {
+		t.Errorf("expected summary line %q in response, got %q", "token_usage:  2", text.Text)
+	}
 
 	all, err := store.GetAll(ctx, "abc123", 100)
 	if err != nil {
 		t.Fatalf("GetAll: %v", err)
 	}
-	if len(all) != 1 {
-		t.Errorf("expected memory to survive dry-run, got %d memories", len(all))
+	if len(all) != 2 {
+		t.Errorf("expected memories to survive dry-run, got %d memories", len(all))
 	}
 }
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -306,7 +306,7 @@ type DeleteProjectSummary struct {
 }
 
 // DeleteProject permanently removes a project and everything under it.
-// memories (with their FTS index entries, embeddings, and links),
+// memories (with their FTS index entries, embeddings, links, and link_scans),
 // conversations (with their messages), tasks, decisions, ghost_state, and
 // memory_snapshots all cascade from the projects row via ON DELETE CASCADE
 // (see schema.go). token_usage and audit_log carry a project_id column but no
@@ -394,17 +394,44 @@ func (s *Store) DeleteProject(ctx context.Context, input string, apply bool) (De
 	if _, err := tx.ExecContext(ctx, `DELETE FROM audit_log WHERE project_id = ?`, id); err != nil {
 		return DeleteProjectSummary{}, fmt.Errorf("delete audit_log: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `DELETE FROM projects WHERE id = ?`, id); err != nil {
-		return DeleteProjectSummary{}, fmt.Errorf("delete project: %w", err)
+	if err := deleteProjectRowTx(ctx, tx, id); err != nil {
+		return DeleteProjectSummary{}, err
 	}
 
 	if err := tx.Commit(); err != nil {
 		return DeleteProjectSummary{}, fmt.Errorf("commit delete: %w", err)
 	}
 
+	// This log line is the only durable record of what was removed once the
+	// project's own audit_log rows are gone, so it carries the full summary.
 	s.logger.Info("deleted project", "project_id", id, "project_name", name,
-		"memories", summary.Memories, "tasks", summary.Tasks, "decisions", summary.Decisions)
+		"memories", summary.Memories, "memory_links", summary.MemoryLinks,
+		"tasks", summary.Tasks, "decisions", summary.Decisions,
+		"token_usage", summary.TokenUsage, "audit_log", summary.AuditLog)
 	return summary, nil
+}
+
+// deleteProjectRowTx deletes the projects row for id inside tx and guards
+// against the row already being gone: ResolveProject released its RLock
+// before DeleteProject acquired s.mu, so a concurrent DeleteProject/
+// MergeProject in this process — or a separate ghost process (CLI and MCP
+// server each open their own *Store against the same SQLite file) — could
+// have already deleted this project in that gap. Without this guard the
+// transaction would still commit and DeleteProject would return a
+// normal-looking success summary for a project that's already gone.
+func deleteProjectRowTx(ctx context.Context, tx *sql.Tx, id string) error {
+	res, err := tx.ExecContext(ctx, `DELETE FROM projects WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete project: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete project rows: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("project %q was already deleted", id)
+	}
+	return nil
 }
 
 // ResolveProject resolves an identifier — a project name, hash ID, or

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -292,6 +292,121 @@ func (s *Store) mergeProjectLocked(ctx context.Context, oldID, newID string) err
 	return nil
 }
 
+// DeleteProjectSummary reports what DeleteProject found (dry-run) or removed
+// (apply) for one project, across every table that references it.
+type DeleteProjectSummary struct {
+	ProjectID   string
+	ProjectName string
+	Memories    int
+	MemoryLinks int
+	Tasks       int
+	Decisions   int
+	TokenUsage  int
+	AuditLog    int
+}
+
+// DeleteProject permanently removes a project and everything under it.
+// memories (and their tags, embeddings, and links), tasks, decisions,
+// ghost_state, and memory_snapshots all cascade from the projects row via
+// ON DELETE CASCADE (see schema.go). token_usage and audit_log carry a
+// project_id column but no foreign key, so they're deleted explicitly in the
+// same transaction.
+//
+// input is resolved exactly like every other command resolves a project (see
+// ResolveProject): id, name, path-prefix, or basename all work.
+//
+// apply=false computes and returns the summary without writing anything.
+// apply=true performs the same computation, then actually deletes everything
+// in one transaction, returning the summary of what was removed. _global can
+// never be deleted, in either mode — it's shared across every project's
+// context injection.
+//
+// ResolveProject takes its own RLock internally, so it's called here before
+// this method takes s.mu itself — taking s.mu first and then calling
+// ResolveProject would deadlock against sync.RWMutex's non-reentrant lock.
+func (s *Store) DeleteProject(ctx context.Context, input string, apply bool) (DeleteProjectSummary, error) {
+	id, name, err := s.ResolveProject(ctx, input)
+	if err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("resolve project: %w", err)
+	}
+	if id == "" {
+		return DeleteProjectSummary{}, fmt.Errorf("project %q not found", input)
+	}
+	if id == "_global" {
+		return DeleteProjectSummary{}, fmt.Errorf("refusing to delete the _global project")
+	}
+
+	if apply {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+	} else {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
+
+	summary := DeleteProjectSummary{ProjectID: id, ProjectName: name}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM memories WHERE project_id = ?`, id,
+	).Scan(&summary.Memories); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count memories: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT count(*) FROM memory_links
+		WHERE source_id IN (SELECT id FROM memories WHERE project_id = ?)
+		   OR target_id IN (SELECT id FROM memories WHERE project_id = ?)
+	`, id, id).Scan(&summary.MemoryLinks); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count memory_links: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM tasks WHERE project_id = ?`, id,
+	).Scan(&summary.Tasks); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count tasks: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM decisions WHERE project_id = ?`, id,
+	).Scan(&summary.Decisions); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count decisions: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM token_usage WHERE project_id = ?`, id,
+	).Scan(&summary.TokenUsage); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count token_usage: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM audit_log WHERE project_id = ?`, id,
+	).Scan(&summary.AuditLog); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count audit_log: %w", err)
+	}
+
+	if !apply {
+		return summary, nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("begin delete tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM token_usage WHERE project_id = ?`, id); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("delete token_usage: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM audit_log WHERE project_id = ?`, id); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("delete audit_log: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM projects WHERE id = ?`, id); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("delete project: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("commit delete: %w", err)
+	}
+
+	s.logger.Info("deleted project", "project_id", id, "project_name", name,
+		"memories", summary.Memories, "tasks", summary.Tasks, "decisions", summary.Decisions)
+	return summary, nil
+}
+
 // ResolveProject resolves an identifier — a project name, hash ID, or
 // filesystem path — to that project's (id, name). Returns ("", "", nil)
 // on no match; a non-nil error only indicates a real DB failure.

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -336,57 +336,47 @@ func (s *Store) DeleteProject(ctx context.Context, input string, apply bool) (De
 		return DeleteProjectSummary{}, fmt.Errorf("refusing to delete the _global project")
 	}
 
-	if apply {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-	} else {
+	if !apply {
 		s.mu.RLock()
 		defer s.mu.RUnlock()
-	}
-
-	summary := DeleteProjectSummary{ProjectID: id, ProjectName: name}
-	if err := s.db.QueryRowContext(ctx,
-		`SELECT count(*) FROM memories WHERE project_id = ?`, id,
-	).Scan(&summary.Memories); err != nil {
-		return DeleteProjectSummary{}, fmt.Errorf("count memories: %w", err)
-	}
-	if err := s.db.QueryRowContext(ctx, `
-		SELECT count(*) FROM memory_links
-		WHERE source_id IN (SELECT id FROM memories WHERE project_id = ?)
-		   OR target_id IN (SELECT id FROM memories WHERE project_id = ?)
-	`, id, id).Scan(&summary.MemoryLinks); err != nil {
-		return DeleteProjectSummary{}, fmt.Errorf("count memory_links: %w", err)
-	}
-	if err := s.db.QueryRowContext(ctx,
-		`SELECT count(*) FROM tasks WHERE project_id = ?`, id,
-	).Scan(&summary.Tasks); err != nil {
-		return DeleteProjectSummary{}, fmt.Errorf("count tasks: %w", err)
-	}
-	if err := s.db.QueryRowContext(ctx,
-		`SELECT count(*) FROM decisions WHERE project_id = ?`, id,
-	).Scan(&summary.Decisions); err != nil {
-		return DeleteProjectSummary{}, fmt.Errorf("count decisions: %w", err)
-	}
-	if err := s.db.QueryRowContext(ctx,
-		`SELECT count(*) FROM token_usage WHERE project_id = ?`, id,
-	).Scan(&summary.TokenUsage); err != nil {
-		return DeleteProjectSummary{}, fmt.Errorf("count token_usage: %w", err)
-	}
-	if err := s.db.QueryRowContext(ctx,
-		`SELECT count(*) FROM audit_log WHERE project_id = ?`, id,
-	).Scan(&summary.AuditLog); err != nil {
-		return DeleteProjectSummary{}, fmt.Errorf("count audit_log: %w", err)
-	}
-
-	if !apply {
+		summary, err := countProjectRows(ctx, s.db, id)
+		if err != nil {
+			return DeleteProjectSummary{}, err
+		}
+		summary.ProjectID, summary.ProjectName = id, name
 		return summary, nil
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return DeleteProjectSummary{}, fmt.Errorf("begin delete tx: %w", err)
 	}
 	defer tx.Rollback() //nolint:errcheck
+
+	// database/sql's BeginTx opens a deferred transaction on this driver: it
+	// only acquires SQLite's write lock lazily, on its first write statement.
+	// Without forcing that now, a separate ghost process (CLI and MCP server
+	// each open their own *Store against the same SQLite file) could write
+	// to this project in the gap between the counts below and the deletes —
+	// and the returned/logged summary, the only durable record of what was
+	// removed once the project's own audit_log rows are gone, would silently
+	// undercount what actually got deleted. This no-op write forces the
+	// upgrade to the write lock immediately, before any counting happens;
+	// verified empirically that a concurrent writer on a separate handle
+	// blocks (and eventually times out via busy_timeout) until this
+	// transaction commits or rolls back.
+	if _, err := tx.ExecContext(ctx, `UPDATE projects SET id = id WHERE id = ?`, id); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("acquire write lock: %w", err)
+	}
+
+	summary, err := countProjectRows(ctx, tx, id)
+	if err != nil {
+		return DeleteProjectSummary{}, err
+	}
+	summary.ProjectID, summary.ProjectName = id, name
 
 	if _, err := tx.ExecContext(ctx, `DELETE FROM token_usage WHERE project_id = ?`, id); err != nil {
 		return DeleteProjectSummary{}, fmt.Errorf("delete token_usage: %w", err)
@@ -408,6 +398,53 @@ func (s *Store) DeleteProject(ctx context.Context, input string, apply bool) (De
 		"memories", summary.Memories, "memory_links", summary.MemoryLinks,
 		"tasks", summary.Tasks, "decisions", summary.Decisions,
 		"token_usage", summary.TokenUsage, "audit_log", summary.AuditLog)
+	return summary, nil
+}
+
+// queryRower is satisfied by both *sql.DB and *sql.Tx, letting
+// countProjectRows run identically as a plain autocommit read (dry-run) or
+// inside an already-open write transaction (apply — see DeleteProject).
+type queryRower interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// countProjectRows computes the per-table counts for DeleteProjectSummary.
+// It does not set ProjectID/ProjectName — the caller already has both from
+// ResolveProject and assigns them itself.
+func countProjectRows(ctx context.Context, q queryRower, id string) (DeleteProjectSummary, error) {
+	var summary DeleteProjectSummary
+	if err := q.QueryRowContext(ctx,
+		`SELECT count(*) FROM memories WHERE project_id = ?`, id,
+	).Scan(&summary.Memories); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count memories: %w", err)
+	}
+	if err := q.QueryRowContext(ctx, `
+		SELECT count(*) FROM memory_links
+		WHERE source_id IN (SELECT id FROM memories WHERE project_id = ?)
+		   OR target_id IN (SELECT id FROM memories WHERE project_id = ?)
+	`, id, id).Scan(&summary.MemoryLinks); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count memory_links: %w", err)
+	}
+	if err := q.QueryRowContext(ctx,
+		`SELECT count(*) FROM tasks WHERE project_id = ?`, id,
+	).Scan(&summary.Tasks); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count tasks: %w", err)
+	}
+	if err := q.QueryRowContext(ctx,
+		`SELECT count(*) FROM decisions WHERE project_id = ?`, id,
+	).Scan(&summary.Decisions); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count decisions: %w", err)
+	}
+	if err := q.QueryRowContext(ctx,
+		`SELECT count(*) FROM token_usage WHERE project_id = ?`, id,
+	).Scan(&summary.TokenUsage); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count token_usage: %w", err)
+	}
+	if err := q.QueryRowContext(ctx,
+		`SELECT count(*) FROM audit_log WHERE project_id = ?`, id,
+	).Scan(&summary.AuditLog); err != nil {
+		return DeleteProjectSummary{}, fmt.Errorf("count audit_log: %w", err)
+	}
 	return summary, nil
 }
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -306,11 +306,11 @@ type DeleteProjectSummary struct {
 }
 
 // DeleteProject permanently removes a project and everything under it.
-// memories (and their tags, embeddings, and links), tasks, decisions,
-// ghost_state, and memory_snapshots all cascade from the projects row via
-// ON DELETE CASCADE (see schema.go). token_usage and audit_log carry a
-// project_id column but no foreign key, so they're deleted explicitly in the
-// same transaction.
+// memories (with their FTS index entries, embeddings, and links),
+// conversations (with their messages), tasks, decisions, ghost_state, and
+// memory_snapshots all cascade from the projects row via ON DELETE CASCADE
+// (see schema.go). token_usage and audit_log carry a project_id column but no
+// foreign key, so they're deleted explicitly in the same transaction.
 //
 // input is resolved exactly like every other command resolves a project (see
 // ResolveProject): id, name, path-prefix, or basename all work.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -8,7 +8,9 @@ import (
 	"log/slog"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -2479,6 +2481,92 @@ func TestDeleteProjectRowTx_AlreadyDeletedGuard(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "already deleted") {
 		t.Errorf("expected %q in error, got: %v", "already deleted", err)
+	}
+}
+
+// TestDeleteProject_ConcurrentWriteFromSeparateProcessDoesNotUndercountSummary
+// exercises the race DeleteProject's write-lock-first ordering exists to
+// close: two separate *Store instances (simulating two separate ghost
+// processes, e.g. a CLI `project delete --apply` and a long-running MCP
+// server) opened against the same on-disk SQLite file — :memory: databases
+// aren't shared across handles, so this needs a real temp file. One store
+// races a write against the project the other is deleting. Whichever side
+// wins, the returned summary must never lie about what was actually deleted.
+func TestDeleteProject_ConcurrentWriteFromSeparateProcessDoesNotUndercountSummary(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "race.sqlite")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	dbA, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB A: %v", err)
+	}
+	defer dbA.Close()
+	storeA := NewStore(dbA, logger)
+
+	dbB, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB B: %v", err)
+	}
+	defer dbB.Close()
+	storeB := NewStore(dbB, logger)
+
+	ctx := context.Background()
+	if err := storeA.EnsureProject(ctx, testProject, "/tmp/race", testProject); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	var bErr error
+	var bSucceeded bool
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Retry briefly: the first attempt or two may land before storeA
+		// even starts its transaction, or may block on storeA's held write
+		// lock until it commits or rolls back.
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			_, _, _, upsertErr := storeB.Upsert(ctx, testProject, "fact", "racing write from a second process", "manual", 0.5, []string{})
+			if upsertErr == nil {
+				bSucceeded = true
+				return
+			}
+			bErr = upsertErr
+			if strings.Contains(upsertErr.Error(), "FOREIGN KEY") {
+				// The project is already gone — a definitive loss, not a
+				// transient lock contention. Stop retrying.
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	summary, err := storeA.DeleteProject(ctx, testProject, true)
+	wg.Wait()
+
+	if err != nil {
+		t.Fatalf("DeleteProject: %v", err)
+	}
+
+	// The invariant this test protects: the summary must never undercount
+	// what actually got deleted. If B's write landed before A's count ran
+	// (bSucceeded), A's count — taken only after the write lock is forced —
+	// must have seen it; if B's write never landed, the count must be 0.
+	if bSucceeded && summary.Memories != 1 {
+		t.Errorf("B's concurrent write succeeded but summary.Memories = %d, want 1 (undercounted)", summary.Memories)
+	}
+	if !bSucceeded && summary.Memories != 0 {
+		t.Errorf("B's concurrent write did not succeed (last err=%v) but summary.Memories = %d, want 0", bErr, summary.Memories)
+	}
+
+	// Whichever side won, the DB must end up fully consistent: no memories
+	// left over under a project that no longer exists.
+	var remaining int
+	if err := dbA.QueryRowContext(ctx, `SELECT count(*) FROM memories WHERE project_id = ?`, testProject).Scan(&remaining); err != nil {
+		t.Fatalf("count remaining: %v", err)
+	}
+	if remaining != 0 {
+		t.Errorf("expected 0 memories remaining for deleted project, got %d", remaining)
 	}
 }
 

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2187,10 +2187,13 @@ func TestMergeProject_SameID(t *testing.T) {
 	}
 }
 
-// seedFullProject creates one memory-link pair, one task, one decision (which
-// also creates its own linked memory row, source='decision_log'), one
+// seedFullProject creates one memory-link pair, two tasks, one decision
+// (which also creates its own linked memory row, source='decision_log'), one
 // token_usage row, and one audit_log row for projectID — one of everything
-// DeleteProject must account for. Returns the two linked memory IDs.
+// DeleteProject must account for, except tasks vs. decisions are deliberately
+// unequal (2 vs. 1) so a test that swaps the Tasks/Decisions scan targets in
+// DeleteProject's count query fails instead of passing silently. Returns the
+// two linked memory IDs.
 func seedFullProject(t *testing.T, s *Store, ctx context.Context, projectID string) (mem1, mem2 string) {
 	t.Helper()
 
@@ -2210,8 +2213,11 @@ func seedFullProject(t *testing.T, s *Store, ctx context.Context, projectID stri
 	if err := s.CreateLink(ctx, mem1, mem2, "related", 0.8, "auto"); err != nil {
 		t.Fatalf("seed link: %v", err)
 	}
-	if _, err := s.CreateTask(ctx, projectID, "seed task", "desc", 1); err != nil {
-		t.Fatalf("seed task: %v", err)
+	if _, err := s.CreateTask(ctx, projectID, "seed task one", "desc", 1); err != nil {
+		t.Fatalf("seed task one: %v", err)
+	}
+	if _, err := s.CreateTask(ctx, projectID, "seed task two", "desc", 1); err != nil {
+		t.Fatalf("seed task two: %v", err)
 	}
 	if _, _, err := s.RecordDecision(ctx, projectID, "seed decision", "did the thing", "because", nil, nil); err != nil {
 		t.Fatalf("seed decision: %v", err)
@@ -2296,8 +2302,8 @@ func TestDeleteProject_DryRunCountsAndWritesNothing(t *testing.T) {
 	if summary.MemoryLinks != 1 {
 		t.Errorf("MemoryLinks = %d, want 1", summary.MemoryLinks)
 	}
-	if summary.Tasks != 1 {
-		t.Errorf("Tasks = %d, want 1", summary.Tasks)
+	if summary.Tasks != 2 {
+		t.Errorf("Tasks = %d, want 2", summary.Tasks)
 	}
 	if summary.Decisions != 1 {
 		t.Errorf("Decisions = %d, want 1", summary.Decisions)
@@ -2313,8 +2319,8 @@ func TestDeleteProject_DryRunCountsAndWritesNothing(t *testing.T) {
 	if n := countRows(t, s, "memories", testProject); n != 3 {
 		t.Errorf("memories after dry-run = %d, want 3 (unchanged)", n)
 	}
-	if n := countRows(t, s, "tasks", testProject); n != 1 {
-		t.Errorf("tasks after dry-run = %d, want 1 (unchanged)", n)
+	if n := countRows(t, s, "tasks", testProject); n != 2 {
+		t.Errorf("tasks after dry-run = %d, want 2 (unchanged)", n)
 	}
 	if n := countRows(t, s, "token_usage", testProject); n != 1 {
 		t.Errorf("token_usage after dry-run = %d, want 1 (unchanged)", n)
@@ -2333,7 +2339,7 @@ func TestDeleteProject_ApplyRemovesEverythingIncludingOrphanTables(t *testing.T)
 	if err != nil {
 		t.Fatalf("DeleteProject apply: %v", err)
 	}
-	if summary.Memories != 3 || summary.MemoryLinks != 1 || summary.Tasks != 1 ||
+	if summary.Memories != 3 || summary.MemoryLinks != 1 || summary.Tasks != 2 ||
 		summary.Decisions != 1 || summary.TokenUsage != 1 || summary.AuditLog != 1 {
 		t.Fatalf("unexpected summary: %+v", summary)
 	}
@@ -2390,7 +2396,7 @@ func TestDeleteProject_IsolatesOtherProjects(t *testing.T) {
 		t.Fatalf("DeleteProject: %v", err)
 	}
 
-	expected := map[string]int{"memories": 3, "tasks": 1, "decisions": 1, "token_usage": 1, "audit_log": 1}
+	expected := map[string]int{"memories": 3, "tasks": 2, "decisions": 1, "token_usage": 1, "audit_log": 1}
 	for table, want := range expected {
 		if n := countRows(t, s, table, otherProject); n != want {
 			t.Errorf("%s for %s after deleting %s = %d, want %d (should be untouched)", table, otherProject, testProject, n, want)

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2187,6 +2187,183 @@ func TestMergeProject_SameID(t *testing.T) {
 	}
 }
 
+// seedFullProject creates one memory-link pair, one task, one decision (which
+// also creates its own linked memory row, source='decision_log'), one
+// token_usage row, and one audit_log row for projectID — one of everything
+// DeleteProject must account for. Returns the two linked memory IDs.
+func seedFullProject(t *testing.T, s *Store, ctx context.Context, projectID string) (mem1, mem2 string) {
+	t.Helper()
+
+	var err error
+	mem1, err = s.Create(ctx, projectID, Memory{
+		Category: "fact", Content: "seed memory one", Source: "manual", Importance: 0.5, Tags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("seed mem1: %v", err)
+	}
+	mem2, err = s.Create(ctx, projectID, Memory{
+		Category: "fact", Content: "seed memory two", Source: "manual", Importance: 0.5, Tags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("seed mem2: %v", err)
+	}
+	if err := s.CreateLink(ctx, mem1, mem2, "related", 0.8, "auto"); err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+	if _, err := s.CreateTask(ctx, projectID, "seed task", "desc", 1); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	if _, _, err := s.RecordDecision(ctx, projectID, "seed decision", "did the thing", "because", nil, nil); err != nil {
+		t.Fatalf("seed decision: %v", err)
+	}
+	if err := s.RecordUsage(ctx, projectID, "claude-opus-4-6", TokenUsage{InputTokens: 10, OutputTokens: 5}); err != nil {
+		t.Fatalf("seed token_usage: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO audit_log (action, project_id) VALUES ('test-action', ?)`, projectID,
+	); err != nil {
+		t.Fatalf("seed audit_log: %v", err)
+	}
+	return mem1, mem2
+}
+
+// countRows returns the number of rows in table matching a project_id column,
+// queried directly so the assertion doesn't depend on DeleteProject's own
+// counting logic being correct.
+func countRows(t *testing.T, s *Store, table, projectID string) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(`SELECT count(*) FROM `+table+` WHERE project_id = ?`, projectID).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+func TestDeleteProject_NotFound(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	_, err := s.DeleteProject(ctx, "no-such-project", false)
+	if err == nil {
+		t.Fatal("expected error for nonexistent project")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected %q in error, got: %v", "not found", err)
+	}
+}
+
+func TestDeleteProject_RefusesGlobal(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	if err := s.SeedGlobalMemories(ctx); err != nil {
+		t.Fatalf("SeedGlobalMemories: %v", err)
+	}
+
+	for _, apply := range []bool{false, true} {
+		_, err := s.DeleteProject(ctx, "_global", apply)
+		if err == nil {
+			t.Fatalf("expected error deleting _global (apply=%v)", apply)
+		}
+	}
+
+	// The seeded global preference must have survived both attempts.
+	mems, err := s.GetAll(ctx, "_global", 100)
+	if err != nil {
+		t.Fatalf("GetAll _global: %v", err)
+	}
+	if len(mems) == 0 {
+		t.Error("expected _global memories to survive refused delete attempts")
+	}
+}
+
+func TestDeleteProject_DryRunCountsAndWritesNothing(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	seedFullProject(t, s, ctx, testProject)
+
+	summary, err := s.DeleteProject(ctx, testProject, false)
+	if err != nil {
+		t.Fatalf("DeleteProject dry-run: %v", err)
+	}
+
+	if summary.ProjectID != testProject {
+		t.Errorf("ProjectID = %q, want %q", summary.ProjectID, testProject)
+	}
+	// 3 memories: the 2 seeded directly + 1 from RecordDecision's decision_log row.
+	if summary.Memories != 3 {
+		t.Errorf("Memories = %d, want 3", summary.Memories)
+	}
+	if summary.MemoryLinks != 1 {
+		t.Errorf("MemoryLinks = %d, want 1", summary.MemoryLinks)
+	}
+	if summary.Tasks != 1 {
+		t.Errorf("Tasks = %d, want 1", summary.Tasks)
+	}
+	if summary.Decisions != 1 {
+		t.Errorf("Decisions = %d, want 1", summary.Decisions)
+	}
+	if summary.TokenUsage != 1 {
+		t.Errorf("TokenUsage = %d, want 1", summary.TokenUsage)
+	}
+	if summary.AuditLog != 1 {
+		t.Errorf("AuditLog = %d, want 1", summary.AuditLog)
+	}
+
+	// Dry-run must write nothing: every row must still be there.
+	if n := countRows(t, s, "memories", testProject); n != 3 {
+		t.Errorf("memories after dry-run = %d, want 3 (unchanged)", n)
+	}
+	if n := countRows(t, s, "tasks", testProject); n != 1 {
+		t.Errorf("tasks after dry-run = %d, want 1 (unchanged)", n)
+	}
+	if n := countRows(t, s, "token_usage", testProject); n != 1 {
+		t.Errorf("token_usage after dry-run = %d, want 1 (unchanged)", n)
+	}
+	if _, _, err := s.ResolveProject(ctx, testProject); err != nil {
+		t.Fatalf("ResolveProject after dry-run: %v", err)
+	}
+}
+
+func TestDeleteProject_ApplyRemovesEverythingIncludingOrphanTables(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	seedFullProject(t, s, ctx, testProject)
+
+	summary, err := s.DeleteProject(ctx, testProject, true)
+	if err != nil {
+		t.Fatalf("DeleteProject apply: %v", err)
+	}
+	if summary.Memories != 3 || summary.MemoryLinks != 1 || summary.Tasks != 1 ||
+		summary.Decisions != 1 || summary.TokenUsage != 1 || summary.AuditLog != 1 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+
+	for _, table := range []string{"memories", "tasks", "decisions", "token_usage", "audit_log"} {
+		if n := countRows(t, s, table, testProject); n != 0 {
+			t.Errorf("%s after apply = %d, want 0", table, n)
+		}
+	}
+	var linkCount int
+	if err := s.db.QueryRow(`
+		SELECT count(*) FROM memory_links
+		WHERE source_id NOT IN (SELECT id FROM memories) OR target_id NOT IN (SELECT id FROM memories)
+	`).Scan(&linkCount); err != nil {
+		t.Fatalf("check dangling links: %v", err)
+	}
+	if linkCount != 0 {
+		t.Errorf("expected no dangling memory_links pointing at deleted memories, got %d", linkCount)
+	}
+
+	// The project row itself is gone.
+	id, _, err := s.ResolveProject(ctx, testProject)
+	if err != nil {
+		t.Fatalf("ResolveProject after apply: %v", err)
+	}
+	if id != "" {
+		t.Errorf("expected project to be gone, ResolveProject still returns id %q", id)
+	}
+}
+
 func TestSeedGlobalMemories(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2569,14 +2569,14 @@ func TestDeleteProject_ConcurrentWriteFromSeparateProcessDoesNotUndercountSummar
 	if err != nil {
 		t.Fatalf("OpenDB A: %v", err)
 	}
-	defer dbA.Close()
+	defer func() { _ = dbA.Close() }()
 	storeA := NewStore(dbA, logger)
 
 	dbB, err := OpenDB(dbPath)
 	if err != nil {
 		t.Fatalf("OpenDB B: %v", err)
 	}
-	defer dbB.Close()
+	defer func() { _ = dbB.Close() }()
 	storeB := NewStore(dbB, logger)
 
 	ctx := context.Background()

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2354,6 +2354,17 @@ func TestDeleteProject_ApplyRemovesEverythingIncludingOrphanTables(t *testing.T)
 		t.Errorf("expected no dangling memory_links pointing at deleted memories, got %d", linkCount)
 	}
 
+	// The memories_fts index (maintained by the memories_ad AFTER DELETE
+	// trigger in schema.go) must also be emptied by the cascade delete —
+	// it has no project_id column, so countRows can't check it directly.
+	var ftsCount int
+	if err := s.db.QueryRow(`SELECT count(*) FROM memories_fts`).Scan(&ftsCount); err != nil {
+		t.Fatalf("count memories_fts: %v", err)
+	}
+	if ftsCount != 0 {
+		t.Errorf("memories_fts retains %d rows after apply, want 0", ftsCount)
+	}
+
 	// The project row itself is gone.
 	id, _, err := s.ResolveProject(ctx, testProject)
 	if err != nil {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2187,13 +2187,15 @@ func TestMergeProject_SameID(t *testing.T) {
 	}
 }
 
-// seedFullProject creates one memory-link pair, two tasks, one decision
-// (which also creates its own linked memory row, source='decision_log'), one
-// token_usage row, and one audit_log row for projectID — one of everything
-// DeleteProject must account for, except tasks vs. decisions are deliberately
-// unequal (2 vs. 1) so a test that swaps the Tasks/Decisions scan targets in
-// DeleteProject's count query fails instead of passing silently. Returns the
-// two linked memory IDs.
+// seedFullProject creates four memories, four memory-link pairs, two tasks,
+// one decision (which also creates its own linked memory row,
+// source='decision_log', bringing the memory total to 5), three token_usage
+// rows, and six audit_log rows for projectID — a row in every table
+// DeleteProject must account for, with every field's final count (memories=5,
+// memory_links=4, tasks=2, decisions=1, token_usage=3, audit_log=6) distinct
+// from every other field's, so a test that transposes any pair of scan
+// targets in DeleteProject's count query fails instead of passing silently.
+// Returns the first two linked memory IDs.
 func seedFullProject(t *testing.T, s *Store, ctx context.Context, projectID string) (mem1, mem2 string) {
 	t.Helper()
 
@@ -2210,8 +2212,22 @@ func seedFullProject(t *testing.T, s *Store, ctx context.Context, projectID stri
 	if err != nil {
 		t.Fatalf("seed mem2: %v", err)
 	}
-	if err := s.CreateLink(ctx, mem1, mem2, "related", 0.8, "auto"); err != nil {
-		t.Fatalf("seed link: %v", err)
+	mem3, err := s.Create(ctx, projectID, Memory{
+		Category: "fact", Content: "seed memory three", Source: "manual", Importance: 0.5, Tags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("seed mem3: %v", err)
+	}
+	mem4, err := s.Create(ctx, projectID, Memory{
+		Category: "fact", Content: "seed memory four", Source: "manual", Importance: 0.5, Tags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("seed mem4: %v", err)
+	}
+	for _, pair := range [][2]string{{mem1, mem2}, {mem1, mem3}, {mem1, mem4}, {mem2, mem3}} {
+		if err := s.CreateLink(ctx, pair[0], pair[1], "related", 0.8, "auto"); err != nil {
+			t.Fatalf("seed link %v: %v", pair, err)
+		}
 	}
 	if _, err := s.CreateTask(ctx, projectID, "seed task one", "desc", 1); err != nil {
 		t.Fatalf("seed task one: %v", err)
@@ -2222,13 +2238,17 @@ func seedFullProject(t *testing.T, s *Store, ctx context.Context, projectID stri
 	if _, _, err := s.RecordDecision(ctx, projectID, "seed decision", "did the thing", "because", nil, nil); err != nil {
 		t.Fatalf("seed decision: %v", err)
 	}
-	if err := s.RecordUsage(ctx, projectID, "claude-opus-4-6", TokenUsage{InputTokens: 10, OutputTokens: 5}); err != nil {
-		t.Fatalf("seed token_usage: %v", err)
+	for i := 0; i < 3; i++ {
+		if err := s.RecordUsage(ctx, projectID, "claude-opus-4-6", TokenUsage{InputTokens: 10, OutputTokens: 5}); err != nil {
+			t.Fatalf("seed token_usage %d: %v", i, err)
+		}
 	}
-	if _, err := s.db.ExecContext(ctx,
-		`INSERT INTO audit_log (action, project_id) VALUES ('test-action', ?)`, projectID,
-	); err != nil {
-		t.Fatalf("seed audit_log: %v", err)
+	for i := 0; i < 6; i++ {
+		if _, err := s.db.ExecContext(ctx,
+			`INSERT INTO audit_log (action, project_id) VALUES ('test-action', ?)`, projectID,
+		); err != nil {
+			t.Fatalf("seed audit_log %d: %v", i, err)
+		}
 	}
 	return mem1, mem2
 }
@@ -2295,12 +2315,12 @@ func TestDeleteProject_DryRunCountsAndWritesNothing(t *testing.T) {
 	if summary.ProjectID != testProject {
 		t.Errorf("ProjectID = %q, want %q", summary.ProjectID, testProject)
 	}
-	// 3 memories: the 2 seeded directly + 1 from RecordDecision's decision_log row.
-	if summary.Memories != 3 {
-		t.Errorf("Memories = %d, want 3", summary.Memories)
+	// 5 memories: the 4 seeded directly + 1 from RecordDecision's decision_log row.
+	if summary.Memories != 5 {
+		t.Errorf("Memories = %d, want 5", summary.Memories)
 	}
-	if summary.MemoryLinks != 1 {
-		t.Errorf("MemoryLinks = %d, want 1", summary.MemoryLinks)
+	if summary.MemoryLinks != 4 {
+		t.Errorf("MemoryLinks = %d, want 4", summary.MemoryLinks)
 	}
 	if summary.Tasks != 2 {
 		t.Errorf("Tasks = %d, want 2", summary.Tasks)
@@ -2308,22 +2328,22 @@ func TestDeleteProject_DryRunCountsAndWritesNothing(t *testing.T) {
 	if summary.Decisions != 1 {
 		t.Errorf("Decisions = %d, want 1", summary.Decisions)
 	}
-	if summary.TokenUsage != 1 {
-		t.Errorf("TokenUsage = %d, want 1", summary.TokenUsage)
+	if summary.TokenUsage != 3 {
+		t.Errorf("TokenUsage = %d, want 3", summary.TokenUsage)
 	}
-	if summary.AuditLog != 1 {
-		t.Errorf("AuditLog = %d, want 1", summary.AuditLog)
+	if summary.AuditLog != 6 {
+		t.Errorf("AuditLog = %d, want 6", summary.AuditLog)
 	}
 
 	// Dry-run must write nothing: every row must still be there.
-	if n := countRows(t, s, "memories", testProject); n != 3 {
-		t.Errorf("memories after dry-run = %d, want 3 (unchanged)", n)
+	if n := countRows(t, s, "memories", testProject); n != 5 {
+		t.Errorf("memories after dry-run = %d, want 5 (unchanged)", n)
 	}
 	if n := countRows(t, s, "tasks", testProject); n != 2 {
 		t.Errorf("tasks after dry-run = %d, want 2 (unchanged)", n)
 	}
-	if n := countRows(t, s, "token_usage", testProject); n != 1 {
-		t.Errorf("token_usage after dry-run = %d, want 1 (unchanged)", n)
+	if n := countRows(t, s, "token_usage", testProject); n != 3 {
+		t.Errorf("token_usage after dry-run = %d, want 3 (unchanged)", n)
 	}
 	if _, _, err := s.ResolveProject(ctx, testProject); err != nil {
 		t.Fatalf("ResolveProject after dry-run: %v", err)
@@ -2339,8 +2359,8 @@ func TestDeleteProject_ApplyRemovesEverythingIncludingOrphanTables(t *testing.T)
 	if err != nil {
 		t.Fatalf("DeleteProject apply: %v", err)
 	}
-	if summary.Memories != 3 || summary.MemoryLinks != 1 || summary.Tasks != 2 ||
-		summary.Decisions != 1 || summary.TokenUsage != 1 || summary.AuditLog != 1 {
+	if summary.Memories != 5 || summary.MemoryLinks != 4 || summary.Tasks != 2 ||
+		summary.Decisions != 1 || summary.TokenUsage != 3 || summary.AuditLog != 6 {
 		t.Fatalf("unexpected summary: %+v", summary)
 	}
 
@@ -2396,7 +2416,7 @@ func TestDeleteProject_IsolatesOtherProjects(t *testing.T) {
 		t.Fatalf("DeleteProject: %v", err)
 	}
 
-	expected := map[string]int{"memories": 3, "tasks": 2, "decisions": 1, "token_usage": 1, "audit_log": 1}
+	expected := map[string]int{"memories": 5, "tasks": 2, "decisions": 1, "token_usage": 3, "audit_log": 6}
 	for table, want := range expected {
 		if n := countRows(t, s, table, otherProject); n != want {
 			t.Errorf("%s for %s after deleting %s = %d, want %d (should be untouched)", table, otherProject, testProject, n, want)
@@ -2410,8 +2430,8 @@ func TestDeleteProject_IsolatesOtherProjects(t *testing.T) {
 		WHERE m.project_id = ?`, otherProject).Scan(&links); err != nil {
 		t.Fatalf("count memory_links: %v", err)
 	}
-	if links != 1 {
-		t.Errorf("memory_links for %s = %d, want 1", otherProject, links)
+	if links != 4 {
+		t.Errorf("memory_links for %s = %d, want 4", otherProject, links)
 	}
 
 	if id, _, err := s.ResolveProject(ctx, otherProject); err != nil || id == "" {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2355,7 +2355,45 @@ func TestDeleteProject_DryRunCountsAndWritesNothing(t *testing.T) {
 func TestDeleteProject_ApplyRemovesEverythingIncludingOrphanTables(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()
-	seedFullProject(t, s, ctx, testProject)
+	mem1, _ := seedFullProject(t, s, ctx, testProject)
+
+	// Seed one row in every remaining cascading table seedFullProject
+	// doesn't already cover, so this test proves the full cascade chain
+	// documented on DeleteProject, not just the tables exercised elsewhere.
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO memory_embeddings (memory_id, embedding) VALUES (?, ?)`, mem1, []byte{0x01, 0x02},
+	); err != nil {
+		t.Fatalf("seed memory_embeddings: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO link_scans (memory_id) VALUES (?)`, mem1,
+	); err != nil {
+		t.Fatalf("seed link_scans: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO ghost_state (project_id, learned_context) VALUES (?, ?)
+		 ON CONFLICT(project_id) DO UPDATE SET learned_context = excluded.learned_context`,
+		testProject, "seeded learned context",
+	); err != nil {
+		t.Fatalf("seed ghost_state: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO memory_snapshots (snapshot_id, project_id, category, content, importance, source) VALUES (?, ?, ?, ?, ?, ?)`,
+		"snap-1", testProject, "fact", "seed snapshot content", 0.5, "manual",
+	); err != nil {
+		t.Fatalf("seed memory_snapshots: %v", err)
+	}
+	const seedConversationID = "conv-1"
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO conversations (id, project_id) VALUES (?, ?)`, seedConversationID, testProject,
+	); err != nil {
+		t.Fatalf("seed conversations: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO messages (conversation_id, role, content) VALUES (?, ?, ?)`, seedConversationID, "user", "seed message",
+	); err != nil {
+		t.Fatalf("seed messages: %v", err)
+	}
 
 	summary, err := s.DeleteProject(ctx, testProject, true)
 	if err != nil {
@@ -2391,6 +2429,37 @@ func TestDeleteProject_ApplyRemovesEverythingIncludingOrphanTables(t *testing.T)
 	}
 	if ftsCount != 0 {
 		t.Errorf("memories_fts retains %d rows after apply, want 0", ftsCount)
+	}
+
+	// memory_embeddings and link_scans key off memory_id, not project_id, so
+	// countRows can't check them directly.
+	var embedCount int
+	if err := s.db.QueryRow(`SELECT count(*) FROM memory_embeddings WHERE memory_id = ?`, mem1).Scan(&embedCount); err != nil {
+		t.Fatalf("count memory_embeddings: %v", err)
+	}
+	if embedCount != 0 {
+		t.Errorf("memory_embeddings retains %d rows after apply, want 0", embedCount)
+	}
+	var scanCount int
+	if err := s.db.QueryRow(`SELECT count(*) FROM link_scans WHERE memory_id = ?`, mem1).Scan(&scanCount); err != nil {
+		t.Fatalf("count link_scans: %v", err)
+	}
+	if scanCount != 0 {
+		t.Errorf("link_scans retains %d rows after apply, want 0", scanCount)
+	}
+
+	for _, table := range []string{"ghost_state", "memory_snapshots", "conversations"} {
+		if n := countRows(t, s, table, testProject); n != 0 {
+			t.Errorf("%s after apply = %d, want 0", table, n)
+		}
+	}
+	// messages keys off conversation_id, not project_id.
+	var msgCount int
+	if err := s.db.QueryRow(`SELECT count(*) FROM messages WHERE conversation_id = ?`, seedConversationID).Scan(&msgCount); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if msgCount != 0 {
+		t.Errorf("messages retains %d rows after apply, want 0", msgCount)
 	}
 
 	// The project row itself is gone.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2375,6 +2375,49 @@ func TestDeleteProject_ApplyRemovesEverythingIncludingOrphanTables(t *testing.T)
 	}
 }
 
+// TestDeleteProjectRowTx_AlreadyDeletedGuard exercises deleteProjectRowTx
+// directly rather than the full DeleteProject method. DeleteProject holds
+// s.mu for its entire apply path (count queries through the final delete),
+// so within a single process two calls to s.DeleteProject can't interleave —
+// the race this guard defends against is ResolveProject (which takes its own
+// RLock and releases it) reporting the project as present, and the row then
+// vanishing before this transaction's DELETE runs: a concurrent caller in
+// this process racing the window between ResolveProject and s.mu.Lock(), or
+// — the realistic case — a separate ghost process (CLI and MCP server each
+// open their own *Store against the same SQLite file) deleting it via its
+// own connection. Reproducing that with real timing would be flaky; deleting
+// the row directly via s.db and then invoking the exact helper DeleteProject
+// calls proves the guard fires without relying on goroutine scheduling.
+func TestDeleteProjectRowTx_AlreadyDeletedGuard(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Simulate a concurrent deletion that already removed the project row
+	// before this transaction's delete runs. This must happen before
+	// BeginTx below: the store's *sql.DB is capped at one open connection
+	// (SetMaxOpenConns(1), see schema.go OpenDB) to serialize SQLite access,
+	// so issuing this DELETE against s.db while a tx already holds that sole
+	// connection would block forever waiting for a connection that can never
+	// free up.
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM projects WHERE id = ?`, testProject); err != nil {
+		t.Fatalf("pre-delete project: %v", err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	err = deleteProjectRowTx(ctx, tx, testProject)
+	if err == nil {
+		t.Fatal("expected error when project row is already gone")
+	}
+	if !strings.Contains(err.Error(), "already deleted") {
+		t.Errorf("expected %q in error, got: %v", "already deleted", err)
+	}
+}
+
 func TestSeedGlobalMemories(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2390,11 +2390,24 @@ func TestDeleteProject_IsolatesOtherProjects(t *testing.T) {
 		t.Fatalf("DeleteProject: %v", err)
 	}
 
-	for _, table := range []string{"memories", "tasks", "decisions", "token_usage", "audit_log"} {
-		if n := countRows(t, s, table, otherProject); n != 1 && !(table == "memories" && n == 3) {
-			t.Errorf("%s for %s after deleting %s = %d, unexpected (should be untouched)", table, otherProject, testProject, n)
+	expected := map[string]int{"memories": 3, "tasks": 1, "decisions": 1, "token_usage": 1, "audit_log": 1}
+	for table, want := range expected {
+		if n := countRows(t, s, table, otherProject); n != want {
+			t.Errorf("%s for %s after deleting %s = %d, want %d (should be untouched)", table, otherProject, testProject, n, want)
 		}
 	}
+
+	var links int
+	if err := s.db.QueryRow(`
+		SELECT count(*) FROM memory_links l
+		JOIN memories m ON m.id = l.source_id
+		WHERE m.project_id = ?`, otherProject).Scan(&links); err != nil {
+		t.Fatalf("count memory_links: %v", err)
+	}
+	if links != 1 {
+		t.Errorf("memory_links for %s = %d, want 1", otherProject, links)
+	}
+
 	if id, _, err := s.ResolveProject(ctx, otherProject); err != nil || id == "" {
 		t.Errorf("expected %s to still exist, ResolveProject: id=%q err=%v", otherProject, id, err)
 	}

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2375,6 +2375,31 @@ func TestDeleteProject_ApplyRemovesEverythingIncludingOrphanTables(t *testing.T)
 	}
 }
 
+func TestDeleteProject_IsolatesOtherProjects(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	const otherProject = "other-project"
+	if err := s.EnsureProject(ctx, otherProject, "/tmp/other-project", "other-project"); err != nil {
+		t.Fatalf("EnsureProject other: %v", err)
+	}
+
+	seedFullProject(t, s, ctx, testProject)
+	seedFullProject(t, s, ctx, otherProject)
+
+	if _, err := s.DeleteProject(ctx, testProject, true); err != nil {
+		t.Fatalf("DeleteProject: %v", err)
+	}
+
+	for _, table := range []string{"memories", "tasks", "decisions", "token_usage", "audit_log"} {
+		if n := countRows(t, s, table, otherProject); n != 1 && !(table == "memories" && n == 3) {
+			t.Errorf("%s for %s after deleting %s = %d, unexpected (should be untouched)", table, otherProject, testProject, n)
+		}
+	}
+	if id, _, err := s.ResolveProject(ctx, otherProject); err != nil || id == "" {
+		t.Errorf("expected %s to still exist, ResolveProject: id=%q err=%v", otherProject, id, err)
+	}
+}
+
 // TestDeleteProjectRowTx_AlreadyDeletedGuard exercises deleteProjectRowTx
 // directly rather than the full DeleteProject method. DeleteProject holds
 // s.mu for its entire apply path (count queries through the final delete),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -73,6 +73,7 @@ type MemoryStore interface {
 	ResolveProject(ctx context.Context, input string) (id, name string, err error)
 	ListProjectNames(ctx context.Context) ([]string, error)
 	MergeProject(ctx context.Context, oldID, newID string) error
+	DeleteProject(ctx context.Context, input string, apply bool) (memory.DeleteProjectSummary, error)
 
 	// Conversation persistence
 	CreateConversation(ctx context.Context, projectID, mode string) (string, error)


### PR DESCRIPTION
## Summary
- Adds `Store.DeleteProject` to permanently remove a project and everything under it: memories, tags, embeddings, memory_links, tasks, decisions, learned context, reflection snapshots, and the non-cascading `token_usage`/`audit_log` history. Dry-run by default; `_global` is always refused.
- Exposes it via `ghost project delete <name-or-id> [--apply]` (requires re-typing the project name to confirm on `--apply`) and via the `ghost_project_delete` MCP tool (`apply: true` to actually delete).
- Backed by a full spec (`docs/superpowers/specs/2026-08-17-delete-project-design.md`) and implementation plan (`docs/superpowers/plans/2026-08-17-delete-project.md`), built task-by-task with TDD, two-stage review per task, and a final whole-branch review with a follow-up hardening pass (mutation-tested fixtures so future field-transposition bugs in the summary counts can't ship silently).

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` — full suite green
- [x] Manual CLI lifecycle smoke test: not-found → dry-run → mismatched confirmation aborts → correct confirmation deletes → post-delete not-found
- [x] Unit tests: `DeleteProject` (not-found, refuses `_global`, dry-run writes nothing, apply cascades incl. FTS5, already-deleted guard, cross-project isolation), CLI confirmation-abort path, `ghost_project_delete` MCP tool (dry-run/apply/`_global` rejection), all with pairwise-distinct fixture counts verified via mutation testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project deletion through the CLI and MCP tools.
  * Deletion defaults to a dry-run preview with related record counts.
  * Actual deletion requires explicit confirmation or apply mode.
  * Applied deletions notify subscribed project resources.
  * Protected the global project from deletion.
* **Bug Fixes**
  * Added safeguards for invalid, missing, concurrent, or already-deleted projects.
* **Documentation**
  * Updated usage, architecture, and tool-count documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->