### PR TITLE
fix(memory): pinned memories are fully exempt from decay, not a 1.5x boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Facts about your stack shouldn't expire. Last month's debugging detour should. T
 | `architecture`, `pattern` | 45-day scale | 0.3 |
 | `decision`, `gotcha`, `dependency` | 30-day scale | 0.15 |
 
-Pinned memories get a 1.5× boost on top.
+Pinned memories are fully exempt from decay — they score at raw importance regardless of age or category.
 
 ### Consolidation you can undo
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,7 +170,7 @@ schema changes only reach databases created after the change.
 
 ## Time-Decay Scoring
 
-Memories are scored by `importance × decay_factor × pinned_boost`, where
+Memories are scored by `importance × decay_factor`, where
 `decay_factor = max(floor, 1 / (1 + age_days / scale))`:
 
 | Category | Scale (half-life) | Floor |
@@ -179,9 +179,10 @@ Memories are scored by `importance × decay_factor × pinned_boost`, where
 | architecture, pattern | 45-day | 0.3 |
 | decision, gotcha, dependency | 30-day | 0.15 |
 
-Pinned memories get a 1.5× boost (`pinned_boost`) on top of their decayed score —
-they do **not** bypass decay, so a sufficiently stale pinned memory can still rank
-below a fresh unpinned one. See `GetTopMemories` in `internal/memory/store.go`.
+Pinned memories are fully exempt from decay — `decay_factor` is forced to `1.0`
+regardless of category or age, so a pinned memory always scores at its raw
+importance. This is a no-op for preference/convention/fact, which already never
+decay. See `DecayRankingSQL` / `GetTopMemories` in `internal/memory/store.go`.
 
 ## Build
 

--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -373,8 +373,9 @@ func loadSessionContext(cwd string) (projectID, project string, memories []sessi
 		totalCountKnown = true
 	}
 
-	// Get top memories using the same category-aware time-decay + pinned-boost
-	// ranking as Store.GetTopMemories (internal/memory/store.go), sharing the
+	// Get top memories using the same category-aware time-decay +
+	// pinned-exemption ranking as Store.GetTopMemories
+	// (internal/memory/store.go), sharing the
 	// exact ranking SQL via memory.DecayRankingSQL so the two orderings can
 	// never drift apart. The query itself isn't issued through a Store method
 	// because this function deliberately uses its own lightweight, read-only

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -706,7 +706,7 @@ func (s *Store) Upsert(ctx context.Context, projectID, category, content, source
 // DecayRankingSQL is the composite-score ranking expression shared by
 // GetTopMemories below and the session-start hook's own read-only query
 // (internal/mcpinit/hook.go's loadSessionContext) — a single source of truth
-// for the category-aware time-decay + pinned-boost formula so the two
+// for the category-aware time-decay + pinned-exemption formula so the two
 // callers can never drift apart. It is a fragment, not a full query: callers
 // interpolate it into their own "ORDER BY (...) DESC" clause.
 // The 0.15 and 0.3 floors create a dead zone at the low end of each decaying
@@ -715,16 +715,20 @@ func (s *Store) Upsert(ctx context.Context, projectID, category, content, source
 // category (1.0 * 0.15 == 0.15 * 1.0). Accepted — importance that low is rare
 // in practice (defaults are 0.5+) — but if ranking ever looks off for a
 // low-importance category member, this tie is why.
+// Pinned is a full decay exemption (factor 1.0), not a multiplier on top of
+// the decayed/floored score — a pinned memory always scores at its raw
+// importance regardless of age or category. It's a no-op for
+// preference/convention/fact, which already never decay.
 const DecayRankingSQL = `
 	importance
 	* CASE
+		WHEN pinned = 1 THEN 1.0
 		WHEN category IN ('preference', 'convention', 'fact') THEN 1.0
 		WHEN category IN ('pattern', 'architecture') THEN
 			MAX(0.3, 1.0 / (1.0 + (julianday('now') - julianday(created_at)) / 45.0))
 		ELSE
 			MAX(0.15, 1.0 / (1.0 + (julianday('now') - julianday(created_at)) / 30.0))
 	END
-	* CASE WHEN pinned = 1 THEN 1.5 ELSE 1.0 END
 `
 
 // GetTopMemories returns the top N memories ranked by composite score

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1049,22 +1049,30 @@ func TestStoreGetTopMemoriesPinnedBoost(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()
 
-	// Create two memories — lower importance but pinned should rank higher.
+	// Lower importance but pinned (and thus exempt from decay) should still
+	// outrank a higher-importance memory that has decayed to its floor.
+	// Both use a decaying category ('dependency') and are aged past the
+	// 170-day floor crossover (see TestDecayFloorCrossoverBoundaries) so an
+	// unpinned row would score importance*0.15.
 	id1, err := s.Create(ctx, testProject, Memory{
-		Category: "fact", Content: "Pinned low importance",
+		Category: "dependency", Content: "Pinned low importance",
 		Source: "manual", Importance: 0.5, Tags: []string{},
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if _, err := s.Create(ctx, testProject, Memory{
-		Category: "fact", Content: "Unpinned higher importance",
+	id2, err := s.Create(ctx, testProject, Memory{
+		Category: "dependency", Content: "Unpinned higher importance",
 		Source: "manual", Importance: 0.6, Tags: []string{},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
+	setCreatedAtDaysAgo(t, s, id1, 300)
+	setCreatedAtDaysAgo(t, s, id2, 300)
 
-	// Pin the first one — 0.5 * 1.5 = 0.75 > 0.6.
+	// Pin the first one — exemption scores it at full importance (0.5),
+	// beating the unpinned one's floored 0.6*0.15=0.09.
 	if err := s.TogglePin(ctx, id1, true); err != nil {
 		t.Fatalf("TogglePin: %v", err)
 	}
@@ -1075,6 +1083,36 @@ func TestStoreGetTopMemoriesPinnedBoost(t *testing.T) {
 	}
 	if top[0].Content != "Pinned low importance" {
 		t.Errorf("expected pinned memory first, got %q", top[0].Content)
+	}
+}
+
+// TestPinnedMemoryExemptFromDecay confirms pinned means fully exempt from
+// category decay (score == importance) rather than a 1.5x multiplier
+// stacked on top of the decayed/floored score. A 300-day-old dependency
+// memory would otherwise floor at importance*0.15 (see
+// TestDecayFloorCrossoverBoundaries); pinned, it must score at full
+// importance instead of importance*0.15*1.5.
+func TestPinnedMemoryExemptFromDecay(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	const importance = 0.6
+
+	id, err := s.Create(ctx, testProject, Memory{
+		Category: "dependency", Content: "old pinned dependency",
+		Source: "manual", Importance: importance, Tags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	setCreatedAtDaysAgo(t, s, id, 300)
+
+	if err := s.TogglePin(ctx, id, true); err != nil {
+		t.Fatalf("TogglePin: %v", err)
+	}
+
+	want := importance
+	if got := memoryScore(t, s, id); math.Abs(got-want) > 1e-6 {
+		t.Errorf("pinned 300-day dependency score = %v, want %v (full exemption, not a boosted floor)", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `DecayRankingSQL` ([store.go:718-732](https://github.com/wcatz/ghost/blob/main/internal/memory/store.go#L718-L732)) previously applied pinning as a flat 1.5x multiplier *on top of* the category decay/floor. A pinned, fully-decayed `dependency`/`gotcha`/`decision` memory could still score below an unpinned never-decaying `preference`/`convention`/`fact` at equal importance — pin softened the fall but didn't guarantee surfacing.
- Pinned now sets the decay factor to `1.0` outright (a true exemption), so a pinned memory always scores at its raw importance regardless of age or category. This is a no-op for preference/convention/fact, which already never decayed.
- Updated the one test whose expected math relied on the old multiplier (`TestStoreGetTopMemoriesPinnedBoost`), added `TestPinnedMemoryExemptFromDecay` asserting the exact exemption behavior via the shared `memoryScore` helper, and fixed "pinned-boost" wording in `README.md` and the session-start hook comment (`internal/mcpinit/hook.go`) to match.
- Follows from an audit of the time-decay feature; a related but separate gap (`ghost_memory_search`'s RRF path has zero time-awareness) is tracked in #316 and intentionally out of scope here.

## Test plan
- [x] `TestPinnedMemoryExemptFromDecay` written first, confirmed failing against the old 1.5x-multiplier formula (`0.135` vs expected `0.6`)
- [x] Implemented the exemption, confirmed the new test passes
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, all packages pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Pinned memories now retain their full importance indefinitely, regardless of age or memory category.
  - Removed the previous pinned-memory scoring boost in favor of complete exemption from time decay.
  - Updated memory ranking behavior so lower-importance pinned memories can outrank older, higher-importance unpinned memories.

- **Documentation**
  - Updated the README and related guidance to explain the new pinned-memory ranking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->