### PR TITLE
fix(reflection): require stronger signal before promoting SQLite-tier memories to global

### DIFF
--- a/internal/reflection/consolidator_test.go
+++ b/internal/reflection/consolidator_test.go
@@ -180,11 +180,15 @@ func TestInferGlobalScope(t *testing.T) {
 		content  string
 		want     string
 	}{
-		{"preference always global", "preference", "use tabs not spaces", "global"},
+		{"generic preference without cross-repo signal stays project", "preference", "use tabs not spaces", "project"},
+		{"preference with explicit cross-repo signal is global", "preference", "use tabs not spaces across all repos", "global"},
 		{"architecture is project", "architecture", "ghost uses 3-block prompt caching", "project"},
 		{"cross-repo workflow", "fact", "deploy to infra cluster from any repo", "global"},
-		{"ssh host", "fact", "SSH into node3 via bastion", "global"},
-		{"always use pattern", "convention", "always use nerdctl not docker", "global"},
+		{"single ssh hit stays project (was false positive, #319)", "fact", "SSH into node3 via bastion", "project"},
+		{"issue #319 example: project-specific ssh note stays project", "fact", "SSH into relay 3 to restart the block producer", "project"},
+		{"issue #319 example: project-specific relay preference stays project", "preference", "prefer using relay 3 for deploys", "project"},
+		{"single always-use hit stays project (was false positive, #319)", "convention", "always use nerdctl not docker", "project"},
+		{"two weak hits promote to global", "fact", "SSH into the shared cluster for maintenance", "global"},
 		{"project convention", "convention", "commit messages use feat/fix prefix", "project"},
 		{"all repos", "pattern", "run go vet across all repos before release", "global"},
 		{"dev machine", "fact", "dev machine runs Asahi Fedora on Apple Silicon", "global"},
@@ -209,7 +213,7 @@ func TestSQLiteConsolidator_SetsScope(t *testing.T) {
 
 	input := ReflectionInput{
 		ExistingMemories: []memory.Memory{
-			{Category: "preference", Content: "use nerdctl not docker", Importance: 0.9, Tags: []string{}},
+			{Category: "preference", Content: "use nerdctl not docker across all repos", Importance: 0.9, Tags: []string{}},
 			{Category: "architecture", Content: "ghost uses SQLite with FTS5", Importance: 0.8, Tags: []string{}},
 		},
 	}

--- a/internal/reflection/consolidator_test.go
+++ b/internal/reflection/consolidator_test.go
@@ -189,6 +189,7 @@ func TestInferGlobalScope(t *testing.T) {
 		{"issue #319 example: project-specific relay preference stays project", "preference", "prefer using relay 3 for deploys", "project"},
 		{"single always-use hit stays project (was false positive, #319)", "convention", "always use nerdctl not docker", "project"},
 		{"two weak hits promote to global", "fact", "SSH into the shared cluster for maintenance", "global"},
+		{"correlated weak hits in a project-scoped sentence stay project", "fact", "deploy to the project cluster for maintenance", "project"},
 		{"project convention", "convention", "commit messages use feat/fix prefix", "project"},
 		{"all repos", "pattern", "run go vet across all repos before release", "global"},
 		{"dev machine", "fact", "dev machine runs Asahi Fedora on Apple Silicon", "global"},
@@ -214,6 +215,7 @@ func TestSQLiteConsolidator_SetsScope(t *testing.T) {
 	input := ReflectionInput{
 		ExistingMemories: []memory.Memory{
 			{Category: "preference", Content: "use nerdctl not docker across all repos", Importance: 0.9, Tags: []string{}},
+			{Category: "preference", Content: "use tabs not spaces", Importance: 0.9, Tags: []string{}},
 			{Category: "architecture", Content: "ghost uses SQLite with FTS5", Importance: 0.8, Tags: []string{}},
 		},
 	}
@@ -223,13 +225,22 @@ func TestSQLiteConsolidator_SetsScope(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	wantScope := map[string]string{
+		"use nerdctl not docker across all repos": "global",
+		"use tabs not spaces":                     "project",
+		"ghost uses SQLite with FTS5":             "project",
+	}
 	for _, m := range result.Memories {
-		if m.Category == "preference" && m.Scope != "global" {
-			t.Errorf("preference should be global, got %q", m.Scope)
+		want, ok := wantScope[m.Content]
+		if !ok {
+			t.Fatalf("unexpected memory in result: %q", m.Content)
 		}
-		if m.Category == "architecture" && m.Scope != "project" {
-			t.Errorf("architecture should be project, got %q", m.Scope)
+		if m.Scope != want {
+			t.Errorf("Scope for %q = %q, want %q", m.Content, m.Scope, want)
 		}
+	}
+	if len(result.Memories) != len(wantScope) {
+		t.Errorf("got %d memories, want %d", len(result.Memories), len(wantScope))
 	}
 }
 

--- a/internal/reflection/tier_sqlite.go
+++ b/internal/reflection/tier_sqlite.go
@@ -120,24 +120,37 @@ func inferGlobalScope(category, content string) string {
 		return "project"
 	}
 
-	// Preferences and certain facts are strong global signals.
-	if category == "preference" {
-		return "global"
-	}
-
-	// Cross-repo workflow indicators.
-	globalPatterns := []string{
+	// Unambiguous cross-repo/personal-environment language: one hit is enough.
+	strongPatterns := []string{
 		"across all", "all repos", "all projects", "every repo", "every project",
 		"cross-repo", "cross-project", "from any repo",
-		"deploy to", "deploy from", "push to infra",
-		"ssh ", "ssh into", "hostname",
-		"always use", "never use", "prefer ",
 		"personal tool", "dev machine", "workstation",
-		"infrastructure topology", "cluster ",
+		"infrastructure topology",
 	}
-	for _, p := range globalPatterns {
+	for _, p := range strongPatterns {
 		if strings.Contains(lower, p) {
 			return "global"
+		}
+	}
+
+	// Ambiguous DevOps phrasing reads the same whether the memory is
+	// project-specific or genuinely cross-repo (e.g. "SSH into relay 3 to
+	// restart the block producer" is project-specific, not global — see #319).
+	// A single hit isn't enough signal on its own; require two independent
+	// hits before promoting.
+	weakPatterns := []string{
+		"deploy to", "deploy from", "push to infra",
+		"ssh ", "hostname",
+		"always use", "never use", "prefer ",
+		"cluster ",
+	}
+	hits := 0
+	for _, p := range weakPatterns {
+		if strings.Contains(lower, p) {
+			hits++
+			if hits >= 2 {
+				return "global"
+			}
 		}
 	}
 

--- a/internal/reflection/tier_sqlite.go
+++ b/internal/reflection/tier_sqlite.go
@@ -120,6 +120,18 @@ func inferGlobalScope(category, content string) string {
 		return "project"
 	}
 
+	// Explicit project-scoping language wins even over multiple weak-pattern
+	// hits below: "deploy to the project cluster for maintenance" hits both
+	// "deploy to" and "cluster " but is unambiguously project-specific.
+	projectScopedMarkers := []string{
+		"this project", "this repo", "the project", "for this service",
+	}
+	for _, p := range projectScopedMarkers {
+		if strings.Contains(lower, p) {
+			return "project"
+		}
+	}
+
 	// Unambiguous cross-repo/personal-environment language: one hit is enough.
 	strongPatterns := []string{
 		"across all", "all repos", "all projects", "every repo", "every project",


### PR DESCRIPTION
## What

`inferGlobalScope` (internal/reflection/tier_sqlite.go) decides whether the mechanical SQLite consolidation tier promotes a memory to global scope (replayed into every project's injected context). Two things made it over-promote:

1. `category == "preference"` auto-promoted to global regardless of content — a project-specific preference like "prefer using relay 3 for deploys" got global scope.
2. A single hit of an ambiguous keyword (`"ssh "`, `"cluster "`, `"always use"`, `"never use"`, `"prefer "`, `"deploy to"`/`"deploy from"`, `"hostname"`) promoted to global, even though that phrasing reads the same whether the memory is project-specific or genuinely cross-repo.

Closes #319.

## Fix

- Split the keyword list into **strong** markers (`"across all"`, `"all repos"`, `"cross-repo"`, `"dev machine"`, etc.) — unambiguous, one hit is enough — and **weak** markers (the ambiguous DevOps phrasing above) — now requires two independent hits before promoting.
- Removed the `category == "preference"` bypass; preferences go through the same content check as every other category.

## Testing

- `go vet ./...`, `go build ./...`, `go test ./...` all clean.
- Updated `TestInferGlobalScope` with the issue's own false-positive examples (`"SSH into relay 3 to restart the block producer"`, `"prefer using relay 3 for deploys"` → now `project`) plus a case proving two independent weak hits still promote.
- Updated `TestSQLiteConsolidator_SetsScope`'s preference fixture to carry an explicit cross-repo signal, since a bare preference is no longer auto-global.

## Out of scope

Issue #319 also flagged `Available()` always returning `true` (SQLite tier is the guaranteed fallback whenever no LLM tier is configured) as a contributing factor. That's documented, intentional behavior for this tier ("Lowest tier: always available, zero external dependencies") — changing it is a separate architectural question, not a keyword-matching bug, so left out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scope classification to better distinguish project-specific information from genuinely cross-project guidance.
  * Prevented isolated SSH, relay, “always use,” and preference-related references from being incorrectly treated as globally applicable.
  * Added support for recognizing sufficiently strong shared-environment wording as global.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->