### PR TITLE
docs: add sourced competitor comparison to Phase 4 results

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,20 @@ Per-category, hybrid vs FTS-only (the delta shows where vector search earns its 
 | temporal-reasoning (127) | 97.6% | 88.2% | +9.4pp |
 | knowledge-update (72) | 98.6% | 94.4% | +4.2pp |
 
-The biggest lifts land on vocabulary-mismatch classes — `single-session-assistant` (+30pp) and `multi-session` (+20pp) — exactly where embeddings fix what FTS misses. The blended score (500 questions) includes abstention for fair comparison with competitors. Not leaderboard-comparable (DeepSeek v4 Pro, not GPT-4o), but the retrieval → answer pipeline is identical to the official harness. Reproduce: see [`bench/longmemeval/phase4/`](bench/longmemeval/phase4/).
+The biggest lifts land on vocabulary-mismatch classes — `single-session-assistant` (+30pp) and `multi-session` (+20pp) — exactly where embeddings fix what FTS misses. Not leaderboard-comparable (DeepSeek v4 Pro, not GPT-4o), but the retrieval → answer pipeline is identical to the official harness.
+
+**Competitor comparison** (500-question blended, all systems):
+
+| System | Score | Generator | Source |
+|--------|-------|-----------|--------|
+| **Ghost (hybrid)** | **96.2%** | DeepSeek V4 Pro | This repo |
+| Mem0 | 94.4% | Not specified | [mem0.ai/research](https://mem0.ai/research) — "managed platform, proprietary optimizations not in OSS SDK" |
+| Hindsight | 91.4% | Gemini-3 Pro | [arxiv 2512.12818](https://arxiv.org/abs/2512.12818) — independently validated by Virginia Tech + Washington Post |
+| Supermemory | 85.2% | Gemini-3 | [supermemory.ai/research](https://supermemory.ai/research/longmembench/) — self-reported |
+
+**Read carefully:** These numbers are **not directly comparable** across rows — each uses a different generator and judge. Within the same generator+judge pair, differences are meaningful; across pairs, they're directional only.
+
+Reproduce: see [`bench/longmemeval/phase4/`](bench/longmemeval/phase4/).
 
 Skipped deliberately: LOCOMO (publicly audited answer-key and judge problems) and DMR.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -169,6 +169,17 @@ Per-category breakdown (non-abstention):
 
 Not leaderboard-comparable (DeepSeek v4 Pro, not GPT-4o), but the retrieval → answer pipeline is identical to the official harness. The blended score (500 questions) enables fair comparison with competitors who include abstention in their aggregates.
 
+### Competitor comparison (500-question blended)
+
+| System | Score | Generator | Source |
+|--------|-------|-----------|--------|
+| **Ghost (hybrid)** | **96.2%** | DeepSeek V4 Pro | This repo |
+| Mem0 | 94.4% | Not specified | [mem0.ai/research](https://mem0.ai/research) — "managed platform, proprietary optimizations not in OSS SDK" |
+| Hindsight | 91.4% | Gemini-3 Pro | [arxiv 2512.12818](https://arxiv.org/abs/2512.12818), [benchmarks](https://benchmarks.hindsight.vectorize.io/) — independently validated by Virginia Tech + Washington Post |
+| Supermemory | 85.2% | Gemini-3 | [supermemory.ai/research](https://supermemory.ai/research/longmembench/) — self-reported |
+
+**Read carefully:** These numbers are **not directly comparable** across rows. Each uses a different generator model and (in Ghost's case) a different judge. Within the same generator+judge pair, differences are meaningful — across pairs, they're directional only. Ghost's self-judged score carries the same caveat as every other system that judges its own output.
+
 ### Cost
 
 Estimated cost at `topk_context=5` over 500 questions: ~$3-5 (DeepSeek V4 Pro via OpenCode Go), ~$20 (gpt-4o gen+judge), ~$24 (claude-sonnet-5 gen+judge). Use `cost_estimate.py` (no API calls) to re-anchor before spending. Temperature 0, single recorded run, per-case results JSON and full logs committed, an explicit note that the memory system never saw oracle context.


### PR DESCRIPTION
## Summary

Adds a properly cited competitor comparison table to both README.md and docs/benchmarks.md, completing the work started in #325.

## Changes

- **docs/benchmarks.md**: New `### Competitor comparison` section with sourced table and methodology caveat
- **README.md**: Same comparison table added after category breakdown

## Competitor numbers (all sourced)

| System | Score | Generator | Source |
|--------|-------|-----------|--------|
| Ghost | 96.2% | DeepSeek V4 Pro | This repo |
| Mem0 | 94.4% | Not specified | mem0.ai/research — managed platform, not OSS |
| Hindsight | 91.4% | Gemini-3 Pro | arxiv 2512.12818 — validated by Virginia Tech + Washington Post |
| Supermemory | 85.2% | Gemini-3 | supermemory.ai/research — self-reported |

## Caveat

Numbers not directly comparable across rows — different generator models and judges. Within same pair, differences are meaningful; across pairs, directional only.