### PR TITLE
obsidian: clean up orphaned project folders on export

### DIFF
--- a/docs/superpowers/plans/2026-08-20-obsidian-orphan-folder-cleanup.md
+++ b/docs/superpowers/plans/2026-08-20-obsidian-orphan-folder-cleanup.md
@@ -1,0 +1,295 @@
+# Obsidian Orphan Folder Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clean up orphaned project folders in the Obsidian vault when projects are deleted from Ghost.
+
+**Architecture:** Add a second pass to `prune` that scans the vault root for top-level directories not in the current project set, and removes any containing Ghost-managed content. The caller (`Export`) passes the full set of known project folders to distinguish orphans from active projects.
+
+**Tech Stack:** Go, `os`, `filepath`, `path/filepath`
+
+## Global Constraints
+
+- Go 1.26+ (see `go.mod`)
+- Pure Go SQLite (modernc.org/sqlite — no CGO)
+- Tests: `go test ./internal/obsidian/...`
+- Lint: `go vet ./...`
+
+---
+
+### Task 1: Add orphan folder cleanup to `prune` and update `Export` caller
+
+**Files:**
+- Modify: `internal/obsidian/vault.go:94` (prune signature + new logic)
+- Modify: `internal/obsidian/export.go:154` (prune call site)
+
+**Interfaces:**
+- Consumes: `subtrees []string`, `keep map[string]string` (existing), `knownFolders []string` (new)
+- Produces: `prune` signature becomes `prune(root string, subtrees []string, keep map[string]string, knownFolders []string) error`
+
+- [ ] **Step 1: Update `prune` signature in `vault.go`**
+
+Change line 94 from:
+
+```go
+func prune(root string, subtrees []string, keep map[string]string) error {
+```
+
+to:
+
+```go
+func prune(root string, subtrees []string, keep map[string]string, knownFolders []string) error {
+```
+
+- [ ] **Step 2: Add orphan folder cleanup after existing subtree walk in `vault.go`**
+
+After the existing `for _, sub := range subtrees` loop (line 129) and before the final `return nil` (line 130), add the orphan cleanup pass:
+
+```go
+	// Orphan cleanup: remove vault top-level directories that are not in the
+	// current project set but contain Ghost-managed content. This handles
+	// projects deleted from the DB since the last export. Skipped when
+	// knownFolders is nil (filtered export — we can't know what's orphaned).
+	if len(knownFolders) > 0 {
+		known := make(map[string]bool, len(knownFolders))
+		for _, f := range knownFolders {
+			known[f] = true
+		}
+		entries, err := readDir(root)
+		if err != nil {
+			return fmt.Errorf("read vault root for orphan scan: %w", err)
+		}
+		for _, e := range entries {
+			if !e.IsDir() || e.Name() == markerName {
+				continue
+			}
+			if known[e.Name()] {
+				continue
+			}
+			if !filepath.IsLocal(e.Name()) {
+				return fmt.Errorf("refusing to prune: orphan dir %q escapes vault root", e.Name())
+			}
+			dir := filepath.Join(root, e.Name())
+			if hasGhostContent(dir) {
+				if err := os.RemoveAll(dir); err != nil {
+					return fmt.Errorf("remove orphan folder %s: %w", e.Name(), err)
+				}
+			}
+		}
+	}
+```
+
+- [ ] **Step 3: Add `hasGhostContent` helper in `vault.go`**
+
+Add this function before `prune` (after `hasGhostID`):
+
+```go
+// hasGhostContent reports whether dir contains any .md file with a ghost_id
+// in its frontmatter — the signature of a Ghost-managed note.
+func hasGhostContent(dir string) bool {
+	var found bool
+	filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		if _, ok := hasGhostID(path); ok {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+```
+
+- [ ] **Step 4: Update `Export` caller in `export.go`**
+
+Change line 154 from:
+
+```go
+	if err := prune(vaultDir, subtrees, keep); err != nil {
+```
+
+to:
+
+```go
+	// Build the full set of known project folders (including truncated
+	// projects) so prune can distinguish deleted projects from active ones.
+	var knownFolders []string
+	if projectFilter == "" {
+		knownFolders = make([]string, 0, len(folders))
+		for _, f := range folders {
+			knownFolders = append(knownFolders, f)
+		}
+	}
+	if err := prune(vaultDir, subtrees, keep, knownFolders); err != nil {
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `go vet ./internal/obsidian/...`
+Expected: no errors
+
+- [ ] **Step 6: Run existing tests to confirm no regressions**
+
+Run: `go test ./internal/obsidian/... -v -count=1`
+Expected: all existing tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/obsidian/vault.go internal/obsidian/export.go
+git commit -m "obsidian: add orphan project folder cleanup to prune"
+```
+
+---
+
+### Task 2: Add tests for orphan folder cleanup
+
+**Files:**
+- Modify: `internal/obsidian/export_test.go`
+
+**Interfaces:**
+- Consumes: `Exporter.Export(ctx, vaultDir, projectFilter)` (existing), `memory.Store` (existing)
+- Produces: three new test functions
+
+- [ ] **Step 1: Write `TestExportPrunesDeletedProjectFolder`**
+
+Add after `TestExportReclaimsOrphanedTmpFiles`:
+
+```go
+func TestExportPrunesDeletedProjectFolder(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	if err := store.EnsureProject(ctx, "doomed", "/tmp/doomed", "doomed"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(ctx, "ghost", memory.Memory{Category: "fact", Content: "Ghost fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(ctx, "doomed", memory.Memory{Category: "fact", Content: "Doomed fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+	// Both project folders exist after initial export.
+	for _, proj := range []string{"ghost", "doomed"} {
+		notes, _ := filepath.Glob(filepath.Join(vault, proj, "Memories", "*.md"))
+		if len(notes) != 1 {
+			t.Fatalf("want 1 note in %s, got %d", proj, len(notes))
+		}
+	}
+
+	// Delete the doomed project from the DB.
+	if _, err := store.DeleteProject(ctx, "doomed", true); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-export — orphan folder should be pruned.
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(vault, "doomed")); !os.IsNotExist(err) {
+		t.Error("deleted project's vault folder should be removed")
+	}
+	ghostNotes, _ := filepath.Glob(filepath.Join(vault, "ghost", "Memories", "*.md"))
+	if len(ghostNotes) != 1 {
+		t.Errorf("surviving project should be untouched, got %d notes", len(ghostNotes))
+	}
+}
+```
+
+- [ ] **Step 2: Write `TestExportSkipsOrphanCleanupWhenFiltered`**
+
+Add after the previous test:
+
+```go
+func TestExportSkipsOrphanCleanupWhenFiltered(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	if err := store.EnsureProject(ctx, "other", "/tmp/other", "other"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(ctx, "ghost", memory.Memory{Category: "fact", Content: "Ghost fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(ctx, "other", memory.Memory{Category: "fact", Content: "Other fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	// Export unfiltered first to create both folders.
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now export with filter — orphan cleanup should be skipped.
+	if err := ex.Export(ctx, vault, "ghost"); err != nil {
+		t.Fatal(err)
+	}
+	// The "other" folder must survive even though it's not in the filtered set.
+	notes, _ := filepath.Glob(filepath.Join(vault, "other", "Memories", "*.md"))
+	if len(notes) != 1 {
+		t.Errorf("filtered export must not prune other project's folder, got %d notes", len(notes))
+	}
+}
+```
+
+- [ ] **Step 3: Write `TestExportIgnoresUserFolders`**
+
+Add after the previous test:
+
+```go
+func TestExportIgnoresUserFolders(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	if _, err := store.Create(ctx, "ghost", memory.Memory{Category: "fact", Content: "Ghost fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a user folder with non-Ghost .md files (no ghost_id frontmatter).
+	userDir := filepath.Join(vault, "my-notes")
+	if err := os.MkdirAll(userDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userDir, "jotting.md"), []byte("# My Note\nJust a note."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-export — user folder must survive.
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(userDir); os.IsNotExist(err) {
+		t.Error("user-created folder should not be pruned")
+	}
+}
+```
+
+- [ ] **Step 4: Run the new tests**
+
+Run: `go test ./internal/obsidian/... -v -run "TestExportPrunesDeletedProjectFolder|TestExportSkipsOrphanCleanupWhenFiltered|TestExportIgnoresUserFolders" -count=1`
+Expected: all three tests pass
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `go test ./internal/obsidian/... -v -count=1`
+Expected: all tests pass (existing + new)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/obsidian/export_test.go
+git commit -m "obsidian: add tests for orphan folder cleanup"
+```

--- a/docs/superpowers/specs/2026-08-20-obsidian-orphan-folder-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-20-obsidian-orphan-folder-cleanup-design.md
@@ -1,0 +1,40 @@
+# Obsidian Export: Orphaned Project Folder Cleanup
+
+## Problem
+
+When a project is deleted from Ghost (via `ghost project delete` or the MCP tool), the Obsidian sync loop detects the DB change and re-exports, but the deleted project's vault folder remains as stale files. The `prune` function only walks folders of projects that still exist in the DB (`subtrees`), so deleted projects' folders are never touched.
+
+## Approach
+
+Add a second pass to `prune` that scans the vault root for top-level directories not in the current `subtrees` set, and removes any that contain Ghost-managed content.
+
+### Changes to `internal/obsidian/vault.go`
+
+Change `prune`'s signature to accept a `knownFolders []string` parameter — the complete set of project folder names computed by `folderNames` for all selected projects (including truncated ones). This is distinct from `subtrees` (which excludes truncated projects and is used for the existing per-file prune walk).
+
+After the existing subtree walk, add:
+
+1. **Scan vault root** for top-level directories (skip the `.ghost-vault` marker file).
+2. **Filter** to directories not in `knownFolders` — these are orphan candidates.
+3. **Ghost-content check**: for each candidate, walk its `.md` files looking for any with `ghost_id` in frontmatter (via existing `hasGhostID`). If none found, skip — it's a user folder or empty.
+4. **Delete** the entire directory with `os.RemoveAll` if it contains Ghost-managed content.
+5. **Same guards** as existing prune: marker check at vault root, `filepath.IsLocal` on directory names.
+
+### Edge cases
+
+- **Empty orphan folders** (no `.md` files): left alone — no Ghost content to clean up.
+- **Truncated lists**: safe because `knownFolders` includes ALL selected projects (truncated or not), so their folders are never orphan candidates. The existing per-file prune walk still skips truncated projects (stale beats deleted).
+- **Filtered export** (`--project ghost`): orphan cleanup is skipped when a filter is active — we only see the filtered subset and can't determine what's orphaned. When a filter is active, pass `nil` for `knownFolders`.
+- **User-created folders**: left alone — `hasGhostID` returns false for non-Ghost `.md` files.
+
+### Changes to `internal/obsidian/export.go`
+
+Update the `prune` call to pass `knownFolders` — the full set of folder names from `folderNames(projects)` for all selected projects. When a filter is active, pass `nil` to disable orphan cleanup.
+
+### Tests
+
+**`TestExportPrunesDeletedProjectFolder`**: Create two projects with memories, export, delete one from DB, re-export, assert deleted project's folder is gone.
+
+**`TestExportSkipsOrphanCleanupWhenFiltered`**: Export with `--project ghost`, assert a second project's folder is not touched even if it exists on disk.
+
+**`TestExportIgnoresUserFolders`**: Create a vault, export, then manually create a non-Ghost folder with user `.md` files. Re-export, assert user folder survives.

--- a/internal/obsidian/export.go
+++ b/internal/obsidian/export.go
@@ -151,7 +151,16 @@ func (e *Exporter) Export(ctx context.Context, vaultDir, projectFilter string) e
 			subtrees = append(subtrees, d.folder)
 		}
 	}
-	if err := prune(vaultDir, subtrees, keep); err != nil {
+	// Build the full set of known project folders (including truncated
+	// projects) so prune can distinguish deleted projects from active ones.
+	var knownFolders []string
+	if projectFilter == "" {
+		knownFolders = make([]string, 0, len(folders))
+		for _, f := range folders {
+			knownFolders = append(knownFolders, f)
+		}
+	}
+	if err := prune(vaultDir, subtrees, keep, knownFolders); err != nil {
 		return err
 	}
 	e.Logger.Info("obsidian export complete", "projects", len(data), "written", written, "unchanged", skipped)

--- a/internal/obsidian/export_test.go
+++ b/internal/obsidian/export_test.go
@@ -279,6 +279,112 @@ func TestExportReclaimsOrphanedTmpFiles(t *testing.T) {
 	}
 }
 
+func TestExportPrunesDeletedProjectFolder(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	if err := store.EnsureProject(ctx, "doomed", "/tmp/doomed", "doomed"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(ctx, "ghost", memory.Memory{Category: "fact", Content: "Ghost fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(ctx, "doomed", memory.Memory{Category: "fact", Content: "Doomed fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+	// Both project folders exist after initial export.
+	for _, proj := range []string{"ghost", "doomed"} {
+		notes, _ := filepath.Glob(filepath.Join(vault, proj, "Memories", "*.md"))
+		if len(notes) != 1 {
+			t.Fatalf("want 1 note in %s, got %d", proj, len(notes))
+		}
+	}
+
+	// Delete the doomed project from the DB.
+	if _, err := store.DeleteProject(ctx, "doomed", true); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-export — orphan folder should be pruned.
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(vault, "doomed")); !os.IsNotExist(err) {
+		t.Error("deleted project's vault folder should be removed")
+	}
+	ghostNotes, _ := filepath.Glob(filepath.Join(vault, "ghost", "Memories", "*.md"))
+	if len(ghostNotes) != 1 {
+		t.Errorf("surviving project should be untouched, got %d notes", len(ghostNotes))
+	}
+}
+
+func TestExportSkipsOrphanCleanupWhenFiltered(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	if err := store.EnsureProject(ctx, "other", "/tmp/other", "other"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(ctx, "ghost", memory.Memory{Category: "fact", Content: "Ghost fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(ctx, "other", memory.Memory{Category: "fact", Content: "Other fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	// Export unfiltered first to create both folders.
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now export with filter — orphan cleanup should be skipped.
+	if err := ex.Export(ctx, vault, "ghost"); err != nil {
+		t.Fatal(err)
+	}
+	// The "other" folder must survive even though it's not in the filtered set.
+	notes, _ := filepath.Glob(filepath.Join(vault, "other", "Memories", "*.md"))
+	if len(notes) != 1 {
+		t.Errorf("filtered export must not prune other project's folder, got %d notes", len(notes))
+	}
+}
+
+func TestExportIgnoresUserFolders(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	if _, err := store.Create(ctx, "ghost", memory.Memory{Category: "fact", Content: "Ghost fact", Importance: 0.8, Source: "mcp"}); err != nil {
+		t.Fatal(err)
+	}
+
+	vault := filepath.Join(t.TempDir(), "vault")
+	ex := &Exporter{Store: store, Logger: slog.Default()}
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a user folder with non-Ghost .md files (no ghost_id frontmatter).
+	userDir := filepath.Join(vault, "my-notes")
+	if err := os.MkdirAll(userDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userDir, "jotting.md"), []byte("# My Note\nJust a note."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-export — user folder must survive.
+	if err := ex.Export(ctx, vault, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(userDir); os.IsNotExist(err) {
+		t.Error("user-created folder should not be pruned")
+	}
+}
+
 func TestTruncated(t *testing.T) {
 	for _, tc := range []struct {
 		n, limit int

--- a/internal/obsidian/vault.go
+++ b/internal/obsidian/vault.go
@@ -88,7 +88,7 @@ func hasGhostID(path string) (string, bool) {
 // in its frontmatter — the signature of a Ghost-managed note.
 func hasGhostContent(dir string) bool {
 	var found bool
-	filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
 			return nil
 		}
@@ -98,6 +98,9 @@ func hasGhostContent(dir string) bool {
 		}
 		return nil
 	})
+	if err != nil {
+		return false // can't scan — preserve the folder
+	}
 	return found
 }
 

--- a/internal/obsidian/vault.go
+++ b/internal/obsidian/vault.go
@@ -84,6 +84,23 @@ func hasGhostID(path string) (string, bool) {
 	return "", false
 }
 
+// hasGhostContent reports whether dir contains any .md file with a ghost_id
+// in its frontmatter — the signature of a Ghost-managed note.
+func hasGhostContent(dir string) bool {
+	var found bool
+	filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		if _, ok := hasGhostID(path); ok {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
 // prune deletes Ghost-managed .md files under the given vault subtrees whose
 // ghost_id is not in keep, or whose basename is not the canonical one for
 // that ghost_id (a content edit renamed the slug — the old-slug file is
@@ -91,7 +108,7 @@ func hasGhostID(path string) (string, bool) {
 // are enforced. Orphaned *.ghost-tmp files (left by a crashed writeIfChanged)
 // are also reclaimed — but only inside the managed subtrees, behind the
 // marker guard.
-func prune(root string, subtrees []string, keep map[string]string) error {
+func prune(root string, subtrees []string, keep map[string]string, knownFolders []string) error {
 	if _, err := os.Stat(filepath.Join(root, markerName)); err != nil {
 		return fmt.Errorf("refusing to prune: %s marker not found in %s", markerName, root)
 	}
@@ -125,6 +142,37 @@ func prune(root string, subtrees []string, keep map[string]string) error {
 		})
 		if err != nil {
 			return err
+		}
+	}
+	// Orphan cleanup: remove vault top-level directories that are not in the
+	// current project set but contain Ghost-managed content. This handles
+	// projects deleted from the DB since the last export. Skipped when
+	// knownFolders is nil (filtered export — we can't know what's orphaned).
+	if len(knownFolders) > 0 {
+		known := make(map[string]bool, len(knownFolders))
+		for _, f := range knownFolders {
+			known[f] = true
+		}
+		entries, err := readDir(root)
+		if err != nil {
+			return fmt.Errorf("read vault root for orphan scan: %w", err)
+		}
+		for _, e := range entries {
+			if !e.IsDir() || e.Name() == markerName {
+				continue
+			}
+			if known[e.Name()] {
+				continue
+			}
+			if !filepath.IsLocal(e.Name()) {
+				return fmt.Errorf("refusing to prune: orphan dir %q escapes vault root", e.Name())
+			}
+			dir := filepath.Join(root, e.Name())
+			if hasGhostContent(dir) {
+				if err := os.RemoveAll(dir); err != nil {
+					return fmt.Errorf("remove orphan folder %s: %w", e.Name(), err)
+				}
+			}
 		}
 	}
 	return nil

--- a/internal/obsidian/vault_test.go
+++ b/internal/obsidian/vault_test.go
@@ -66,7 +66,7 @@ func TestPrune(t *testing.T) {
 	mustWrite(t, filepath.Join(sub, "stale-dead0000.md"), ghostNote)
 	mustWrite(t, filepath.Join(sub, "user-note.md"), "no frontmatter")
 
-	if err := prune(root, []string{"proj"}, map[string]string{}); err != nil {
+	if err := prune(root, []string{"proj"}, map[string]string{}, nil); err != nil {
 		t.Fatalf("prune: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(sub, "stale-dead0000.md")); !os.IsNotExist(err) {
@@ -80,7 +80,7 @@ func TestPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 	mustWrite(t, filepath.Join(sub, "stale2-beef0000.md"), ghostNote)
-	if err := prune(root, []string{"proj"}, map[string]string{}); err == nil {
+	if err := prune(root, []string{"proj"}, map[string]string{}, nil); err == nil {
 		t.Fatal("prune without marker must error")
 	}
 }
@@ -106,7 +106,7 @@ func TestPruneGuards(t *testing.T) {
 	renamed := "---\nghost_id: cafe0000\ntype: memory\n---\nbody\n"
 	mustWrite(t, filepath.Join(sub, "old-slug-cafe0000.md"), renamed)
 
-	if err := prune(root, []string{"proj"}, map[string]string{"cafe0000": "kept-cafe0000.md"}); err != nil {
+	if err := prune(root, []string{"proj"}, map[string]string{"cafe0000": "kept-cafe0000.md"}, nil); err != nil {
 		t.Fatalf("prune: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(sub, "kept-cafe0000.md")); err != nil {
@@ -134,14 +134,14 @@ func TestPruneRefusesEscapingSubtree(t *testing.T) {
 	victim := filepath.Join(escape, "victim-dead0000.md")
 	mustWrite(t, victim, "---\nghost_id: dead0000\ntype: memory\n---\nbody\n")
 
-	if err := prune(root, []string{"../escape"}, map[string]string{}); err == nil {
+	if err := prune(root, []string{"../escape"}, map[string]string{}, nil); err == nil {
 		t.Fatal("prune with escaping subtree must error")
 	}
 	if _, err := os.Stat(victim); err != nil {
 		t.Fatal("file outside the vault root must survive an escaping-subtree prune attempt")
 	}
 	// Absolute paths must be refused too.
-	if err := prune(root, []string{escape}, map[string]string{}); err == nil {
+	if err := prune(root, []string{escape}, map[string]string{}, nil); err == nil {
 		t.Fatal("prune with absolute subtree must error")
 	}
 	if _, err := os.Stat(victim); err != nil {


### PR DESCRIPTION
When a project is deleted from Ghost, the Obsidian vault folder remains as stale files. This adds a second pass to the `prune` function that scans the vault root for top-level directories not in the current project set, and removes any containing Ghost-managed content.

Changes:
- `vault.go`: Add `hasGhostContent` helper and orphan folder cleanup logic to `prune`
- `export.go`: Build `knownFolders` from all selected projects and pass to `prune`
- `export_test.go`: Add tests for deleted project pruning, filtered export safety, and user folder preservation

Closes the gap where `obsidian sync` would re-export after a project deletion but leave the orphaned folder untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically removes orphaned project folders from Obsidian vaults after projects are deleted.
  * Preserves user-created folders, empty folders, filtered exports, and folders belonging to truncated projects.
  * Detects Ghost-managed notes to avoid deleting unrelated content.

* **Tests**
  * Added coverage for orphan removal and protection of user folders and filtered exports.

* **Documentation**
  * Added design and implementation documentation for orphan-folder cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->