### PR TITLE
fix(mcpinit): test helper writes config to ConfigFilePath on macOS

### DIFF
--- a/internal/mcpinit/status_test.go
+++ b/internal/mcpinit/status_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/wcatz/ghost/internal/config"
 	"github.com/wcatz/ghost/internal/embedding"
 	"github.com/wcatz/ghost/internal/memory"
 )
@@ -159,19 +160,22 @@ func writeStubGhost(t *testing.T) string {
 	return binDir
 }
 
-// writeGhostConfigFile writes a ghost config.yaml into the isolated config dir
-// (os.UserConfigDir under the test's HOME) and returns its path.
+// writeGhostConfigFile writes a ghost config.yaml to the exact path
+// config.ConfigFilePath resolves (which honors XDG_CONFIG_HOME via
+// userConfigDir), so the file is at the location the code under test reads.
+// Using os.UserConfigDir here would diverge on macOS, where it ignores
+// XDG_CONFIG_HOME and returns ~/Library/Application Support, making
+// reportConfigFile report "no config file" for a file that exists.
 func writeGhostConfigFile(t *testing.T, content string) string {
 	t.Helper()
-	configDir, err := os.UserConfigDir()
+	path, err := config.ConfigFilePath()
 	if err != nil {
-		t.Fatalf("user config dir: %v", err)
+		t.Fatalf("config file path: %v", err)
 	}
-	dir := filepath.Join(configDir, "ghost")
+	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatalf("mkdir ghost config dir: %v", err)
 	}
-	path := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write ghost config: %v", err)
 	}


### PR DESCRIPTION
Fixes #330.

## Root cause

`writeGhostConfigFile` (`internal/mcpinit/status_test.go`) wrote the config to `os.UserConfigDir()` — which on **macOS ignores `XDG_CONFIG_HOME`** and returns `~/Library/Application Support`. Meanwhile `reportConfigFile` and `config.Load` resolve through `config.ConfigFilePath` → `userConfigDir`, which honors `XDG_CONFIG_HOME`. So on macOS the test wrote config to one directory and the code looked in another:

- `TestReportConfigFile_Present`: reported "no config file" for a file that existed.
- `TestStatus_OllamaDownDurationReported`: the embedding config was never loaded, so `cfg.Embedding.Enabled` stayed false and the Ollama-down duration report never fired.

On Linux, `os.UserConfigDir()` honors `XDG_CONFIG_HOME`, which is why this only broke on macOS.

## Fix

The helper now writes to the exact path `config.ConfigFilePath()` resolves, so the file lands where the code under test reads it.

Verified: `go test ./...` all pass, `go vet ./...` clean.