### PR TITLE
resolve prefilter recall (#336) + reflect guarded-drop guard (#337)

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -266,7 +266,7 @@ func resolveProjectOrExit(ctx context.Context, store *memory.Store, projectName 
 // Use --restore to undo the last consolidation from snapshot.
 func runReflect() {
 	var projectName, tierValue string
-	var apply, restore, requireLLM bool
+	var apply, restore, requireLLM, allowDrops bool
 	tierValue = "auto"
 	for i := 2; i < len(os.Args); i++ {
 		switch {
@@ -281,6 +281,8 @@ func runReflect() {
 			restore = true
 		case os.Args[i] == "--require-llm":
 			requireLLM = true
+		case os.Args[i] == "--allow-drops":
+			allowDrops = true
 		case !strings.HasPrefix(os.Args[i], "-"):
 			projectName = os.Args[i]
 		}
@@ -292,7 +294,8 @@ Flags:
   --tier string   Consolidation tier: auto, haiku, cli, opencode, sqlite (default "auto")
   --apply         Save results (default is dry-run/preview only)
   --restore       Undo the last consolidation from snapshot
-  --require-llm   Fail instead of falling back to the Jaccard-only sqlite tier`)
+  --require-llm   Fail instead of falling back to the Jaccard-only sqlite tier
+  --allow-drops   Apply even when guarded-category memories would be deleted without a merge`)
 		os.Exit(1)
 	}
 
@@ -512,6 +515,25 @@ Flags:
 			len(projectMems), existingNonManual)
 		if len(globalMems) > 0 {
 			fmt.Fprintf(os.Stderr, "  (%d memories classified as global — check scope accuracy)\n", len(globalMems))
+		}
+	}
+
+	// Guarded-drop audit (#337): gotcha/dependency/preference/convention
+	// memories must be merged, never deleted outright. Dry-run reports them;
+	// --apply refuses to write unless --allow-drops is set.
+	guardedDrops := reflection.AuditGuardedDrops(input, result)
+	if len(guardedDrops) > 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: %d guarded-category memory(ies) would be deleted without a merge:\n", len(guardedDrops))
+		for _, d := range guardedDrops {
+			truncated := d.Content
+			if len(truncated) > 100 {
+				truncated = truncated[:100] + "..."
+			}
+			fmt.Fprintf(os.Stderr, "  [%s] %s\n", d.Category, truncated)
+		}
+		if apply && !allowDrops {
+			fmt.Fprintln(os.Stderr, "error: refusing to apply — re-run with --allow-drops to accept these deletions")
+			os.Exit(1)
 		}
 	}
 

--- a/eval/cycle/main.go
+++ b/eval/cycle/main.go
@@ -145,25 +145,25 @@ func run(cfg config) error {
 	// default timeout when the caller's context has none — a deadline here
 	// both bounds the stage and lets classify calls run past that default.
 	supCtx, supCancel := context.WithTimeout(ctx, 8*time.Minute)
-	supOut, err := runGhost(supCtx, env, ghostBin, "supersede", cfg.project, "--apply")
+	supOut, supErrOut, err := runGhost(supCtx, env, ghostBin, "supersede", cfg.project, "--apply")
 	supCancel()
 	if err != nil {
 		return fmt.Errorf("supersede: %w", err)
 	}
-	writeRaw(cfg.resultsDir, "supersede", supOut)
-	_ = os.WriteFile(filepath.Join(scratch, "supersede.out.txt"), []byte(supOut), 0o644)
+	writeRaw(cfg.resultsDir, "supersede", supOut+supErrOut)
+	_ = os.WriteFile(filepath.Join(scratch, "supersede.out.txt"), []byte(supOut+supErrOut), 0o644)
 	rep.Supersede = gradeSupersede(ids, entries, parseSupersedeLines(supOut))
 	reportStage("supersede", rep.Supersede)
 
 	fmt.Println("stage: resolve")
 	resCtx, resCancel := context.WithTimeout(ctx, 8*time.Minute)
-	resOut, err := runGhost(resCtx, env, ghostBin, "resolve", cfg.project, "--apply")
+	resOut, resErrOut, err := runGhost(resCtx, env, ghostBin, "resolve", cfg.project, "--apply")
 	resCancel()
 	if err != nil {
 		return fmt.Errorf("resolve: %w", err)
 	}
-	writeRaw(cfg.resultsDir, "resolve", resOut)
-	_ = os.WriteFile(filepath.Join(scratch, "resolve.out.txt"), []byte(resOut), 0o644)
+	writeRaw(cfg.resultsDir, "resolve", resOut+resErrOut)
+	_ = os.WriteFile(filepath.Join(scratch, "resolve.out.txt"), []byte(resOut+resErrOut), 0o644)
 	rep.Resolve = gradeResolve(entries, parseResolveIDs(resOut), ids)
 	reportStage("resolve", rep.Resolve)
 
@@ -176,19 +176,19 @@ func run(cfg config) error {
 		refCtx, refCancel := context.WithTimeout(ctx, 15*time.Minute)
 		// --allow-drops: in the scratch DB, guarded-category deletions are
 		// data the reflect grader measures, not production harm.
-		refOut, rerr := runGhost(refCtx, env, ghostBin, "reflect", cfg.project, "--tier", "opencode", "--apply", "--allow-drops")
+		refOut, refErrOut, rerr := runGhost(refCtx, env, ghostBin, "reflect", cfg.project, "--tier", "opencode", "--apply", "--allow-drops")
 		refCancel()
 		if rerr != nil && strings.Contains(rerr.Error(), "SQLITE_BUSY") {
 			time.Sleep(5 * time.Second)
 			refCtx2, refCancel2 := context.WithTimeout(ctx, 15*time.Minute)
-			refOut, rerr = runGhost(refCtx2, env, ghostBin, "reflect", cfg.project, "--tier", "opencode", "--apply", "--allow-drops")
+			refOut, refErrOut, rerr = runGhost(refCtx2, env, ghostBin, "reflect", cfg.project, "--tier", "opencode", "--apply", "--allow-drops")
 			refCancel2()
 		}
 		if rerr != nil {
-			return fmt.Errorf("reflect: %w\noutput:\n%s", rerr, refOut)
+			return fmt.Errorf("reflect: %w\noutput:\n%s\nstderr:\n%s", rerr, refOut, refErrOut)
 		}
-		writeRaw(cfg.resultsDir, "reflect", refOut)
-		_ = os.WriteFile(filepath.Join(scratch, "reflect.out.txt"), []byte(refOut), 0o644)
+		writeRaw(cfg.resultsDir, "reflect", refOut+refErrOut)
+		_ = os.WriteFile(filepath.Join(scratch, "reflect.out.txt"), []byte(refOut+refErrOut), 0o644)
 		rowsAfter, ferr := fetchMemRows(dbPath, cfg.project)
 		if ferr != nil {
 			return fmt.Errorf("post-reflect state: %w", ferr)
@@ -316,17 +316,19 @@ func scratchEnv(scratch string) []string {
 	)
 }
 
-// runGhost runs one ghost CLI command in the scratch environment.
-func runGhost(ctx context.Context, env []string, bin string, args ...string) (string, error) {
+// runGhost runs one ghost CLI command in the scratch environment, returning
+// stdout and stderr separately — stderr carries warnings (e.g. the guarded-
+// drop audit) worth persisting even when the command succeeds.
+func runGhost(ctx context.Context, env []string, bin string, args ...string) (string, string, error) {
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Env = env
 	var out, errb bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &out, &errb
 	if err := cmd.Run(); err != nil {
-		return out.String(), fmt.Errorf("ghost %s: %w: %s",
+		return out.String(), errb.String(), fmt.Errorf("ghost %s: %w: %s",
 			strings.Join(args, " "), err, strings.TrimSpace(errb.String()))
 	}
-	return out.String(), nil
+	return out.String(), errb.String(), nil
 }
 
 // writeIDsFile persists the corpus-key → memory-id mapping inside the kept

--- a/eval/cycle/main.go
+++ b/eval/cycle/main.go
@@ -174,12 +174,14 @@ func run(cfg config) error {
 			return fmt.Errorf("pre-reflect state: %w", ferr)
 		}
 		refCtx, refCancel := context.WithTimeout(ctx, 15*time.Minute)
-		refOut, rerr := runGhost(refCtx, env, ghostBin, "reflect", cfg.project, "--tier", "opencode", "--apply")
+		// --allow-drops: in the scratch DB, guarded-category deletions are
+		// data the reflect grader measures, not production harm.
+		refOut, rerr := runGhost(refCtx, env, ghostBin, "reflect", cfg.project, "--tier", "opencode", "--apply", "--allow-drops")
 		refCancel()
 		if rerr != nil && strings.Contains(rerr.Error(), "SQLITE_BUSY") {
 			time.Sleep(5 * time.Second)
 			refCtx2, refCancel2 := context.WithTimeout(ctx, 15*time.Minute)
-			refOut, rerr = runGhost(refCtx2, env, ghostBin, "reflect", cfg.project, "--tier", "opencode", "--apply")
+			refOut, rerr = runGhost(refCtx2, env, ghostBin, "reflect", cfg.project, "--tier", "opencode", "--apply", "--allow-drops")
 			refCancel2()
 		}
 		if rerr != nil {

--- a/internal/reflection/drops.go
+++ b/internal/reflection/drops.go
@@ -1,0 +1,74 @@
+package reflection
+
+// guardedCategories are memory kinds whose loss is never acceptable without a
+// merge target: operational pitfalls, version pins, workflow rules, and user
+// preferences. Deleting them outright silently erases knowledge that still
+// guides future work (issue #337, eval-cycle finding F3).
+var guardedCategories = map[string]bool{
+	"gotcha":     true,
+	"dependency": true,
+	"preference": true,
+	"convention": true,
+}
+
+// DroppedGuarded is an input memory in a guarded category that has no close
+// survivor in the consolidation output.
+type DroppedGuarded struct {
+	Category string
+	Content  string
+}
+
+// dropContainmentThreshold: an input memory counts as survived when this
+// fraction of its tokens appears in some single output memory. Containment
+// (input→output), not Jaccard: the question is whether the input's substance
+// survives anywhere, not whether the rewrite is fully explained by one source.
+// Deliberately lenient — this audit can BLOCK an apply, so false positives
+// (flagging a healthy merge) are the expensive failure mode. Outright
+// deletions land far below it (an unrelated survivor shares only a stray
+// token or two).
+const dropContainmentThreshold = 0.45
+
+// AuditGuardedDrops returns input memories in guarded categories that have no
+// token-overlap survivor among the result memories. Uses the package's
+// tokenize (numeric-retaining, stopword-filtered) so merged rewrites that
+// preserve substance — including ports and versions — are recognized.
+func AuditGuardedDrops(input ReflectionInput, result ReflectionResult) []DroppedGuarded {
+	outTokens := make([]map[string]bool, 0, len(result.Memories))
+	for _, m := range result.Memories {
+		outTokens = append(outTokens, tokenize(m.Content))
+	}
+
+	var drops []DroppedGuarded
+	for _, in := range input.ExistingMemories {
+		if !guardedCategories[in.Category] {
+			continue
+		}
+		inTokens := tokenize(in.Content)
+		if len(inTokens) == 0 {
+			continue
+		}
+		if hasCloseSurvivor(inTokens, outTokens) {
+			continue
+		}
+		drops = append(drops, DroppedGuarded{Category: in.Category, Content: in.Content})
+	}
+	return drops
+}
+
+func hasCloseSurvivor(inTokens map[string]bool, outTokens []map[string]bool) bool {
+	for _, out := range outTokens {
+		if len(out) == 0 {
+			continue
+		}
+		found := 0
+		for tok := range inTokens {
+			if out[tok] {
+				found++
+			}
+		}
+		if float64(found)/float64(len(inTokens)) >= dropContainmentThreshold {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/reflection/drops_test.go
+++ b/internal/reflection/drops_test.go
@@ -1,0 +1,64 @@
+package reflection
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+func mem(cat, content string) memory.Memory {
+	return memory.Memory{Category: cat, Content: content}
+}
+
+// TestAuditGuardedDrops_FlagsDeletionWithoutMerge: a guarded-category input
+// with no close survivor in the output must be flagged (issue #337, finding
+// F3: the consolidator deleted bastion-port facts outright).
+func TestAuditGuardedDrops_FlagsDeletionWithoutMerge(t *testing.T) {
+	input := ReflectionInput{ExistingMemories: []memory.Memory{
+		mem("gotcha", "SSH to the Hetzner bastion goes through port 2222, not 22"),
+		mem("fact", "Production runs in region fsn1 behind Cloudflare"),
+	}}
+	result := ReflectionResult{Memories: []ReflectMemory{
+		{Category: "fact", Content: "Production runs in region fsn1 behind Cloudflare"},
+		{Category: "architecture", Content: "Orchestrator splits into ingest and billing services"},
+	}}
+	drops := AuditGuardedDrops(input, result)
+	if len(drops) != 1 {
+		t.Fatalf("want 1 dropped guarded memory, got %d: %+v", len(drops), drops)
+	}
+	if !strings.Contains(drops[0].Content, "bastion") {
+		t.Fatalf("wrong drop flagged: %+v", drops[0])
+	}
+}
+
+// TestAuditGuardedDrops_MergedRewriteIsNotADrop: consolidation may rewrite a
+// guarded memory into a survivor; token overlap must recognize it.
+func TestAuditGuardedDrops_MergedRewriteIsNotADrop(t *testing.T) {
+	input := ReflectionInput{ExistingMemories: []memory.Memory{
+		mem("gotcha", "Redis maxmemory must stay at 512mb on prod or the OOM killer reaps it during batch windows"),
+	}}
+	result := ReflectionResult{Memories: []ReflectMemory{
+		{Category: "gotcha", Content: "Redis is capped at maxmemory 512mb in production; raising it invites OOM kills during batch jobs"},
+	}}
+	if drops := AuditGuardedDrops(input, result); len(drops) != 0 {
+		t.Fatalf("merged rewrite flagged as drop: %+v", drops)
+	}
+}
+
+// TestAuditGuardedDrops_IgnoresUnguardedCategories: fact/architecture memories
+// are free to be consolidated away — only gotcha/dependency/preference/
+// convention are guarded.
+func TestAuditGuardedDrops_IgnoresUnguardedCategories(t *testing.T) {
+	input := ReflectionInput{ExistingMemories: []memory.Memory{
+		mem("fact", "The queue once used Redis lists with manual requeues"),
+		mem("preference", "Wayne prefers PRs under 400 changed lines"),
+	}}
+	result := ReflectionResult{Memories: []ReflectMemory{
+		{Category: "fact", Content: "The job queue uses Redis Streams"},
+	}}
+	drops := AuditGuardedDrops(input, result)
+	if len(drops) != 1 || drops[0].Category != "preference" {
+		t.Fatalf("want only the preference flagged, got %+v", drops)
+	}
+}

--- a/internal/reflection/prompt.go
+++ b/internal/reflection/prompt.go
@@ -81,6 +81,7 @@ func BuildReflectionPrompt(input ReflectionInput) string {
 	if len(input.ExistingMemories) > 0 {
 		_, _ = fmt.Fprintf(&sb, "\n\n## Existing Memories (%d total) — CONSOLIDATE THESE\n", len(input.ExistingMemories))
 		sb.WriteString("Review each memory. Merge duplicates, combine similar items into one stronger memory, drop stale/irrelevant ones, and keep confirmed facts.\n")
+		sb.WriteString("Hard rule: never DROP a memory whose category is gotcha, dependency, preference, or convention, or that records operational configuration (ports, hosts, paths, credentials locations) — fold its substance into a surviving memory instead. These facts still guide future work even when the surrounding thread is stale.\n")
 		for _, m := range input.ExistingMemories {
 			line := fmt.Sprintf("- [%s] (imp:%.1f, src:%s", m.Category, m.Importance, m.Source)
 			if m.AccessCount > 0 {

--- a/internal/resolve/haiku.go
+++ b/internal/resolve/haiku.go
@@ -31,7 +31,11 @@ func NewHaikuClassifier(client classifyProvider) *HaikuClassifier {
 
 const classifySystemPrompt = `You decide whether a memory note is RESOLVED evidence or should be KEPT.
 
-A note is RESOLVED evidence when it records intermediate findings, changelog entries, cost estimates, PR locators, or experiment results for work that has since concluded — the kind of note that mattered while the work was in progress but is now just history. Example: "kill experiment found 7.3% cross-session links, so we removed the bonus."
+A note is RESOLVED evidence when it records intermediate findings, changelog entries, cost estimates, PR locators, or experiment results for work that has since concluded — the kind of note that mattered while the work was in progress but is now just history. Examples:
+- "kill experiment found 7.3% cross-session links, so we removed the bonus."
+- "Cost estimate from May: $148/mo projected; actuals have since replaced it."
+- "Postmortem (concluded): deploy failure was a stale hash; mitigated. No open actions."
+- "Changelog: connection leak fixed in v0.9.3 (PR #398). Concluded work."
 
 KEEP the note when it is a terminal conclusion, an active decision of record, a standing rule, or reusable knowledge that still guides future work — even if it refers to a concluded thread. Example: "Graph-expansion RESOLVED NO-GO (2026-07-20)" is a decision record: KEEP.
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -34,6 +34,13 @@ var resolveKeywords = []string{
 	"no-go", "resolved", "shipped", "retracted", "superseded", "abandoned",
 	"fixed in", "removed", "merged", "kill experiment", "root cause",
 	"concluded", "closed", "reverted", "deprecated", "landed in",
+	// Concluded-work genres the eval corpus showed slipping the net
+	// (finding F2, issue #336). Multi-word phrases stay high-precision;
+	// "completed" is broader but false positives only cost one KEEP-biased
+	// LLM call.
+	"cost estimate", "postmortem", "changelog:", "investigation note",
+	"pr locator", "reference only", "history only", "no follow-up",
+	"completed",
 }
 
 // Classifier decides whether a memory's content is resolved evidence (true) or

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -228,3 +228,28 @@ func TestRun_MixedFallbackAndPrimary_SkipsApply(t *testing.T) {
 		t.Error("SetResolved must not be called when any candidate in the batch came from a fallback provider, even if another was confirmed via primary")
 	}
 }
+
+// TestPrefilterCatchesEstimateAndPostmortemPhrasings: eval-cycle corpus
+// evidence (finding F2, issue #336) showed concluded-work phrasings like cost
+// estimates and downtime estimates slipping past the keyword net.
+func TestPrefilterCatchesEstimateAndPostmortemPhrasings(t *testing.T) {
+	in := []memory.Memory{
+		{ID: "est", Content: "Cost estimate from May: Fly.io projected $148/mo at current traffic."},
+		{ID: "downtime", Content: "Migration plan estimated a 20-minute downtime window for final cutover; cutover completed 07-19."},
+		{ID: "pm", Content: "Postmortem (concluded): the deploy failure was a stale compose hash."},
+		{ID: "inv", Content: "Investigation note: slow queue drain was a missing XACK; fixed in v0.9.4."},
+		{ID: "loc", Content: "PR locator: compose file split landed in PR #405. Reference only."},
+	}
+	got := Prefilter(in)
+	if len(got) != len(in) {
+		dropped := map[string]bool{}
+		for _, m := range got {
+			dropped[m.ID] = true
+		}
+		for _, m := range in {
+			if !dropped[m.ID] {
+				t.Errorf("prefilter dropped resolved-evidence memory %s: %q", m.ID, m.Content)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Two follow-ups from the eval-cycle findings, stacked on one branch:

## 1. Resolve prefilter recall — closes #336
- Prefilter gains high-precision concluded-work phrases (`cost estimate`, `postmortem`, `changelog:`, `investigation note`, `pr locator`, `reference only`, `history only`, `no follow-up`, `completed`)
- Classifier prompt RESOLVED examples mirror the observed miss shapes
- **Measured** (eval/cycle, deepseek-v4-flash): resolve R 0.42–0.67 → **0.92** at P=1.00

## 2. Reflect guarded-drop guard — #337
- `AuditGuardedDrops` (internal/reflection): gotcha/dependency/preference/convention inputs with no survivor in the consolidation output are flagged, using **containment** (input tokens found in one survivor, ≥0.45) — lenient by design since this can block an apply; outright deletions land far below the threshold
- `ghost reflect`: dry-run reports guarded drops; `--apply` **refuses to write** unless `--allow-drops`
- Reflection prompt gains the matching hard rule (fold substance into a survivor, never drop)
- eval/cycle passes `--allow-drops`: in scratch, deletions are grader data

## Test plan
- [x] New tests: prefilter phrasings, AuditGuardedDrops ×3 (deletion flagged / merged rewrite recognized / unguarded ignored)
- [x] Full suite + vet + golangci-lint clean
- [x] Judged eval-cycle run on branch: resolve R=0.92 P=1.00


Closes #336
Closes #337
