### PR TITLE
feat(hostevent): codex-rollout transcript scanner — enables codex save-nudge

### DIFF
--- a/docs/superpowers/specs/2026-08-23-normalized-host-contract-design.md
+++ b/docs/superpowers/specs/2026-08-23-normalized-host-contract-design.md
@@ -321,6 +321,13 @@ Honest constraints, stated up front:
   dialect fields always win; argv agreement still enforced), so hooks invoke
   `<ghost> hook <event> --source goose` directly — no shim scripts,
   cross-platform by construction.
+- **`codex-rollout` scanner registered** (follow-up): Parse completes codex
+  envelopes to `codex-rollout`, and the scanner counts function_call /
+  local_shell_call items in `~/.codex/sessions/**.jsonl`. Ghost save detection
+  is separator-agnostic — codex flattens namespaced tools as namespace+name and
+  MCP namespaces take the `mcp__<server>` form, so both
+  `mcp__ghost`+`ghost_memory_save` and legacy flat forms match on substring.
+  Codex stops now get the full save-nudge treatment.
 - Nudge stays log-only for opencode; document it.
 
 ### Phase 3 — distribution polish

--- a/internal/hostevent/hostevent_test.go
+++ b/internal/hostevent/hostevent_test.go
@@ -130,8 +130,8 @@ func TestParseStrict(t *testing.T) {
 		if p.HostSource() != SourceCodex || p.Event() != EventStop {
 			t.Errorf("routing wrong: %+v", p)
 		}
-		// codex has no v1 scanner mapping yet, so completion starts at none.
-		if p.Contract.Version != ContractVersion || p.Contract.TranscriptFormat != FormatNone {
+		// codex completion points at its rollout scanner.
+		if p.Contract.Version != ContractVersion || p.Contract.TranscriptFormat != FormatCodexRollout {
 			t.Errorf("completed envelope wrong: %+v", p.Contract)
 		}
 	})
@@ -183,7 +183,7 @@ func TestParseStrict(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parse: %v", err)
 		}
-		if p.Contract.Version != ContractVersion || p.Contract.TranscriptFormat != FormatNone {
+		if p.Contract.Version != ContractVersion || p.Contract.TranscriptFormat != FormatCodexRollout {
 			t.Errorf("completed envelope wrong: %+v", p.Contract)
 		}
 	})

--- a/internal/hostevent/parse.go
+++ b/internal/hostevent/parse.go
@@ -89,10 +89,14 @@ func Parse(data []byte, eventArg, sourceArg string) (Payload, error) {
 // dialect, used only when argv completes an absent envelope. Sources without a
 // v1 scanner mapping start at "none" until their adapter lands.
 func defaultFormatFor(source Source) string {
-	if source == SourceClaudeCode {
+	switch source {
+	case SourceClaudeCode:
 		return FormatClaudeJSONL
+	case SourceCodex:
+		return FormatCodexRollout
+	default:
+		return FormatNone
 	}
-	return FormatNone
 }
 
 // gooseNativeFields mirrors the native payload fields goose actually sends,

--- a/internal/hostevent/scanner.go
+++ b/internal/hostevent/scanner.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"io"
+	"strings"
 )
 
 // Transcript formats known to the contract. The scanner registry is keyed by
@@ -35,6 +36,7 @@ type ScanFunc func(io.Reader) (ScanResult, error)
 var scanners = map[string]ScanFunc{
 	FormatClaudeJSONL:      ScanClaudeJSONL,
 	FormatOpencodeMessages: ScanOpencodeMessages,
+	FormatCodexRollout:     ScanCodexRollout,
 }
 
 // Scan runs the scanner registered for format. ok is false when no scanner is
@@ -103,6 +105,57 @@ func ScanClaudeJSONL(r io.Reader) (ScanResult, error) {
 					res.GhostSaves++
 				}
 			}
+		}
+	})
+	return res, err
+}
+
+// codexRolloutLine is the minimal shape of one codex rollout JSONL record
+// (openai/codex, codex-rs/rollout): a timestamped envelope whose type selects
+// the payload — only "response_item" lines carry model traffic; everything
+// else (session_meta, event_msg, turn_context, …) is skipped.
+type codexRolloutLine struct {
+	Type    string `json:"type"`
+	Payload struct {
+		Type      string  `json:"type"`
+		Name      string  `json:"name"`
+		Namespace *string `json:"namespace"`
+	} `json:"payload"`
+}
+
+// ScanCodexRollout streams a codex rollout transcript and counts tool calls
+// (function_call items plus local_shell_call items — codex's shell is not a
+// function call), plus how many were Ghost save tools. Ghost save detection
+// is separator-agnostic: codex flattens namespaced tools as namespace+name
+// with no separator (flat_tool_name in codex-rs/core/src/tools), and MCP
+// namespaces take the mcp__<server> form — so "mcp__ghost"+"ghost_memory_save"
+// and a legacy flat "ghost_memory_save" both match on substring, while a
+// different server's identically-named tool cannot (its namespace lacks
+// "ghost"). Unparseable lines are skipped; errors mid-file are returned with
+// partial counts, same fail-open posture as the other scanners.
+func ScanCodexRollout(r io.Reader) (ScanResult, error) {
+	var res ScanResult
+	err := streamJSONL(r, func(line []byte) {
+		var l codexRolloutLine
+		if err := json.Unmarshal(line, &l); err != nil {
+			return
+		}
+		if l.Type != "response_item" {
+			return
+		}
+		switch l.Payload.Type {
+		case "function_call":
+			res.ToolCalls++
+			flat := ""
+			if l.Payload.Namespace != nil {
+				flat = *l.Payload.Namespace
+			}
+			flat += l.Payload.Name
+			if strings.Contains(flat, "ghost_memory_save") || strings.Contains(flat, "ghost_save_global") {
+				res.GhostSaves++
+			}
+		case "local_shell_call":
+			res.ToolCalls++
 		}
 	})
 	return res, err

--- a/internal/hostevent/scanner.go
+++ b/internal/hostevent/scanner.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"io"
-	"strings"
 )
 
 // Transcript formats known to the contract. The scanner registry is keyed by
@@ -123,16 +122,28 @@ type codexRolloutLine struct {
 	} `json:"payload"`
 }
 
+// codexGhostSaveIdentities are the flattened tool identities (namespace+name;
+// codex's concatenation has no separator) that count as Ghost saves:
+//   - legacy/flat: bare "ghost_memory_save" / "ghost_save_global" with no
+//     namespace
+//   - namespaced: MCP server "ghost" (namespace "mcp__ghost") exposing those
+//     same tool names
+//
+// Exact-match only — a different server shipping an identically-named tool
+// (e.g. namespace "mcp__other", name "ghost_memory_save") must not read as a
+// Ghost save, or codex stops would skip the nudge when nothing was saved.
+var codexGhostSaveIdentities = map[string]bool{
+	"ghost_memory_save":           true,
+	"ghost_save_global":           true,
+	"mcp__ghostghost_memory_save": true,
+	"mcp__ghostghost_save_global": true,
+}
+
 // ScanCodexRollout streams a codex rollout transcript and counts tool calls
 // (function_call items plus local_shell_call items — codex's shell is not a
-// function call), plus how many were Ghost save tools. Ghost save detection
-// is separator-agnostic: codex flattens namespaced tools as namespace+name
-// with no separator (flat_tool_name in codex-rs/core/src/tools), and MCP
-// namespaces take the mcp__<server> form — so "mcp__ghost"+"ghost_memory_save"
-// and a legacy flat "ghost_memory_save" both match on substring, while a
-// different server's identically-named tool cannot (its namespace lacks
-// "ghost"). Unparseable lines are skipped; errors mid-file are returned with
-// partial counts, same fail-open posture as the other scanners.
+// function call), plus how many were Ghost save tools per
+// codexGhostSaveIdentities. Unparseable lines are skipped; errors mid-file are
+// returned with partial counts, same fail-open posture as the other scanners.
 func ScanCodexRollout(r io.Reader) (ScanResult, error) {
 	var res ScanResult
 	err := streamJSONL(r, func(line []byte) {
@@ -151,7 +162,7 @@ func ScanCodexRollout(r io.Reader) (ScanResult, error) {
 				flat = *l.Payload.Namespace
 			}
 			flat += l.Payload.Name
-			if strings.Contains(flat, "ghost_memory_save") || strings.Contains(flat, "ghost_save_global") {
+			if codexGhostSaveIdentities[flat] {
 				res.GhostSaves++
 			}
 		case "local_shell_call":

--- a/internal/hostevent/scanner_test.go
+++ b/internal/hostevent/scanner_test.go
@@ -148,6 +148,7 @@ func TestScanCodexRollout(t *testing.T) {
 		{"namespaced save counts", []string{cxShell, cxSaveNS}, 2, 1},
 		{"legacy flat save counts", []string{cxShell, cxSaveFlat}, 2, 1},
 		{"another server's tool is not a save", []string{cxShell, cxOtherMCP}, 2, 0},
+		{"identically-named tool on another server is not a save", []string{cxShell, `{"timestamp":"t","type":"response_item","payload":{"type":"function_call","name":"ghost_memory_save","namespace":"mcp__other","arguments":"{}","call_id":"c9"}}`}, 2, 0},
 		{"non-response lines skipped", []string{cxMeta, cxShell, cxEventMsg}, 1, 0},
 		{"garbage skipped", []string{"not json", cxShell, "{{{"}, 1, 0},
 	}

--- a/internal/hostevent/scanner_test.go
+++ b/internal/hostevent/scanner_test.go
@@ -112,13 +112,73 @@ func TestScanRegistry(t *testing.T) {
 		t.Errorf("Scan(opencode-messages) = %+v,%v,%v want 1 tool call", res, ok, err)
 	}
 
-	// Formats whose adapters have not landed stay unregistered — callers fail
-	// open; scanning is selected by format and never falls back by source.
-	if _, ok, err := Scan(FormatCodexRollout, strings.NewReader(lineToolBash)); ok || err != nil {
-		t.Error("Scan(codex-rollout) should be unregistered until the codex adapter lands")
+	res, ok, err = Scan(FormatCodexRollout, strings.NewReader(`{"timestamp":"t","type":"response_item","payload":{"type":"function_call","name":"shell"}}`))
+	if !ok || err != nil || res.ToolCalls != 1 {
+		t.Errorf("Scan(codex-rollout) = %+v,%v,%v want 1 tool call", res, ok, err)
 	}
+
+	// Unknown formats stay unregistered — callers fail open; scanning is
+	// selected by format and never falls back by source.
 	if _, ok, err := Scan("", strings.NewReader(lineToolBash)); ok || err != nil {
 		t.Error(`Scan("") should be unregistered`)
+	}
+}
+
+// codex-rollout fixtures: timestamped envelopes whose payload carries the
+// Responses-API items (function_call with optional mcp__<server> namespace,
+// local_shell_call for the built-in shell).
+const (
+	cxMeta     = `{"timestamp":"t0","type":"session_meta","payload":{"id":"s"}}`
+	cxMsg      = `{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"ghost_memory_save in prose does not count"}]}}`
+	cxShell    = `{"timestamp":"t2","type":"response_item","payload":{"type":"local_shell_call","call_id":"c1","status":"completed","action":{"command":["ls"]}}}`
+	cxSaveNS   = `{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"ghost_memory_save","namespace":"mcp__ghost","arguments":"{}","call_id":"c2"}}`
+	cxSaveFlat = `{"timestamp":"t4","type":"response_item","payload":{"type":"function_call","name":"ghost_save_global","arguments":"{}","call_id":"c3"}}`
+	cxOtherMCP = `{"timestamp":"t5","type":"response_item","payload":{"type":"function_call","name":"search","namespace":"mcp__other","arguments":"{}","call_id":"c4"}}`
+	cxEventMsg = `{"timestamp":"t6","type":"event_msg","payload":{"type":"token_count"}}`
+)
+
+func TestScanCodexRollout(t *testing.T) {
+	cases := []struct {
+		name          string
+		lines         []string
+		wantToolCalls int
+		wantSaves     int
+	}{
+		{"shell counts as a tool call", []string{cxMeta, cxShell}, 1, 0},
+		{"namespaced save counts", []string{cxShell, cxSaveNS}, 2, 1},
+		{"legacy flat save counts", []string{cxShell, cxSaveFlat}, 2, 1},
+		{"another server's tool is not a save", []string{cxShell, cxOtherMCP}, 2, 0},
+		{"non-response lines skipped", []string{cxMeta, cxShell, cxEventMsg}, 1, 0},
+		{"garbage skipped", []string{"not json", cxShell, "{{{"}, 1, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ScanCodexRollout(strings.NewReader(strings.Join(tc.lines, "\n") + "\n"))
+			if err != nil {
+				t.Fatalf("ScanCodexRollout: %v", err)
+			}
+			if got.ToolCalls != tc.wantToolCalls || got.GhostSaves != tc.wantSaves {
+				t.Errorf("= %+v, want calls=%d saves=%d", got, tc.wantToolCalls, tc.wantSaves)
+			}
+		})
+	}
+}
+
+// TestScanCodexRollout_GoldenFixture pins the scanner against a realistic
+// full-fidelity rollout (meta + event noise, shell + MCP function calls,
+// non-JSON junk).
+func TestScanCodexRollout_GoldenFixture(t *testing.T) {
+	f, err := os.Open(filepath.Join("testdata", "codex-rollout", "session.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close() //nolint:errcheck
+	got, err := ScanCodexRollout(f)
+	if err != nil {
+		t.Fatalf("ScanCodexRollout: %v", err)
+	}
+	if got.ToolCalls != 4 || got.GhostSaves != 1 {
+		t.Errorf("golden fixture = %+v, want toolCalls=4 saves=1", got)
 	}
 }
 

--- a/internal/hostevent/testdata/codex-rollout/session.jsonl
+++ b/internal/hostevent/testdata/codex-rollout/session.jsonl
@@ -1,0 +1,10 @@
+{"timestamp":"2026-08-24T09:00:00.000Z","type":"session_meta","payload":{"id":"sess_cx1","timestamp":1756000000000,"cwd":"/repo","originator":"codex_cli_rs","cli_version":"0.149.1"}}
+{"timestamp":"2026-08-24T09:00:05.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"list files and save what you learn"}]}}
+this line is not json and must be skipped
+{"timestamp":"2026-08-24T09:00:06.000Z","type":"event_msg","payload":{"type":"token_count","info":{}}}
+{"timestamp":"2026-08-24T09:00:07.000Z","type":"response_item","payload":{"type":"reasoning","summary":[{"type":"summary_text","text":"thinking"}]}}
+{"timestamp":"2026-08-24T09:00:08.000Z","type":"response_item","payload":{"type":"local_shell_call","call_id":"call_a","status":"completed","action":{"command":["ls","internal/"]}}}
+{"timestamp":"2026-08-24T09:00:09.000Z","type":"response_item","payload":{"type":"function_call","name":"read_file","arguments":"{\"path\":\"README.md\"}","call_id":"call_b"}}
+{"timestamp":"2026-08-24T09:00:10.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_b","output":"content"}}
+{"timestamp":"2026-08-24T09:00:11.000Z","type":"response_item","payload":{"type":"function_call","name":"ghost_memory_save","namespace":"mcp__ghost","arguments":"{\"content\":\"config loader lives in internal/config\"}","call_id":"call_c"}}
+{"timestamp":"2026-08-24T09:00:12.000Z","type":"response_item","payload":{"type":"local_shell_call","call_id":"call_d","status":"timeout","action":{"command":["sleep","999"]},"output":"timed out"}}


### PR DESCRIPTION
Follow-up to the Phase 2 adapters: **codex stops now get the full save-nudge.**

- `ScanCodexRollout` parses codex rollout JSONL (timestamped envelopes; only `response_item` payloads carry model traffic) and counts `function_call` + `local_shell_call` items
- Ghost-save detection is separator-agnostic over codex's flattened tool identity (`namespace+name`, MCP namespaces take `mcp__<server>`): both `mcp__ghost`+`ghost_memory_save` and legacy flat forms match; other servers cannot collide
- `Parse` completes absent codex envelopes to `codex-rollout` instead of `none`
- Golden fixture pins meta/event noise, errored shells, cross-server non-collisions, junk lines

Shapes verified against openai/codex source: `rollout/src/lib.rs` (`decode_rollout_line`), `protocol/src/models.rs` (`ResponseItem::FunctionCall`, optional `namespace`, test fixture `"namespace": "mcp__codex_apps__gmail"`), `tools/mod.rs` (`flat_tool_name` concatenates namespace+name), plus recorder test fixtures.

@coderabbitai review