### PR TITLE
feat(opencode): publishable npm package for the opencode plugin (Phase 3)

### DIFF
--- a/plugin/ghost-opencode/.gitignore
+++ b/plugin/ghost-opencode/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.tgz

--- a/plugin/ghost-opencode/README.md
+++ b/plugin/ghost-opencode/README.md
@@ -1,0 +1,39 @@
+# ghost-opencode
+
+[opencode](https://opencode.ai) plugin for [Ghost](https://github.com/wcatz/ghost), the MCP memory server. One npm package is the entire integration:
+
+- **MCP self-registration** — the plugin's typed `config(cfg)` hook adds the ghost stdio MCP server to the SDK config directly. No `opencode.json[mcp]` edit needed.
+- **Lifecycle bridge** — on `session.status` → idle (falling back to legacy `session.idle`), it materializes the session transcript as temp JSONL and spawns `ghost hook stop --source opencode`, driving reflection, resolve, and supersede after each turn.
+
+Everything fails open: any error logs one line via `client.app.log` and never disturbs the session.
+
+## Prerequisites
+
+The `ghost` binary must be resolvable: on `PATH`, or set `GHOST_BIN` to an absolute path for hermetic setups. Install ghost separately (`go install github.com/wcatz/ghost/cmd/ghost@latest` or grab a release).
+
+## Install
+
+Add the package to your opencode config:
+
+```jsonc
+// ~/.config/opencode/opencode.json
+{
+  "plugin": ["ghost-opencode"]
+}
+```
+
+## npm vs local-file variant
+
+`ghost mcp init --client opencode` installs a *local-file* copy of this same plugin to `~/.config/opencode/plugins/ghost-opencode.ts`, managed and drift-checked by ghost itself.
+
+| | npm (`"plugin": ["ghost-opencode"]`) | local-file (`ghost mcp init --client opencode`) |
+| --- | --- | --- |
+| Updates | Independent of ghost releases — bump via npm whenever the plugin changes | Re-run `ghost mcp init`; always matches your installed ghost binary |
+| Network | Requires npm/Bun install | Zero-network; file written locally |
+| Management | You own the dependency entry | `ghost mcp status --client opencode` verifies it byte-for-byte |
+
+Pick npm if you want plugin updates decoupled from ghost releases; pick local-file if you prefer zero-network installs kept in lockstep with your ghost binary.
+
+## Limitations
+
+opencode cannot block stops or inject context, so save nudges degrade to log lines instead of prompts. Memory capture, reflection, and resolution all still run.

--- a/plugin/ghost-opencode/index.ts
+++ b/plugin/ghost-opencode/index.ts
@@ -1,0 +1,144 @@
+// ghost-opencode v1 — opencode lifecycle adapter for Ghost
+// (https://github.com/wcatz/ghost). npm distribution: add "ghost-opencode" to
+// your opencode.json `plugin` array. (The other channel — a locally managed
+// copy installed and auto-repaired by `ghost mcp init --client opencode` —
+// carries the same logic.)
+//
+// Bridges opencode's idle transition to the ghost host-event contract:
+//
+//	ghost hook stop --source opencode
+//
+// with the transcript materialized as temp JSONL in the `opencode-messages`
+// format ({info, parts} per line, verbatim client.session.messages
+// serialization). Ghost scans it for save-tool usage. opencode cannot block
+// stops or inject context, so any ghost nudge degrades to a log line there —
+// fail-open is absolute: every error logs one line and never disturbs the
+// session.
+import type { Plugin } from "@opencode-ai/plugin"
+import { spawn } from "node:child_process"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const CONTRACT_VERSION = 1
+
+// The ghost binary must be findable at spawn time: GHOST_BIN overrides for
+// hermetic setups; otherwise PATH lookup of `ghost` is used (npm installs of
+// this plugin are decoupled from how/where ghost itself was installed).
+const GHOST_BIN = process.env.GHOST_BIN ?? "ghost"
+
+// Once a modern session.status event has been observed, legacy session.idle
+// events are ignored — versions emitting both would otherwise double-fire.
+let sawStatusEvent = false
+
+// Idle transitions can repeat in quick succession (status + legacy idle, or
+// rapid turns); one stop hook per session per window is enough. The map is
+// FIFO-bounded: long-lived hosts (desktop apps) would otherwise grow one
+// entry per session forever. JS Maps iterate in insertion order, so the
+// oldest entry is evicted.
+const lastFire = new Map<string, number>()
+const DEBOUNCE_MS = 2000
+const MAX_TRACKED_SESSIONS = 256
+
+export const GhostPlugin: Plugin = async ({ client, directory }) => {
+	const log = async (level: "info" | "warn" | "error", message: string) => {
+		try {
+			await client.app.log({ body: { service: "ghost-opencode", level, message } })
+		} catch {
+			// Logging is best-effort; never let it mask the real outcome.
+		}
+	}
+
+	const fireStopHook = async (sessionID: string) => {
+		if (!sessionID) return
+		const now = Date.now()
+		if (now - (lastFire.get(sessionID) ?? 0) < DEBOUNCE_MS) return
+		lastFire.set(sessionID, now)
+		if (lastFire.size > MAX_TRACKED_SESSIONS) {
+			const oldest = lastFire.keys().next().value
+			if (oldest !== undefined) lastFire.delete(oldest)
+		}
+
+		let transcriptPath = ""
+		try {
+			const res = await client.session.messages({ path: { id: sessionID } })
+			if (res.error) throw res.error
+			if (Array.isArray(res.data) && res.data.length > 0) {
+				const dir = await mkdtemp(join(tmpdir(), "ghost-"))
+				transcriptPath = join(dir, "messages.jsonl")
+				const body = res.data.map((m: unknown) => JSON.stringify(m)).join("\n") + "\n"
+				await writeFile(transcriptPath, body)
+			}
+		} catch (e) {
+			await log("warn", `ghost: fail-open (transcript materialization: ${e})`)
+			transcriptPath = ""
+		}
+
+		const payload = {
+			contract: {
+				version: CONTRACT_VERSION,
+				source: "opencode",
+				transcript_format: transcriptPath ? "opencode-messages" : "none",
+			},
+			hook_event_name: "stop",
+			session_id: sessionID,
+			transcript_path: transcriptPath,
+			cwd: directory ?? process.cwd(),
+			stop_hook_active: false,
+		}
+
+		try {
+			const child = spawn(GHOST_BIN, ["hook", "stop", "--source", "opencode"], {
+				stdio: ["pipe", "ignore", "inherit"],
+				detached: true,
+				env: process.env,
+			})
+			child.on("error", async (e) => {
+				await log("warn", `ghost: fail-open (spawn: ${e})`)
+			})
+			// Best-effort local cleanup when we outlive the hook; ghost also
+			// sweeps its ghost-* temp transcript dirs consumer-side, covering
+			// hosts that exit before this handler runs (e.g. `opencode run`).
+			child.on("close", () => {
+				if (transcriptPath) rm(join(transcriptPath, ".."), { recursive: true, force: true }).catch(() => {})
+			})
+			child.stdin.on("error", () => {})
+			child.stdin.end(JSON.stringify(payload))
+			child.unref()
+		} catch (e) {
+			await log("warn", `ghost: fail-open (spawn: ${e})`)
+		}
+	}
+
+	return {
+		// Self-registration: this hook receives the full SDK config, so the
+		// plugin alone brings ghost's MCP tools online — no opencode.json edit
+		// needed. GHOST_BIN overrides PATH lookup of the ghost binary
+		// (hermetic setups); without it `ghost` on PATH is used.
+		config: async (cfg) => {
+			cfg.mcp = cfg.mcp ?? {}
+			cfg.mcp["ghost"] = {
+				type: "local",
+				command: [GHOST_BIN, "mcp"],
+				enabled: true,
+			}
+		},
+		event: async ({ event }) => {
+			try {
+				if (event.type === "session.status") {
+					sawStatusEvent = true
+					const props = event.properties as { sessionID?: string; status?: { type?: string } }
+					if (props?.status?.type !== "idle") return
+					await fireStopHook(props.sessionID ?? "")
+					return
+				}
+				if (event.type === "session.idle" && !sawStatusEvent) {
+					const props = event.properties as { sessionID?: string }
+					await fireStopHook(props?.sessionID ?? "")
+				}
+			} catch (e) {
+				await log("warn", `ghost: fail-open (${e})`)
+			}
+		},
+	}
+}

--- a/plugin/ghost-opencode/package.json
+++ b/plugin/ghost-opencode/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ghost-opencode",
+  "version": "0.1.0",
+  "description": "opencode plugin for Ghost's persistent memory server: self-registers the ghost MCP server and bridges opencode's idle transition to the ghost host-event contract.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wcatz/ghost.git",
+    "directory": "plugin/ghost-opencode"
+  },
+  "main": "./index.ts",
+  "files": [
+    "index.ts"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "opencode",
+    "opencode-plugin",
+    "mcp",
+    "memory",
+    "ghost"
+  ]
+}


### PR DESCRIPTION
The Phase 3 "one npm package" artifact: `plugin/ghost-opencode/`.

- `index.ts` adapted from the go:embed'd plugin with ONE divergence class: binary resolution is PATH-based (`GHOST_BIN ?? "ghost"`) instead of a baked absolute path — npm users install ghost separately, and opencode's own process resolves at spawn time
- Everything else byte-equivalent to the managed local-file variant: session.status preference over legacy idle, FIFO-bounded debounce, fail-open logging, temp-JSONL materialization
- `package.json`: zero runtime deps, `files: ["index.ts"]`, Apache-2.0 matching repo LICENSE
- README documents both channels and when to prefer each (npm = updates decoupled from ghost releases; local-file = offline installs managed/repaired by `ghost mcp init --client opencode`)
- Publish is deliberately NOT wired into release.yml yet — do it manually (`cd plugin/ghost-opencode && npm publish`) or ask me to wire an npm-publish job gated on tags first

@coderabbitai review