### PR TITLE
chore(ci): add PR-Agent repo settings (.pr_agent.toml)

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,15 @@
+# PR-Agent repository settings.
+# Fetched automatically from this default branch by the pr-agent.yml
+# workflow (apply_repo_settings). Runtime plumbing — API key, endpoint,
+# model routing — stays in the workflow's env; anything set in both
+# places keeps the workflow value.
+
+[pr_reviewer]
+# Anchor key issues as inline comments on diff lines instead of
+# listing them only in the summary table (matches the old CodeRabbit
+# comment style more closely).
+inline_key_issues = true
+
+# Upstream caps findings at 3; raise for better coverage on
+# refactors. Reviewer extra_instructions keep style noise out.
+num_max_findings = 5


### PR DESCRIPTION
- `inline_key_issues = true`: key issues anchored as inline comments on diff lines (closer to the old CodeRabbit style)
- `num_max_findings = 5` (upstream default 3)

Key names verified against the-pr-agent/pr-agent v0.43.0 configuration.toml. Runtime plumbing stays in workflow env.