### PR TITLE
fix(mcpinit): surface alternative clients when claude is missing; add --client all

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -148,14 +148,14 @@ func parseMCPClient(args []string) (string, error) {
 		switch {
 		case args[i] == "--client":
 			if i+1 >= len(args) {
-				return "", fmt.Errorf("--client requires a value (claude, opencode, codex, or goose)")
+				return "", fmt.Errorf("--client requires a value (claude, opencode, codex, goose, or all)")
 			}
 			client = args[i+1]
 			i++
 		case strings.HasPrefix(args[i], "--client="):
 			client = strings.TrimPrefix(args[i], "--client=")
 			if client == "" {
-				return "", fmt.Errorf("--client requires a value (claude, opencode, codex, or goose)")
+				return "", fmt.Errorf("--client requires a value (claude, opencode, codex, goose, or all)")
 			}
 		}
 	}

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -148,22 +148,55 @@ func parseMCPClient(args []string) (string, error) {
 		switch {
 		case args[i] == "--client":
 			if i+1 >= len(args) {
-				return "", fmt.Errorf("--client requires a value (claude or opencode)")
+				return "", fmt.Errorf("--client requires a value (claude, opencode, codex, or goose)")
 			}
 			client = args[i+1]
 			i++
 		case strings.HasPrefix(args[i], "--client="):
 			client = strings.TrimPrefix(args[i], "--client=")
 			if client == "" {
-				return "", fmt.Errorf("--client requires a value (claude or opencode)")
+				return "", fmt.Errorf("--client requires a value (claude, opencode, codex, or goose)")
 			}
 		}
 	}
 	return client, nil
 }
 
+// clientTarget pairs a display name with its `mcp init` installer.
+type clientTarget struct {
+	name string
+	run  func(w io.Writer, dryRun bool) error
+}
+
+// mcpInitTargets lists every installable client in run order.
+func mcpInitTargets() []clientTarget {
+	return []clientTarget{
+		{"claude", mcpinit.Run},
+		{"opencode", mcpinit.RunOpencode},
+		{"codex", mcpinit.RunCodex},
+		{"goose", mcpinit.RunGoose},
+	}
+}
+
+// runAllClients installs ghost into every target sequentially, continuing past
+// individual failures so one broken client never blocks the rest. Each target's
+// installer output goes to stdout under a banner; failures go to stderr. Returns
+// the names of failed targets (empty when all succeeded).
+func runAllClients(stdout, stderr io.Writer, dryRun bool, targets []clientTarget) []string {
+	var failed []string
+	for _, t := range targets {
+		_, _ = fmt.Fprintf(stdout, "\n=== %s ===\n", t.name)
+		if err := t.run(stdout, dryRun); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error (%s): %v\n", t.name, err)
+			failed = append(failed, t.name)
+		}
+	}
+	return failed
+}
+
 // runMCPInit configures an MCP client to use Ghost as its memory system.
-// Defaults to Claude Code; --client opencode targets opencode instead.
+// Defaults to Claude Code; --client opencode targets opencode instead; --client
+// all installs into every supported client sequentially.
 func runMCPInit() {
 	client, err := parseMCPClient(os.Args[3:])
 	if err != nil {
@@ -182,6 +215,13 @@ func runMCPInit() {
 	}
 
 	switch client {
+	case "all":
+		failed := runAllClients(os.Stdout, os.Stderr, dryRun, mcpInitTargets())
+		if len(failed) > 0 {
+			fmt.Fprintf(os.Stderr, "\ncompleted with failures: %s\n", strings.Join(failed, ", "))
+			os.Exit(1)
+		}
+		return
 	case "opencode":
 		err = mcpinit.RunOpencode(os.Stdout, dryRun)
 	case "codex":
@@ -191,7 +231,7 @@ func runMCPInit() {
 	case "claude":
 		err = mcpinit.Run(os.Stdout, dryRun)
 	default:
-		fmt.Fprintf(os.Stderr, "error: unknown client %q (expected claude, opencode, codex, or goose)\n", client)
+		fmt.Fprintf(os.Stderr, "error: unknown client %q (expected claude, opencode, codex, goose, or all)\n", client)
 		os.Exit(1)
 	}
 	if err != nil {
@@ -1186,8 +1226,8 @@ Usage:
 
 Commands:
   mcp                         Start MCP server on stdio (used by Claude Code)
-  mcp init [--client claude|opencode] [--dry-run]  Configure MCP client integration
-  mcp status [--client claude|opencode]            Check MCP client integration health
+  mcp init [--client claude|opencode|codex|goose|all] [--dry-run]  Configure MCP client integration
+  mcp status [--client claude|opencode|codex|goose]                Check MCP client integration health
   reflect <project> [flags]   Memory consolidation (dry-run by default, --apply to save)
   supersede <project> [flags] Link superseded memories (dry-run by default, --apply to write)
   resolve <project> [flags]   Mark resolved evidence memories (dry-run by default, --apply to write)

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/url"
@@ -410,4 +411,75 @@ func TestBuildClassifyProvider_KeySetBuildsRegardless(t *testing.T) {
 	if err != nil || p == nil {
 		t.Fatalf("build: p=%v err=%v", p, err)
 	}
+}
+
+// TestRunAllClients verifies the `--client all` orchestration: banners in run
+// order, continue past individual failures, per-failure stderr lines, and the
+// failed-names return that drives the exit code.
+func TestRunAllClients(t *testing.T) {
+	t.Run("continues past failures and reports them", func(t *testing.T) {
+		targets := []clientTarget{
+			{"ok-first", func(w io.Writer, dryRun bool) error { return nil }},
+			{"boom", func(w io.Writer, dryRun bool) error { return fmt.Errorf("kaput") }},
+			{"ok-last", func(w io.Writer, dryRun bool) error { return nil }},
+			{"boom2", func(w io.Writer, dryRun bool) error { return fmt.Errorf("kaput too") }},
+		}
+		var stdout, stderr bytes.Buffer
+		failed := runAllClients(&stdout, &stderr, false, targets)
+		if len(failed) != 2 || failed[0] != "boom" || failed[1] != "boom2" {
+			t.Fatalf("failed = %v, want [boom boom2]", failed)
+		}
+		for _, want := range []string{"error (boom): kaput", "error (boom2): kaput too"} {
+			if !strings.Contains(stderr.String(), want) {
+				t.Errorf("stderr missing %q, got:\n%s", want, stderr.String())
+			}
+		}
+		out := stdout.String()
+		firstOK, boomOK, lastOK := strings.Index(out, "=== ok-first ==="), strings.Index(out, "=== boom ==="), strings.Index(out, "=== ok-last ===")
+		if firstOK < 0 || boomOK < 0 || lastOK < 0 {
+			t.Fatalf("stdout missing a banner, got:\n%s", out)
+		}
+		if !(firstOK < boomOK && boomOK < lastOK) {
+			t.Errorf("targets must run in order and failures must not stop the loop, got:\n%s", out)
+		}
+	})
+	t.Run("all succeed returns empty", func(t *testing.T) {
+		targets := []clientTarget{
+			{"a", func(w io.Writer, dryRun bool) error { return nil }},
+			{"b", func(w io.Writer, dryRun bool) error { return nil }},
+		}
+		var stdout, stderr bytes.Buffer
+		if failed := runAllClients(&stdout, &stderr, true, targets); len(failed) != 0 {
+			t.Fatalf("failed = %v, want empty", failed)
+		}
+		if stderr.Len() != 0 {
+			t.Errorf("stderr should stay clean when nothing fails, got:\n%s", stderr.String())
+		}
+	})
+}
+
+// TestMCPInitTargets_CoverAllClients guards the target list against accidental
+// drift: every supported client installer appears exactly once, in order.
+func TestMCPInitTargets_CoverAllClients(t *testing.T) {
+	want := []string{"claude", "opencode", "codex", "goose"}
+	targets := mcpInitTargets()
+	if len(targets) != len(want) {
+		t.Fatalf("got %d targets (%v), want %d", len(targets), targetNames(targets), len(want))
+	}
+	for i, name := range want {
+		if targets[i].name != name {
+			t.Errorf("targets[%d] = %q, want %q", i, targets[i].name, name)
+		}
+		if targets[i].run == nil {
+			t.Errorf("target %q has no installer", name)
+		}
+	}
+}
+
+func targetNames(targets []clientTarget) []string {
+	names := make([]string, len(targets))
+	for i, t := range targets {
+		names[i] = t.name
+	}
+	return names
 }

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -439,7 +439,7 @@ func TestRunAllClients(t *testing.T) {
 		if firstOK < 0 || boomOK < 0 || lastOK < 0 {
 			t.Fatalf("stdout missing a banner, got:\n%s", out)
 		}
-		if !(firstOK < boomOK && boomOK < lastOK) {
+		if firstOK >= boomOK || boomOK >= lastOK {
 			t.Errorf("targets must run in order and failures must not stop the loop, got:\n%s", out)
 		}
 	})

--- a/internal/mcpinit/init.go
+++ b/internal/mcpinit/init.go
@@ -24,11 +24,14 @@ func Run(w io.Writer, dryRun bool) error {
 		_, _ = fmt.Fprintf(w, "\nDry run — showing what would change:\n\n")
 	}
 
-	// Step 1: Prerequisites.
+	// Step 1: Prerequisites. No retryHint here: a missing binary is an
+	// install-first problem that re-running init cannot fix, and the
+	// claude-missing error carries its own next-step guidance (alternative
+	// clients) that the generic re-run hint would bury.
 	_, _ = fmt.Fprintln(w, "[1/9] Checking prerequisites...")
 	ghostBin, claudeBin, err := checkPrereqs(w, "claude")
 	if err != nil {
-		return retryHint(err)
+		return err
 	}
 
 	// Step 2: Config file.
@@ -143,7 +146,8 @@ func checkPrereqs(w io.Writer, client string) (ghostBin, claudeBin string, err e
 	if client == "claude" {
 		claudeBin = findBinary("claude")
 		if claudeBin == "" {
-			return "", "", fmt.Errorf("claude CLI not found in PATH — install Claude Code first")
+			return "", "", fmt.Errorf("claude CLI not found in PATH — install Claude Code first\n" +
+				"  Or configure a different MCP client: ghost mcp init --client opencode|codex|goose|all")
 		}
 		_, _ = fmt.Fprintf(w, "  ✓ claude CLI at %s\n", claudeBin)
 	}

--- a/internal/mcpinit/opencode_test.go
+++ b/internal/mcpinit/opencode_test.go
@@ -265,8 +265,19 @@ func TestCheckPrereqs_ClaudeMissing(t *testing.T) {
 	t.Setenv("PATH", binDir)
 
 	var out bytes.Buffer
-	if _, _, err := checkPrereqs(&out, "claude"); err == nil {
+	_, _, err := checkPrereqs(&out, "claude")
+	if err == nil {
 		t.Error("expected error when claude is missing from PATH and common dirs")
+	} else {
+		// The dead-end guard: the error must point at the other clients and
+		// must not suggest re-running init, which can never succeed here.
+		msg := err.Error()
+		if !strings.Contains(msg, "--client opencode") {
+			t.Errorf("claude-missing error should list alternative clients, got: %q", msg)
+		}
+		if strings.Contains(msg, "Re-run") {
+			t.Errorf("claude-missing error should not carry the circular re-run hint, got: %q", msg)
+		}
 	}
 	if _, _, err := checkPrereqs(&out, "opencode"); err != nil {
 		t.Errorf("opencode target should require only ghost: %v", err)


### PR DESCRIPTION
## Problem

Bare `ghost mcp init` hard-defaults to the claude target, so on a machine without Claude Code it dies at step [1/9] with "claude CLI not found in PATH" plus a circular "Re-run `ghost mcp init` to retry" hint that never mentions the other supported clients.

## Changes

- fix: when the claude CLI is missing, the error now points at `ghost mcp init --client opencode|codex|goose|all`; prerequisite failures no longer carry the circular re-run hint (internal/mcpinit/init.go)
- feat: `ghost mcp init --client all` runs the claude, opencode, codex, and goose installers sequentially under per-client banners, continues past individual failures, prints a failed-target summary, and exits 1 if any leg failed (cmd/ghost/main.go)
- docs: usage text and --client parse errors list all supported clients

`mcp status` is intentionally unchanged.

## Validation

- `go vet ./...`, `go test ./...`, gofmt clean
- New tests: TestRunAllClients (run order, continue-on-failure, stderr lines), TestMCPInitTargets_CoverAllClients; TestCheckPrereqs_ClaudeMissing extended to assert the alternatives line is present and the re-run hint absent
- Live sim on a ghost-only fake $HOME: bare init prints the new message, exit 1; `--client all` fails only the claude leg, completes opencode/codex/goose legs, exits 1 with summary
- Fully provisioned machine: `ghost mcp init --client all --dry-run` runs all four sections, exit 0, no writes

## Not validated

- Non-dry-run install on a real multi-client machine end-to-end (installer internals are covered by their existing per-client tests)