### PR TITLE
ci: parallelize checks, add concurrency groups, raise PR-Agent cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,24 @@ on:
   pull_request:
     branches: [main]
 
+# Rapid successive pushes replace the pending run instead of queueing
+# duplicates behind it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
-  build-and-test:
+  # Fast-feedback leg: everything that fails in seconds, in parallel with
+  # build-and-test instead of ahead of it.
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
+          # --new-from-rev=origin/main needs main's tip in the local history.
           fetch-depth: 0
 
       - uses: actions/setup-go@v7
@@ -40,6 +49,18 @@ jobs:
         # Pinned for the same reproducibility reason as golangci-lint above —
         # 'latest' can change scan behavior without a repository change.
         run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
+
+  # Heavy leg: race-instrumented compile dominates wall time, so it runs
+  # concurrently with lint. The job name is a required branch-protection
+  # context — do not rename casually.
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
 
       - name: Test
         run: go test -race -count=1 ./...

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -11,6 +11,13 @@ permissions:
   issues: write
   pull-requests: write
 
+# One agent run per PR at a time: a duplicate trigger (e.g. the same /review
+# comment delivered twice by a client retry) replaces the in-flight run
+# instead of racing it and burning double quota.
+concurrency:
+  group: pr-agent-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   config:
     # Same-repo / trust resolution before the agent job (which holds
@@ -54,7 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     # Hard cap: litellm's ai_timeout does not bound a hung streamed call —
     # observed 651s before the upstream 500 came back. Kill at the runner.
-    timeout-minutes: 8
+    # 90s per LLM call x several sequential calls can legitimately exceed
+    # 8 minutes (a full review died at exactly 8m24s), so allow 10.
+    timeout-minutes: 10
     steps:
       - name: PR Agent action step
         id: pragent


### PR DESCRIPTION
## Changes

- Split the single sequential `ci` job into two parallel legs: `lint` (mod tidy, vet, golangci-lint, govulncheck — everything that fails in seconds) and `build-and-test` (`go test -race` + build, the dominant cost). Wall time drops from the sum of all steps (~2-2.5 min) to roughly the slowest single leg.
- `concurrency` groups on both ci.yml and pr-agent.yml cancel superseded runs on rapid pushes; pr-agent's group is per-PR, so duplicate `/review` triggers (observed today via a client retry posting the same comment twice) replace the in-flight run instead of racing it.
- PR-Agent runner cap 8 -> 10 minutes: a full multi-call review died at exactly 8m24s under the old cap.
- `build-and-test` keeps its name deliberately — it is an existing required protection context; `lint` is added to required contexts alongside it.

## Validation

- YAML parses clean
- This PR exercises the new parallel structure itself (pull_request workflows read from the merge ref)
- Branch protection updated to require `[build-and-test, lint, Analyze (go), github-advanced-security]`

## Not validated

- Actual wall-time improvement until this run completes (measured in checks below)