### PR TITLE
feat(ci): trigger PR-Agent on synchronize pushes

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -2,7 +2,10 @@ name: PR Agent
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    # synchronize keeps the pr_agent_job check run current on every push —
+    # it is (or will be) a required branch-protection context, and a stale
+    # context on a new head SHA blocks merge with "Expected" forever.
+    types: [opened, reopened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
Keeps the pr_agent_job check run attached to every head SHA so it can become a required branch-protection context without stranding PRs in Expected-check limbo (cf. #362's lint hang). No behavior change to review content; pr_actions still governs what the agent actually does per event.