### PR TITLE
fix(ci): PR gate exits clean on agent runs without an associated PR

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -54,7 +54,16 @@ jobs:
           NUMBER="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")"
           if [ -z "$NUMBER" ]; then
             HEAD_SHA="$(jq -r '.workflow_run.head_sha' "$GITHUB_EVENT_PATH")"
-            NUMBER="$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls" --jq '.[0].number')"
+            NUMBER="$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls" --jq '.[0].number // empty')"
+          fi
+          # Agent runs fired from PR comments execute in default-branch
+          # context with no associated PR — there is nothing to gate.
+          # Exit clean; a required check must never fail on an unmappable
+          # run, and skipping via job-level `if` would count as success
+          # anyway.
+          if [ -z "$NUMBER" ] || [ "$NUMBER" = "null" ]; then
+            echo "No PR associated with this run (default-branch context); nothing to gate."
+            exit 0
           fi
           echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
### **User description**
Agent runs fired from PR comments execute in default-branch context; the chained workflow_run gate found no PR number and crashed. Now exits clean — required checks must never fail on unmappable runs, and a job-level skip would count as success anyway.


___

### **PR Type**
Bug fix


___

### **Description**
- Handle agent runs with no associated PR

- Make `gh api` jq fallback return empty

- Exit clean instead of failing gate


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["workflow_run / issue_comment event"] --> B["Resolve PR number"]
  B --> C{"PR found?"}
  C -- "yes" --> D["Evaluate findings"]
  C -- "no / null" --> E["Log message and exit 0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-gate.yml</strong><dd><code>Make PR gate exit cleanly on unmappable runs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-gate.yml

<ul><li>Append <code>// empty</code> to jq query in <code>gh api</code> call so missing PR resolves to <br>an empty string<br> <li> Add explicit empty/null check for resolved PR number<br> <li> Exit with code 0 and log an explanatory message when the workflow <br>cannot map a run to a PR</ul>


</details>


  </td>
  <td><a href="https://github.com/wcatz/ghost/pull/368/files#diff-5a90fe7db9ab3037e8d300c0f46fca67675e1e156c6a5ec8c7e6656b9424cce6">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

