### PR TITLE
feat(ci): review loop — auto-resolve + changes-requested signal

### DIFF
--- a/.github/workflows/pr-loop.yml
+++ b/.github/workflows/pr-loop.yml
@@ -1,0 +1,123 @@
+# Closes the review loop after PR-Agent runs.
+#
+# Validated mechanics (wcatz/ci-mech-spike, 2026-08-25):
+#   - GITHUB_TOKEN cannot resolve review threads ("not accessible by
+#     integration") — resolutions use the GH_RESOLVE_TOKEN secret, a
+#     fine-grained PAT with Pull requests: read+write on this repo only.
+#     Without the secret this job degrades to reporting-only.
+#   - Outdated unresolved threads still block merge under required
+#     conversation resolution, so stale agent findings must be swept
+#     once a fresh review has re-judged the new diff.
+#   - GITHUB_TOKEN CAN submit REQUEST_CHANGES reviews; it can never
+#     APPROVE. Signal-only: approvals stay out of branch protection.
+#
+# Triggered by workflow_run after each PR Agent completion and by PR
+# comments for manual re-runs. workflow_run executes in default-branch
+# context — fine here, because nothing in this file is (or may become)
+# a required status check: those attach to the wrong SHA.
+
+name: Review Loop
+
+on:
+  workflow_run:
+    workflows: ["PR Agent"]
+    types: [completed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: review-loop-${{ github.event.workflow_run.pull_requests[0].number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  loop:
+    if: >-
+      github.event_name == 'workflow_run' ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        github.event.sender.type != 'Bot')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Resolve PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          NUMBER="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")"
+          if [ -z "$NUMBER" ]; then
+            HEAD_SHA="$(jq -r '.workflow_run.head_sha' "$GITHUB_EVENT_PATH")"
+            NUMBER="$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls" --jq '.[0].number // empty')"
+          fi
+          if [ -z "$NUMBER" ] || [ "$NUMBER" = "null" ]; then
+            echo "No PR associated with this run; nothing to do."
+            exit 0
+          fi
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Sweep stale findings, signal on live ones
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESOLVE_TOKEN: ${{ secrets.GH_RESOLVE_TOKEN }}
+          NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          [ -n "$NUMBER" ] || { echo "no PR"; exit 0; }
+
+          THREADS="$(gh api graphql \
+            -f query='query($owner:String!,$name:String!,$number:Int!){
+              repository(owner:$owner,name:$name){
+                pullRequest(number:$number){
+                  headRefOid
+                  reviewThreads(first:50){nodes{
+                    id isResolved isOutdated
+                    comments(first:1){nodes{author{login}}}
+                  }}
+                }
+              }}' \
+            -f owner="${GITHUB_REPOSITORY%%/*}" \
+            -f name="${GITHUB_REPOSITORY##*/}" \
+            -F number="$NUMBER" \
+            --jq '.data.repository.pullRequest')"
+
+          STALE="$(echo "$THREADS" | jq '[.reviewThreads.nodes[]
+            | select(.isResolved==false and .isOutdated==true)
+            | select(.comments.nodes[0].author.login=="github-actions[bot]") | .id]')"
+
+          LIVE="$(echo "$THREADS" | jq '[.reviewThreads.nodes[]
+            | select(.isResolved==false and .isOutdated==false)
+            | select(.comments.nodes[0].author.login=="github-actions[bot]")]')"
+
+          N_STALE="$(jq length <<<"$STALE")"
+          N_LIVE="$(jq length <<<"$LIVE")"
+
+          if [ "$N_STALE" -gt 0 ]; then
+            if [ -n "$RESOLVE_TOKEN" ]; then
+              RESOLVED=0
+              for id in $(jq -r .[] <<<"$STALE"); do
+                if gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' \
+                     -f id="$id" --jq '.data.resolveReviewThread.thread.isResolved' >/dev/null 2>&1; then
+                  RESOLVED=$((RESOLVED+1))
+                fi
+              done
+              echo "Auto-resolved $RESOLVED/$N_STALE stale finding(s) (superseded by newer review)."
+            else
+              echo "::warning::$N_STALE stale finding(s) need resolution but GH_RESOLVE_TOKEN is not configured."
+            fi
+          fi
+
+          if [ "$N_LIVE" -gt 0 ]; then
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$NUMBER/reviews" \
+              -f event=REQUEST_CHANGES \
+              -f body="PR-Agent has $N_LIVE unresolved finding(s) — see inline threads." >/dev/null 2>&1 \
+              && echo "Requested changes: $N_LIVE live finding(s) block-by-thread." \
+              || echo "Could not set REQUEST_CHANGES state."
+          else
+            echo "No live PR-Agent findings."
+          fi

--- a/.github/workflows/pr-loop.yml
+++ b/.github/workflows/pr-loop.yml
@@ -2,14 +2,15 @@
 #
 # Validated mechanics (wcatz/ci-mech-spike, 2026-08-25):
 #   - GITHUB_TOKEN cannot resolve review threads ("not accessible by
-#     integration") — resolutions use the GH_RESOLVE_TOKEN secret, a
-#     fine-grained PAT with Pull requests: read+write on this repo only.
-#     Without the secret this job degrades to reporting-only.
+#     integration") and cannot submit APPROVED reviews. Resolutions go
+#     through a GitHub App installation token (GH_APP_ID +
+#     GH_APP_PRIVATE_KEY secrets, Pull requests: read+write on this repo
+#     only). Without those secrets this job degrades to report-only.
 #   - Outdated unresolved threads still block merge under required
 #     conversation resolution, so stale agent findings must be swept
 #     once a fresh review has re-judged the new diff.
-#   - GITHUB_TOKEN CAN submit REQUEST_CHANGES reviews; it can never
-#     APPROVE. Signal-only: approvals stay out of branch protection.
+#   - GITHUB_TOKEN CAN submit REQUEST_CHANGES reviews. Signal-only:
+#     approvals stay out of branch protection entirely.
 #
 # Triggered by workflow_run after each PR Agent completion and by PR
 # comments for manual re-runs. workflow_run executes in default-branch
@@ -41,6 +42,8 @@ jobs:
         github.event.sender.type != 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      HAS_APP: ${{ secrets.GH_APP_ID != '' && secrets.GH_APP_PRIVATE_KEY != '' }}
     steps:
       - name: Resolve PR number
         id: pr
@@ -62,10 +65,18 @@ jobs:
           fi
           echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
 
+      - name: Mint app token
+        id: app-token
+        if: env.HAS_APP == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Sweep stale findings, signal on live ones
         env:
           GH_TOKEN: ${{ github.token }}
-          RESOLVE_TOKEN: ${{ secrets.GH_RESOLVE_TOKEN }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
           NUMBER: ${{ steps.pr.outputs.number }}
         run: |
           [ -n "$NUMBER" ] || { echo "no PR"; exit 0; }
@@ -98,17 +109,18 @@ jobs:
           N_LIVE="$(jq length <<<"$LIVE")"
 
           if [ "$N_STALE" -gt 0 ]; then
-            if [ -n "$RESOLVE_TOKEN" ]; then
+            if [ -n "$APP_TOKEN" ]; then
               RESOLVED=0
               for id in $(jq -r .[] <<<"$STALE"); do
-                if gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' \
+                if GH_TOKEN="$APP_TOKEN" gh api graphql \
+                     -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' \
                      -f id="$id" --jq '.data.resolveReviewThread.thread.isResolved' >/dev/null 2>&1; then
                   RESOLVED=$((RESOLVED+1))
                 fi
               done
               echo "Auto-resolved $RESOLVED/$N_STALE stale finding(s) (superseded by newer review)."
             else
-              echo "::warning::$N_STALE stale finding(s) need resolution but GH_RESOLVE_TOKEN is not configured."
+              echo "::warning::$N_STALE stale finding(s) await resolution — configure the GH_APP_ID / GH_APP_PRIVATE_KEY secrets to enable auto-resolve."
             fi
           fi
 
@@ -116,7 +128,7 @@ jobs:
             gh api "repos/$GITHUB_REPOSITORY/pulls/$NUMBER/reviews" \
               -f event=REQUEST_CHANGES \
               -f body="PR-Agent has $N_LIVE unresolved finding(s) — see inline threads." >/dev/null 2>&1 \
-              && echo "Requested changes: $N_LIVE live finding(s) block-by-thread." \
+              && echo "Requested changes: $N_LIVE live finding(s)." \
               || echo "Could not set REQUEST_CHANGES state."
           else
             echo "No live PR-Agent findings."


### PR DESCRIPTION
### **User description**
Closes the CodeRabbit-style loop validated in wcatz/ci-mech-spike: sweeps the agent's own outdated threads after each fresh re-review (needs GH_RESOLVE_TOKEN secret — degrades to warning without it), and sets a REQUEST_CHANGES review while live findings exist. Signal only; the merge gate remains native conversation resolution. Not a required check — workflow_run runs attach to the wrong SHA for that.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `Review Loop` CI workflow for post-review cleanup.

- Auto-resolve stale `github-actions[bot]` review threads after re-review.

- Submit `REQUEST_CHANGES` signal while live findings remain unresolved.

- Degrade gracefully to a warning when `GH_RESOLVE_TOKEN` is missing.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR Agent completes"] --> B{"workflow_run / issue_comment"}
  B --> C["Fetch review threads"]
  C --> D{"Stale threads?"}
  D -- yes + token --> E["Resolve via GH_RESOLVE_TOKEN"]
  D -- no token --> F["Emit warning"]
  C --> G{"Live threads?"}
  G -- yes --> H["Submit REQUEST_CHANGES review"]
  G -- no --> I["No action needed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-loop.yml</strong><dd><code>Add Review Loop CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-loop.yml

<ul><li>New workflow triggered by <code>workflow_run</code> after <code>PR Agent</code> or by non-bot <br><code>issue_comment</code>.<br> <li> Resolves PR number from event payload or commit association.<br> <li> Queries GraphQL for review threads; auto-resolves outdated <br><code>github-actions[bot]</code> threads using <code>GH_RESOLVE_TOKEN</code>, warns if missing.<br> <li> Submits a <code>REQUEST_CHANGES</code> review when live unresolved findings exist; <br>otherwise logs no live findings.<br> <li> Sets <code>pull-requests: write</code> permission and concurrency keyed by PR <br>number.</ul>


</details>


  </td>
  <td><a href="https://github.com/wcatz/ghost/pull/370/files#diff-69050a23d8e1664d73d96b6d9358e0beeb5e1c6cdec09d38dcf651013187ce8c">+123/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

