### PR TITLE
fix(mcpinit): opencode plugin children no longer inherit stderr into the TUI

### DIFF
--- a/internal/mcpinit/opencode_ghost.ts
+++ b/internal/mcpinit/opencode_ghost.ts
@@ -57,11 +57,13 @@ const nudgePrompt = (reason: string): string =>
 // Materializes ghost's session-start context block for a directory and returns
 // it, so opencode can inject it passively via instructions (opencode has no
 // stdout-injection surface of its own). Read-only and fail-open: any spawn
-// error or missing context yields "" and the caller skips injection.
+// error or missing context yields "" and the caller skips injection. stderr is
+// ignored — this helper runs outside the plugin closure (no app.log access),
+// and ghost context diagnostics must never reach the terminal (issue #363).
 const renderStartContext = (cwd: string): Promise<string> =>
 	new Promise((resolve) => {
 		const child = spawn(process.env.GHOST_BIN ?? GHOST_BIN_DEFAULT, ["context", "--cwd", cwd], {
-			stdio: ["ignore", "pipe", "inherit"],
+			stdio: ["ignore", "pipe", "ignore"],
 		})
 		let out = ""
 		child.stdout?.on("data", (d) => {
@@ -120,25 +122,35 @@ export const GhostPlugin: Plugin = async ({ client, directory }) => {
 
 		try {
 			const child = spawn(process.env.GHOST_BIN ?? GHOST_BIN_DEFAULT, ["hook", "stop", "--source", "opencode"], {
-				stdio: ["pipe", "pipe", "inherit"],
+				stdio: ["pipe", "pipe", "pipe"],
 				detached: true,
 				env: process.env,
 			})
 			child.on("error", async (e) => {
 				await log("warn", `ghost: fail-open (spawn: ${e})`)
 			})
-			// opencode cannot block a stop, so the {"decision":"block"} nudge
+			// opencode cannot block a stop, so the {"decision":"approve"} nudge
 			// ghost emits on stdout is captured here and injected into the live
 			// session (client.session.promptAsync) so the agent itself acts on
 			// it — the faithful analog of the claude/codex blocking nudge. If
-			// the injection fails it falls back to a log line. Either way the
-			// nudge never touches stderr, so there is no terminal bleed.
+			// the injection fails it falls back to a log line.
 			let nudge = ""
 			child.stdout?.on("data", (d) => { nudge += d.toString() })
+			// stderr is piped and drained rather than inherited: this child is
+			// detached from opencode's process tree, so an inherited stderr
+			// writes straight to the controlling terminal outside the TUI
+			// redraw (issue #363). Diagnostics are re-routed to app.log on
+			// close; if this process exits before the child does, the drain is
+			// lost — acceptable for fail-open diagnostics.
+			let errs = ""
+			child.stderr?.on("data", (d) => { errs += d.toString() })
 			// Best-effort local cleanup when we outlive the hook; ghost also
 			// sweeps its ghost-* temp transcript dirs consumer-side, covering
 			// hosts that exit before this handler runs (e.g. `opencode run`).
 			child.on("close", () => {
+				if (errs.trim()) {
+					log("warn", `ghost hook stderr: ${errs.trim().slice(0, 500)}`)
+				}
 				const trimmed = nudge.trim()
 				if (trimmed) {
 					let reason = trimmed

--- a/plugin/ghost-opencode/index.ts
+++ b/plugin/ghost-opencode/index.ts
@@ -89,17 +89,28 @@ export const GhostPlugin: Plugin = async ({ client, directory }) => {
 
 		try {
 			const child = spawn(GHOST_BIN, ["hook", "stop", "--source", "opencode"], {
-				stdio: ["pipe", "ignore", "inherit"],
+				// stderr piped and drained, never inherited: this child is
+				// detached from opencode's process tree, so an inherited
+				// stderr writes straight to the controlling terminal outside
+				// the TUI redraw (issue #363). Diagnostics re-route to
+				// app.log on close; if this process exits first the drain is
+				// lost — acceptable for fail-open diagnostics.
+				stdio: ["pipe", "ignore", "pipe"],
 				detached: true,
 				env: process.env,
 			})
 			child.on("error", async (e) => {
 				await log("warn", `ghost: fail-open (spawn: ${e})`)
 			})
+			let errs = ""
+			child.stderr?.on("data", (d) => { errs += d.toString() })
 			// Best-effort local cleanup when we outlive the hook; ghost also
 			// sweeps its ghost-* temp transcript dirs consumer-side, covering
 			// hosts that exit before this handler runs (e.g. `opencode run`).
 			child.on("close", () => {
+				if (errs.trim()) {
+					log("warn", `ghost hook stderr: ${errs.trim().slice(0, 500)}`)
+				}
 				if (transcriptPath) rm(join(transcriptPath, ".."), { recursive: true, force: true }).catch(() => {})
 			})
 			child.stdin.on("error", () => {})


### PR DESCRIPTION
### **User description**
Detached stop-hook children inherited stderr, so ghost's fail-open diagnostics bled into opencode's TUI on every idle/stop transition (#363). Both spawn sites (embedded template + published package) now pipe and drain stderr into app.log; the awaited session-start context spawn ignores it outright (fail-open helper, no log handle available).

Fixes #363


___

### **PR Type**
Bug fix


___

### **Description**
- Pipe detached stop-hook stderr instead of inheriting terminal

- Drain stderr into opencode `app.log` on child close

- Ignore stderr in session-start context helper

- Sync embedded template and published package fixes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Detached ghost stop hook"] -- "stdio stderr" --> B["pipe"]
  B -- "collect diagnostics" --> C["app.log"]
  D["Session-start context helper"] -- "stdio stderr" --> E["ignore"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>opencode_ghost.ts</strong><dd><code>Prevent stderr bleed from detached hooks in embedded template</code></dd></summary>
<hr>

internal/mcpinit/opencode_ghost.ts

<ul><li><code>renderStartContext</code> now sets stderr to <code>ignore</code> instead of <code>inherit</code>, <br>preventing ghost diagnostics from reaching the terminal.<br> <li> Stop-hook spawn changed stdio from <code>["pipe", "pipe", "inherit"]</code> to <br><code>["pipe", "pipe", "pipe"]</code>.<br> <li> Added stderr buffering and drains it into <code>app.log</code> on <code>close</code>.<br> <li> Corrected inline comment referencing <code>{"decision":"approve"}</code> and <br>documented issue #363.</ul>


</details>


  </td>
  <td><a href="https://github.com/wcatz/ghost/pull/374/files#diff-3d0b4eacd3ad1bcd6b75138c4cf79bd9065e46f6eadf68acbaaea1b00f9ec27b">+18/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Prevent stderr bleed from detached hooks in published package</code></dd></summary>
<hr>

plugin/ghost-opencode/index.ts

<ul><li>Stop-hook spawn changed stdio from <code>["pipe", "ignore", "inherit"]</code> to <br><code>["pipe", "ignore", "pipe"]</code>.<br> <li> Added stderr buffering and drains it into <code>app.log</code> on <code>close</code>.<br> <li> Added comments explaining detached-child stderr behavior and issue <br>#363.</ul>


</details>


  </td>
  <td><a href="https://github.com/wcatz/ghost/pull/374/files#diff-e3ad4c46e46a9c88616daee621067f8df25f9652beecff8c791921b3ba7c7f2a">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

