### PR TITLE
feat(ci): switch PR-Agent to big-pickle on opencode Zen

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -76,25 +76,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          # Kimi K2.7 Code via opencode Go subscription.
-          # OpenAI-compatible endpoint, so litellm's openai provider +
-          # api_base override routes there (PR-Agent "OpenAI like API" docs).
+          # Big Pickle via opencode Zen — free stealth reasoning model
+          # (opencode's deliberate-analysis model), chosen for review
+          # quality and to dodge the Go endpoint's recurring hang days.
           OPENAI__KEY: ${{ secrets.OPENCODE_GO_API_KEY }}
-          OPENAI__API_BASE: https://opencode.ai/zen/go/v1
+          OPENAI__API_BASE: https://opencode.ai/zen/v1
 
-          # openai/ prefix routes through litellm's OpenAI-compatible path;
-          # kimi-k2.7-code is the Go endpoint's model id.
-          config.model: "openai/kimi-k2.7-code"
-          # Fallback rides a different provider lane (DeepSeek vs Moonshot
-          # hosting) so an unhealthy Kimi endpoint doesn't fail the run.
-          # Both accept temperature=1 and are inside the Go subscription.
+          # openai/ prefix routes through litellm's OpenAI-compatible path.
+          config.model: "openai/big-pickle"
+          # Fallback rides a different provider lane (DeepSeek) on the same
+          # Zen endpoint so an unhealthy pickle host doesn't fail the run.
           config.fallback_models: '["openai/deepseek-v4-flash"]'
           # Not in PR-Agent's MAX_TOKENS catalog → must set explicitly.
-          # Conservative slice of K2.7's context window; plenty for any diff.
           config.custom_model_max_tokens: "65536"
-          # K2.7 Code on the Go endpoint only accepts temperature=1
-          # (PR-Agent's default 0.2 is rejected with invalid_request_error).
-          config.temperature: "1"
+          # No temperature override: 1 was a Kimi-Go quirk; PR-Agent's
+          # default 0.2 keeps reviews deterministic.
           # Hard cap per LLM call — a hung endpoint must fail fast, not
           # park the runner for 10 minutes.
           config.ai_timeout: "90"


### PR DESCRIPTION
### **User description**
Moves the reviewer from kimi-k2.7-code (Go endpoint — had a hang-day today, two 10-min runner kills on #374) to opencode's free stealth reasoning model big-pickle on plain Zen. Fallback stays deepseek-v4-flash on the same endpoint so one api_base covers both; the temperature=1 override is dropped (Kimi-Go quirk, default 0.2 restored). Unverified: whether the Go-subscription key authenticates against plain Zen — this PR's own agent run answers that.


___

### **PR Type**
Other


___

### **Description**
- Switch PR-Agent model from `kimi-k2.7-code` to `big-pickle`

- Update API endpoint from opencode's Go subscription to Zen

- Remove Kimi-specific temperature override for deterministic reviews

- Maintain fallback to `deepseek-v4-flash` on same endpoint


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR-Agent"] -- "uses" --> B["openai/big-pickle"]
  A -- "fallback" --> C["openai/deepseek-v4-flash"]
  B -- "endpoint" --> D["opencode.ai/zen/v1"]
  E["Previous Kimi K2.7 Code"] -- "replaced by" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Switch PR-Agent model and endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Switch model from <code>kimi-k2.7-code</code> to <code>big-pickle</code><br> <li> Update API base URL from Go endpoint to Zen endpoint<br> <li> Remove Kimi-specific temperature=1 override<br> <li> Update comments to reflect new model and endpoint</ul>


</details>


  </td>
  <td><a href="https://github.com/wcatz/ghost/pull/376/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+10/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

