### PR TITLE
feat/source aware llm provider

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -427,79 +427,76 @@ Flags:
 				tiers = append(tiers, reflection.NewSQLiteConsolidator())
 			}
 			consolidator = reflection.NewTieredConsolidator(tiers, logger)
-			if consolidator.Available(ctx) {
-				// Re-use the existing consolidation path below; override tierValue
-				// so the switch-case doesn't fire. The consolidator is built.
-				goto built
-			}
 		}
-		// Not available — fall through to standard auto logic.
 	}
 
-	switch tierValue {
-	case "haiku":
-		if cfg.API.Key == "" {
-			fmt.Fprintln(os.Stderr, "error: haiku tier requires ANTHROPIC_API_KEY")
-			os.Exit(1)
-		}
-		client := ai.NewClient(cfg.API.Key, logger)
-		consolidator = reflection.NewHaikuConsolidator(client)
-	case "cli":
-		binary := "claude"
-		if cfg.CLI.ClaudeBinary != "" {
-			binary = cfg.CLI.ClaudeBinary
-		}
-		if _, err := exec.LookPath(binary); err != nil {
-			hint := "set cli.claude_binary"
-			if cfg.CLI.ClaudeBinary != "" {
-				hint = "check that cli.claude_binary (" + binary + ") is a valid, executable path"
+	// If source-aware path above didn't build a consolidator, fall through
+	// to the standard tier switch.
+	if consolidator == nil {
+		switch tierValue {
+		case "haiku":
+			if cfg.API.Key == "" {
+				fmt.Fprintln(os.Stderr, "error: haiku tier requires ANTHROPIC_API_KEY")
+				os.Exit(1)
 			}
-			fmt.Fprintf(os.Stderr, "error: cli tier requires the `%s` binary on PATH (or %s)\n", binary, hint)
-			os.Exit(1)
-		}
-		consolidator = reflection.NewNamedConsolidator(ai.NewCLIClientWithBinary(binary), "cli")
-	case "opencode":
-		binary := "opencode"
-		if cfg.CLI.OpenCodeBinary != "" {
-			binary = cfg.CLI.OpenCodeBinary
-		}
-		if _, err := exec.LookPath(binary); err != nil {
-			hint := "set cli.opencode_binary"
-			if cfg.CLI.OpenCodeBinary != "" {
-				hint = "check that cli.opencode_binary (" + binary + ") is a valid, executable path"
-			}
-			fmt.Fprintf(os.Stderr, "error: opencode tier requires the `%s` binary on PATH (or %s)\n", binary, hint)
-			os.Exit(1)
-		}
-		consolidator = reflection.NewNamedConsolidator(ai.NewOpenCodeClientWithBinary(binary), "opencode")
-	case "sqlite":
-		if requireLLM {
-			fmt.Fprintln(os.Stderr, "error: --require-llm conflicts with --tier sqlite")
-			os.Exit(1)
-		}
-		consolidator = reflection.NewSQLiteConsolidator()
-	default: // "auto"
-		var tiers []reflection.Consolidator
-		if cfg.API.Key != "" {
 			client := ai.NewClient(cfg.API.Key, logger)
-			tiers = append(tiers, reflection.NewHaikuConsolidator(client))
+			consolidator = reflection.NewHaikuConsolidator(client)
+		case "cli":
+			binary := "claude"
+			if cfg.CLI.ClaudeBinary != "" {
+				binary = cfg.CLI.ClaudeBinary
+			}
+			if _, err := exec.LookPath(binary); err != nil {
+				hint := "set cli.claude_binary"
+				if cfg.CLI.ClaudeBinary != "" {
+					hint = "check that cli.claude_binary (" + binary + ") is a valid, executable path"
+				}
+				fmt.Fprintf(os.Stderr, "error: cli tier requires the `%s` binary on PATH (or %s)\n", binary, hint)
+				os.Exit(1)
+			}
+			consolidator = reflection.NewNamedConsolidator(ai.NewCLIClientWithBinary(binary), "cli")
+		case "opencode":
+			binary := "opencode"
+			if cfg.CLI.OpenCodeBinary != "" {
+				binary = cfg.CLI.OpenCodeBinary
+			}
+			if _, err := exec.LookPath(binary); err != nil {
+				hint := "set cli.opencode_binary"
+				if cfg.CLI.OpenCodeBinary != "" {
+					hint = "check that cli.opencode_binary (" + binary + ") is a valid, executable path"
+				}
+				fmt.Fprintf(os.Stderr, "error: opencode tier requires the `%s` binary on PATH (or %s)\n", binary, hint)
+				os.Exit(1)
+			}
+			consolidator = reflection.NewNamedConsolidator(ai.NewOpenCodeClientWithBinary(binary), "opencode")
+		case "sqlite":
+			if requireLLM {
+				fmt.Fprintln(os.Stderr, "error: --require-llm conflicts with --tier sqlite")
+				os.Exit(1)
+			}
+			consolidator = reflection.NewSQLiteConsolidator()
+		default: // "auto"
+			var tiers []reflection.Consolidator
+			if cfg.API.Key != "" {
+				client := ai.NewClient(cfg.API.Key, logger)
+				tiers = append(tiers, reflection.NewHaikuConsolidator(client))
+			}
+			if cli := ai.NewCLIProviderWithBinaries(cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary, cfg.CLI.CodexBinary, cfg.CLI.GooseBinary); cli.Available() {
+				tiers = append(tiers, reflection.NewNamedConsolidator(cli, cli.Name()))
+			}
+			// --require-llm is the autonomous-reflect guard: it must never silently
+			// degrade to the Jaccard-only sqlite tier (which would rewrite every
+			// non-manual memory with no consolidation quality). A stale/exhausted
+			// ANTHROPIC_API_KEY is a false positive for "has an LLM", so the cheap
+			// stop-hook pre-check can't be trusted; this flag is the real guard at
+			// the write site — no LLM tier available (or all fail) => exit non-zero
+			// without touching the DB.
+			if !requireLLM {
+				tiers = append(tiers, reflection.NewSQLiteConsolidator())
+			}
+			consolidator = reflection.NewTieredConsolidator(tiers, logger)
 		}
-		if cli := ai.NewCLIProviderWithBinaries(cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary, cfg.CLI.CodexBinary, cfg.CLI.GooseBinary); cli.Available() {
-			tiers = append(tiers, reflection.NewNamedConsolidator(cli, cli.Name()))
-		}
-		// --require-llm is the autonomous-reflect guard: it must never silently
-		// degrade to the Jaccard-only sqlite tier (which would rewrite every
-		// non-manual memory with no consolidation quality). A stale/exhausted
-		// ANTHROPIC_API_KEY is a false positive for "has an LLM", so the cheap
-		// stop-hook pre-check can't be trusted; this flag is the real guard at
-		// the write site — no LLM tier available (or all fail) => exit non-zero
-		// without touching the DB.
-		if !requireLLM {
-			tiers = append(tiers, reflection.NewSQLiteConsolidator())
-		}
-		consolidator = reflection.NewTieredConsolidator(tiers, logger)
 	}
-built:
 
 	if !consolidator.Available(ctx) {
 		fmt.Fprintf(os.Stderr, "error: consolidator %q is not available\n", consolidator.Name())

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -419,7 +419,7 @@ Flags:
 	// lets the stop-hook or cron reflect use the same CLI that served the
 	// session, avoiding ANTHROPIC_API_KEY when not needed.
 	if tierValue == "auto" && source != "" {
-		sp := ai.NewSourceProviderForSource(source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary)
+		sp := ai.NewSourceProviderForSource(source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary, cfg.CLI.CodexBinary, cfg.CLI.GooseBinary)
 		if sp.Available() {
 			var tiers []reflection.Consolidator
 			tiers = append(tiers, reflection.NewNamedConsolidator(sp, sp.Name()))
@@ -484,7 +484,7 @@ Flags:
 			client := ai.NewClient(cfg.API.Key, logger)
 			tiers = append(tiers, reflection.NewHaikuConsolidator(client))
 		}
-		if cli := ai.NewCLIProviderWithBinaries(cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary); cli.Available() {
+		if cli := ai.NewCLIProviderWithBinaries(cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary, cfg.CLI.CodexBinary, cfg.CLI.GooseBinary); cli.Available() {
 			tiers = append(tiers, reflection.NewNamedConsolidator(cli, cli.Name()))
 		}
 		// --require-llm is the autonomous-reflect guard: it must never silently
@@ -714,7 +714,7 @@ built:
 // primary when no key is configured at all, so these commands work without
 // spending API credits as long as `claude` or `opencode` is available.
 func buildClassifyProvider(cfg *config.Config, logger *slog.Logger) (*ai.FallbackProvider, error) {
-	cli := ai.NewCLIProviderWithBinaries(cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary)
+	cli := ai.NewCLIProviderWithBinaries(cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary, cfg.CLI.CodexBinary, cfg.CLI.GooseBinary)
 	if cfg.API.Key == "" {
 		if !cli.Available() {
 			return nil, errors.New("requires ANTHROPIC_API_KEY or a `claude`/`opencode` binary (on PATH or via cli.claude_binary/cli.opencode_binary)")
@@ -733,7 +733,7 @@ func buildClassifyProvider(cfg *config.Config, logger *slog.Logger) (*ai.Fallbac
 // API-first fallback chain.
 func buildClassifyProviderForSource(cfg *config.Config, source string, logger *slog.Logger) (*ai.FallbackProvider, error) {
 	if source != "" {
-		sp := ai.NewSourceProviderForSource(source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary)
+		sp := ai.NewSourceProviderForSource(source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary, cfg.CLI.CodexBinary, cfg.CLI.GooseBinary)
 		if !sp.Available() {
 			return nil, fmt.Errorf("source %q: no CLI binary available", source)
 		}

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -355,7 +355,7 @@ func resolveProjectOrExit(ctx context.Context, store *memory.Store, projectName 
 // Defaults to dry-run (preview only). Use --apply to save results.
 // Use --restore to undo the last consolidation from snapshot.
 func runReflect() {
-	var projectName, tierValue string
+	var projectName, tierValue, source string
 	var apply, restore, requireLLM, allowDrops bool
 	tierValue = "auto"
 	for i := 2; i < len(os.Args); i++ {
@@ -373,6 +373,11 @@ func runReflect() {
 			requireLLM = true
 		case os.Args[i] == "--allow-drops":
 			allowDrops = true
+		case os.Args[i] == "--source" && i+1 < len(os.Args):
+			source = os.Args[i+1]
+			i++
+		case strings.HasPrefix(os.Args[i], "--source="):
+			source = strings.TrimPrefix(os.Args[i], "--source=")
 		case !strings.HasPrefix(os.Args[i], "-"):
 			projectName = os.Args[i]
 		}
@@ -385,7 +390,8 @@ Flags:
   --apply         Save results (default is dry-run/preview only)
   --restore       Undo the last consolidation from snapshot
   --require-llm   Fail instead of falling back to the Jaccard-only sqlite tier
-  --allow-drops   Apply even when guarded-category memories would be deleted without a merge`)
+  --allow-drops   Apply even when guarded-category memories would be deleted without a merge
+  --source string Host source for CLI selection (e.g. claude-code, opencode)`)
 		os.Exit(1)
 	}
 
@@ -407,6 +413,29 @@ Flags:
 	}
 
 	var consolidator reflection.Consolidator
+
+	// Source-aware auto tier: when --source is set and tier is "auto", prefer
+	// the source-matched CLI backend directly, skipping API entirely. This
+	// lets the stop-hook or cron reflect use the same CLI that served the
+	// session, avoiding ANTHROPIC_API_KEY when not needed.
+	if tierValue == "auto" && source != "" {
+		sp := ai.NewSourceProviderForSource(source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary)
+		if sp.Available() {
+			var tiers []reflection.Consolidator
+			tiers = append(tiers, reflection.NewNamedConsolidator(sp, sp.Name()))
+			if !requireLLM {
+				tiers = append(tiers, reflection.NewSQLiteConsolidator())
+			}
+			consolidator = reflection.NewTieredConsolidator(tiers, logger)
+			if consolidator.Available(ctx) {
+				// Re-use the existing consolidation path below; override tierValue
+				// so the switch-case doesn't fire. The consolidator is built.
+				goto built
+			}
+		}
+		// Not available — fall through to standard auto logic.
+	}
+
 	switch tierValue {
 	case "haiku":
 		if cfg.API.Key == "" {
@@ -470,6 +499,7 @@ Flags:
 		}
 		consolidator = reflection.NewTieredConsolidator(tiers, logger)
 	}
+built:
 
 	if !consolidator.Available(ctx) {
 		fmt.Fprintf(os.Stderr, "error: consolidator %q is not available\n", consolidator.Name())
@@ -698,6 +728,20 @@ func buildClassifyProvider(cfg *config.Config, logger *slog.Logger) (*ai.Fallbac
 	return ai.NewFallbackProvider(primary, cli, true), nil
 }
 
+// buildClassifyProviderForSource wraps buildClassifyProvider when --source is
+// set: routes through the matching CLI backend instead of the default
+// API-first fallback chain.
+func buildClassifyProviderForSource(cfg *config.Config, source string, logger *slog.Logger) (*ai.FallbackProvider, error) {
+	if source != "" {
+		sp := ai.NewSourceProviderForSource(source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary)
+		if !sp.Available() {
+			return nil, fmt.Errorf("source %q: no CLI binary available", source)
+		}
+		return ai.NewFallbackProvider(sp, nil, false), nil
+	}
+	return buildClassifyProvider(cfg, logger)
+}
+
 // runSupersede implements `ghost supersede <project> [--apply]` — the creation
 // half of staleness-aware ranking. It proposes newer→older 'supersedes' links
 // over the project's live memories (cosine-similar candidates, Haiku-confirmed)
@@ -706,6 +750,7 @@ func buildClassifyProvider(cfg *config.Config, logger *slog.Logger) (*ai.Fallbac
 // SupersedeDemote is set. See docs/benchmarks.md Phase 3.
 func runSupersede() {
 	var projectName string
+	var source string
 	apply := false
 	threshold := float32(0.80) // supersession candidates are the SAME fact — tighter than the 0.70 'related' floor
 	for i := 2; i < len(os.Args); i++ {
@@ -721,6 +766,11 @@ func runSupersede() {
 			if v, err := strconv.ParseFloat(strings.TrimPrefix(os.Args[i], "--threshold="), 32); err == nil {
 				threshold = float32(v)
 			}
+		case os.Args[i] == "--source" && i+1 < len(os.Args):
+			source = os.Args[i+1]
+			i++
+		case strings.HasPrefix(os.Args[i], "--source="):
+			source = strings.TrimPrefix(os.Args[i], "--source=")
 		case !strings.HasPrefix(os.Args[i], "-"):
 			projectName = os.Args[i]
 		default:
@@ -734,6 +784,7 @@ func runSupersede() {
 Flags:
   --apply             Write the supersedes/causes links (default is dry-run/preview)
   --threshold float   Min cosine similarity for a candidate pair (default 0.80)
+  --source string     Host source for CLI selection (e.g. claude-code, opencode)
 
 Classifies each candidate as supersedes, causes, or neither. Uses
 ANTHROPIC_API_KEY if set; otherwise falls back to a subscription-billed
@@ -747,7 +798,7 @@ cli.opencode_binary) — requires one of the two.`)
 	ctx := context.Background()
 
 	projectID := resolveProjectOrExit(ctx, store, projectName)
-	provider, err := buildClassifyProvider(cfg, logger)
+	provider, err := buildClassifyProviderForSource(cfg, source, logger)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: ghost supersede %v\n", err)
 		os.Exit(1)
@@ -795,11 +846,17 @@ cli.opencode_binary) — requires one of the two.`)
 // resolution-classifier spec.
 func runResolve() {
 	var projectName string
+	var source string
 	apply := false
 	for i := 2; i < len(os.Args); i++ {
 		switch {
 		case os.Args[i] == "--apply":
 			apply = true
+		case os.Args[i] == "--source" && i+1 < len(os.Args):
+			source = os.Args[i+1]
+			i++
+		case strings.HasPrefix(os.Args[i], "--source="):
+			source = strings.TrimPrefix(os.Args[i], "--source=")
 		case !strings.HasPrefix(os.Args[i], "-"):
 			if projectName != "" {
 				fmt.Fprintln(os.Stderr, "error: expected exactly one project")
@@ -815,7 +872,8 @@ func runResolve() {
 		fmt.Fprintln(os.Stderr, `Usage: ghost resolve <project> [flags]
 
 Flags:
-  --apply   Stamp resolved_at on confirmed memories (default is dry-run/preview)
+  --apply         Stamp resolved_at on confirmed memories (default is dry-run/preview)
+  --source string Host source for CLI selection (e.g. claude-code, opencode)
 
 Marks resolved-evidence memories so they drop from session-start injection
 (still searchable). Uses ANTHROPIC_API_KEY if set; otherwise falls back to a
@@ -829,7 +887,7 @@ cli.claude_binary / cli.opencode_binary) — requires one of the two.`)
 	ctx := context.Background()
 
 	projectID := resolveProjectOrExit(ctx, store, projectName)
-	provider, err := buildClassifyProvider(cfg, logger)
+	provider, err := buildClassifyProviderForSource(cfg, source, logger)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: ghost resolve %v\n", err)
 		os.Exit(1)

--- a/docs/superpowers/plans/2026-08-25-source-aware-llm-provider.md
+++ b/docs/superpowers/plans/2026-08-25-source-aware-llm-provider.md
@@ -1,0 +1,376 @@
+# Source-Aware LLM Provider Selection
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop using Anthropic API as the default LLM for reflect/resolve/supersede. Instead, use the `source` field from the contract envelope to select the same CLI the user was paying for in their session.
+
+**Architecture:** The stop hook already knows which host disconnected (via `--source`). We pass that source through to reflect/supersede/resolve as a `--source` flag, which selects the matching CLI subprocess (claude → `claude -p`, opencode → `opencode run`, codex → codex CLI, goose → goose CLI). Anthropic API becomes opt-in only (user explicitly sets `ANTHROPIC_API_KEY`).
+
+**Tech Stack:** Go 1.26+, existing ai package interfaces, hostevent.Source constants
+
+---
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `internal/ai/source_provider.go` | NEW: Maps source string → CLI backend (claude-code→claude, opencode→opencode, etc.) |
+| `internal/ai/source_provider_test.go` | NEW: Tests for source-based routing |
+| `internal/mcpinit/stophook.go` | Pass `--source` to reflect/supersede/resolve spawns |
+| `cmd/ghost/main.go` | Add `--source` flag; add `buildClassifyProviderForSource()`; update reflect tier |
+
+---
+
+## Task 1: Create SourceProvider — source-to-CLI mapping
+
+**Files:**
+- Create: `internal/ai/source_provider.go`
+- Create: `internal/ai/source_provider_test.go`
+
+- [ ] **Step 1: Create SourceProvider**
+
+New file `internal/ai/source_provider.go`. Maps source string to the matching CLI subprocess. Implements both `Provider` (Classify) and the reflection `reflector` interface (Reflect).
+
+```go
+package ai
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+)
+
+var errUnknownSource = errors.New("unknown source: no CLI backend available for this host")
+
+type SourceProvider struct {
+	backend cliBackend
+	name    string
+}
+
+// NewSourceProviderForSource returns a provider matching the host source.
+// Empty/unknown source falls back to best-available-on-PATH.
+func NewSourceProviderForSource(source string, cfgBinaries ...string) *SourceProvider {
+	claudeBin, opencodeBin := "", ""
+	if len(cfgBinaries) > 0 {
+		claudeBin = cfgBinaries[0]
+	}
+	if len(cfgBinaries) > 1 {
+		opencodeBin = cfgBinaries[1]
+	}
+	switch source {
+	case "claude-code":
+		return resolveCLI(claudeBin, "claude", "cli")
+	case "opencode":
+		return resolveCLI(opencodeBin, "opencode", "opencode")
+	case "codex":
+		// Codex doesn't have a Reflect/Classify-compatible CLI yet.
+		// Fall back to best available (same as unknown source).
+		return fallbackCLI(claudeBin, opencodeBin)
+	case "goose":
+		// Goose doesn't have a Reflect/Classify-compatible CLI yet.
+		return fallbackCLI(claudeBin, opencodeBin)
+	default:
+		return fallbackCLI(claudeBin, opencodeBin)
+	}
+}
+
+func resolveCLI(configured, defaultName, providerName string) *SourceProvider {
+	bin := configured
+	if bin == "" {
+		bin = defaultName
+	}
+	if _, err := exec.LookPath(bin); err != nil {
+		return &SourceProvider{backend: nil, name: "none"}
+	}
+	switch providerName {
+	case "cli":
+		return &SourceProvider{backend: NewCLIClientWithBinary(bin), name: "cli"}
+	case "opencode":
+		return &SourceProvider{backend: NewOpenCodeClientWithBinary(bin), name: "opencode"}
+	}
+	return &SourceProvider{backend: nil, name: "none"}
+}
+
+func fallbackCLI(claudeBin, opencodeBin string) *SourceProvider {
+	p := NewCLIProviderWithBinaries(claudeBin, opencodeBin)
+	return &SourceProvider{backend: p.backend, name: p.name}
+}
+
+func (p *SourceProvider) Name() string    { return p.name }
+func (p *SourceProvider) Available() bool { return p.backend != nil }
+
+func (p *SourceProvider) Reflect(ctx context.Context, prompt string) (string, TokenUsage, error) {
+	if p.backend == nil {
+		return "", TokenUsage{}, errUnknownSource
+	}
+	return p.backend.Reflect(ctx, prompt)
+}
+
+func (p *SourceProvider) Classify(ctx context.Context, systemPrompt, userContent string) (string, error) {
+	if p.backend == nil {
+		return "", errUnknownSource
+	}
+	return p.backend.Classify(ctx, systemPrompt, userContent)
+}
+```
+
+- [ ] **Step 2: Write tests**
+
+New file `internal/ai/source_provider_test.go`:
+
+```go
+package ai
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSourceProviderForSource(t *testing.T) {
+	dir := t.TempDir()
+	claude := filepath.Join(dir, "claude")
+	opencode := filepath.Join(dir, "opencode")
+	os.WriteFile(claude, []byte("#!/bin/sh\nexit 0"), 0o755)
+	os.WriteFile(opencode, []byte("#!/bin/sh\nexit 0"), 0o755)
+
+	tests := []struct {
+		source string
+		name   string
+		ok     bool
+	}{
+		{"claude-code", "cli", true},
+		{"opencode", "opencode", true},
+		{"codex", "", false},     // no codex CLI impl yet
+		{"goose", "", false},     // no goose CLI impl yet
+		{"unknown-source", "", false}, // falls back, nothing on PATH
+	}
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			p := NewSourceProviderForSource(tt.source, claude, opencode)
+			if tt.name == "" && !tt.ok {
+				// For unavailable providers, just check Available
+				if p.Available() {
+					t.Error("expected unavailable")
+				}
+				return
+			}
+			if p.Name() != tt.name {
+				t.Errorf("Name() = %q, want %q", p.Name(), tt.name)
+			}
+			if !p.Available() {
+				t.Error("expected available")
+			}
+		})
+	}
+}
+
+func TestSourceProviderClassify(t *testing.T) {
+	p := &SourceProvider{backend: nil, name: "none"}
+	_, err := p.Classify(t.Context(), "sys", "user")
+	if err != errUnknownSource {
+		t.Errorf("expected errUnknownSource, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `go test ./internal/ai/ -run TestSourceProvider -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/ai/source_provider.go internal/ai/source_provider_test.go
+git commit -s -m "feat(ai): add SourceProvider for source-based CLI routing"
+```
+
+---
+
+## Task 2: Pass source from stop hook to spawned processes
+
+**Files:**
+- Modify: `internal/mcpinit/stophook.go`
+
+- [ ] **Step 1: Update runStop to pass source**
+
+In `runStop` (line 77), extract source from payload and pass to spawn helpers:
+
+```go
+func runStop(p hostevent.Payload, stdout io.Writer, stderr io.Writer, nudge bool) {
+	defer cleanupTransientTranscript(p)
+	if nudge && p.StopHookActive {
+		return
+	}
+	source := string(p.HostSource())
+	spawnResolveIfConfigured(p.CWD, source)
+	spawnSupersedeIfConfigured(p.CWD, source)
+	spawnReflectIfConfigured(p.CWD, source)
+	// ... rest unchanged ...
+```
+
+- [ ] **Step 2: Update spawnResolveIfConfigured signature**
+
+Change `spawnResolveIfConfigured(cwd string)` to `spawnResolveIfConfigured(cwd, source string)`. Append `--source` to the command args when non-empty:
+
+```go
+func spawnResolveIfConfigured(cwd string, source string) {
+	// ... existing guard logic unchanged ...
+
+	cmd := exec.Command(exe, "resolve", projectName, "--apply")
+	if source != "" {
+		cmd.Args = append(cmd.Args, "--source", source)
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	detachProcess(cmd)
+	// ... rest unchanged ...
+```
+
+- [ ] **Step 3: Update spawnSupersedeIfConfigured**
+
+Same pattern — add `source string` param, append `--source` arg.
+
+- [ ] **Step 4: Update spawnReflectIfConfigured**
+
+Add `source string` param. Update the no-LLM guard to also check source-matched CLI:
+
+```go
+func spawnReflectIfConfigured(cwd string, source string) {
+	// ... existing guard ...
+	// Updated no-LLM guard: check source-matched CLI too
+	cli := ai.NewCLIProviderWithBinaries(cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary)
+	if cfg.API.Key == "" && !cli.Available() {
+		// Also check if the source-matched CLI is available
+		sp := ai.NewSourceProviderForSource(source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary)
+		if !sp.Available() {
+			return
+		}
+	}
+	// ... existing DB logic ...
+	cmd := exec.Command(exe, "reflect", projectName, "--apply", "--require-llm")
+	if source != "" {
+		cmd.Args = append(cmd.Args, "--source", source)
+	}
+	// ... rest unchanged ...
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./internal/mcpinit/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/mcpinit/stophook.go
+git commit -s -m "feat(mcpinit): pass source from stop hook to reflect/resolve/supersede"
+```
+
+---
+
+## Task 3: Add --source flag to resolve/supersede/reflect commands
+
+**Files:**
+- Modify: `cmd/ghost/main.go`
+
+- [ ] **Step 1: Add buildClassifyProviderForSource**
+
+New function in `cmd/ghost/main.go`:
+
+```go
+func buildClassifyProviderForSource(cfg *config.Config, source string, logger *slog.Logger) (*ai.FallbackProvider, error) {
+	if source != "" {
+		sp := ai.NewSourceProviderForSource(source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary)
+		if !sp.Available() {
+			return nil, fmt.Errorf("source %q: no CLI binary available", source)
+		}
+		return ai.NewFallbackProvider(sp, nil, false), nil
+	}
+	return buildClassifyProvider(cfg, logger)
+}
+```
+
+- [ ] **Step 2: Add --source to runResolve**
+
+In `runResolve` (~line 732), add `source` flag and use it:
+
+```go
+func runResolve(args []string, logger *slog.Logger) {
+	fs := flag.NewFlagSet("resolve", flag.ContinueOnError)
+	apply := fs.Bool("apply", false, "")
+	source := fs.String("source", "", "host source for CLI selection")
+	// ... parse args ...
+	provider, err := buildClassifyProviderForSource(cfg, *source, logger)
+	// ... use provider ...
+```
+
+- [ ] **Step 3: Add --source to runSupersede**
+
+Same pattern in `runSupersede` (~line 643).
+
+- [ ] **Step 4: Add --source to runReflect**
+
+In `runReflect` (~line 293), add the flag. When source is set and tier is "auto", prefer the source-matched CLI:
+
+```go
+func runReflect(args []string, logger *slog.Logger) {
+	fs := flag.NewFlagSet("reflect", flag.ContinueOnError)
+	// ... existing flags ...
+	source := fs.String("source", "", "host source for CLI selection")
+	// ... parse ...
+
+	// Source-aware auto tier: use matching CLI, skip API entirely
+	if *tier == "auto" && *source != "" {
+		sp := ai.NewSourceProviderForSource(*source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary)
+		if sp.Available() {
+			tiers = []reflection.Consolidator{
+				reflection.NewNamedConsolidator(sp, sp.Name()),
+			}
+			if !requireLLM {
+				tiers = append(tiers, reflection.NewSQLiteConsolidator())
+			}
+		}
+		// If not available, fall through to standard auto logic
+	}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./cmd/ghost/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/ghost/main.go
+git commit -s -m "feat(ghost): add --source flag to reflect/resolve/supersede for source-aware LLM routing"
+```
+
+---
+
+## Task 4: Verify end-to-end
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `go test ./...`
+Expected: PASS
+
+- [ ] **Step 2: Run linter**
+
+Run: `go vet ./...`
+Expected: PASS
+
+- [ ] **Step 3: Verify on mr-slave**
+
+Deploy to mr-slave and test with opencode session. Verify that:
+1. `ghost resolve` with `--source opencode` uses opencode subprocess
+2. Stop hook passes source to reflect/resolve/supersede spawns
+3. No Anthropic API key needed when source is set
+
+- [ ] **Step 4: Final commit if needed**
+
+```bash
+git commit -s -m "chore: verify source-aware provider selection"
+```

--- a/internal/ai/cli_client.go
+++ b/internal/ai/cli_client.go
@@ -70,7 +70,7 @@ func (c *CLIClient) run(ctx context.Context, prompt string, extraArgs ...string)
 	args := append([]string{"-p", "--setting-sources", "project,local"}, extraArgs...)
 	args = append(args, prompt)
 	cmd := exec.CommandContext(ctx, c.binary, args...)
-	cmd.Env = stripAPIKey(os.Environ())
+	cmd.Env = stripLLMKeys(os.Environ())
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -85,6 +85,27 @@ func stripAPIKey(env []string) []string {
 	for _, kv := range env {
 		key, _, found := strings.Cut(kv, "=")
 		if found && strings.EqualFold(key, "ANTHROPIC_API_KEY") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+// stripLLMKeys strips API keys for all LLM providers from the environment,
+// preventing the subprocess from billing to the wrong account.
+func stripLLMKeys(env []string) []string {
+	out := stripAPIKey(env)
+	out = stripEnvKey(out, "OPENAI_API_KEY")
+	out = stripEnvKey(out, "GOOSE_PROVIDER__API_KEY")
+	return out
+}
+
+func stripEnvKey(env []string, key string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		k, _, found := strings.Cut(kv, "=")
+		if found && strings.EqualFold(k, key) {
 			continue
 		}
 		out = append(out, kv)

--- a/internal/ai/cli_provider.go
+++ b/internal/ai/cli_provider.go
@@ -27,14 +27,14 @@ type CLIProvider struct {
 // NewCLIProvider picks the best backend available on PATH: claude if present,
 // else opencode if present, else an unavailable provider.
 func NewCLIProvider() *CLIProvider {
-	return NewCLIProviderWithBinaries("", "")
+	return NewCLIProviderWithBinaries("", "", "", "")
 }
 
 // NewCLIProviderWithBinaries is NewCLIProvider with explicit binary paths.
-// claudeBinary/opencodeBinary override the PATH lookup when set (and resolvable),
-// so a binary installed outside the current process's PATH still wins; an empty
-// value falls back to the PATH lookup for that backend.
-func NewCLIProviderWithBinaries(claudeBinary, opencodeBinary string) *CLIProvider {
+// Binary paths override the PATH lookup when set (and resolvable), so a binary
+// installed outside the current process's PATH still wins; an empty value falls
+// back to the PATH lookup for that backend. Priority: claude > opencode > codex > goose.
+func NewCLIProviderWithBinaries(claudeBinary, opencodeBinary, codexBinary, gooseBinary string) *CLIProvider {
 	if claudeBinary != "" {
 		if _, err := exec.LookPath(claudeBinary); err == nil {
 			return &CLIProvider{backend: NewCLIClientWithBinary(claudeBinary), name: "cli"}
@@ -50,6 +50,22 @@ func NewCLIProviderWithBinaries(claudeBinary, opencodeBinary string) *CLIProvide
 	}
 	if _, err := exec.LookPath("opencode"); err == nil {
 		return &CLIProvider{backend: NewOpenCodeClient(), name: "opencode"}
+	}
+	if codexBinary != "" {
+		if _, err := exec.LookPath(codexBinary); err == nil {
+			return &CLIProvider{backend: NewCodexClientWithBinary(codexBinary), name: "codex"}
+		}
+	}
+	if _, err := exec.LookPath("codex"); err == nil {
+		return &CLIProvider{backend: NewCodexClient(), name: "codex"}
+	}
+	if gooseBinary != "" {
+		if _, err := exec.LookPath(gooseBinary); err == nil {
+			return &CLIProvider{backend: NewGooseClientWithBinary(gooseBinary), name: "goose"}
+		}
+	}
+	if _, err := exec.LookPath("goose"); err == nil {
+		return &CLIProvider{backend: NewGooseClient(), name: "goose"}
 	}
 	return &CLIProvider{backend: nil, name: "none"}
 }

--- a/internal/ai/cli_provider_test.go
+++ b/internal/ai/cli_provider_test.go
@@ -80,7 +80,7 @@ func TestCLIProviderWithBinaries_UsesExplicitOpenCodePath(t *testing.T) {
 	writeFake(t, dir, "opencode")
 	t.Setenv("PATH", t.TempDir()) // empty PATH: nothing resolvable by name
 
-	p := NewCLIProviderWithBinaries("", filepath.Join(dir, "opencode"))
+	p := NewCLIProviderWithBinaries("", filepath.Join(dir, "opencode"), "", "")
 	if !p.Available() {
 		t.Fatal("expected available via explicit opencode path")
 	}
@@ -94,7 +94,7 @@ func TestCLIProviderWithBinaries_UsesExplicitClaudePath(t *testing.T) {
 	writeFake(t, dir, "claude")
 	t.Setenv("PATH", t.TempDir())
 
-	p := NewCLIProviderWithBinaries(filepath.Join(dir, "claude"), "")
+	p := NewCLIProviderWithBinaries(filepath.Join(dir, "claude"), "", "", "")
 	if !p.Available() {
 		t.Fatal("expected available via explicit claude path")
 	}
@@ -110,7 +110,7 @@ func TestCLIProviderWithBinaries_FallsBackToPathWhenOverrideMissing(t *testing.T
 
 	// Explicit claude path is missing, so fall back to the PATH lookup, which
 	// finds opencode.
-	p := NewCLIProviderWithBinaries(filepath.Join(dir, "no-such-claude"), "")
+	p := NewCLIProviderWithBinaries(filepath.Join(dir, "no-such-claude"), "", "", "")
 	if !p.Available() {
 		t.Fatal("expected available via PATH fallback")
 	}

--- a/internal/ai/codex_client.go
+++ b/internal/ai/codex_client.go
@@ -1,0 +1,50 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type CodexClient struct {
+	binary string
+}
+
+func NewCodexClient() *CodexClient {
+	return NewCodexClientWithBinary("codex")
+}
+
+func NewCodexClientWithBinary(binary string) *CodexClient {
+	return &CodexClient{binary: binary}
+}
+
+func (c *CodexClient) Reflect(ctx context.Context, prompt string) (string, TokenUsage, error) {
+	text, err := c.run(ctx, prompt)
+	return text, TokenUsage{}, err
+}
+
+func (c *CodexClient) Classify(ctx context.Context, systemPrompt, userContent string) (string, error) {
+	return c.run(ctx, systemPrompt+"\n\n"+userContent)
+}
+
+func (c *CodexClient) run(ctx context.Context, prompt string) (string, error) {
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultTimeout)
+		defer cancel()
+	}
+	args := []string{"exec", "--sandbox", "read-only"}
+	args = append(args, prompt)
+	cmd := exec.CommandContext(ctx, c.binary, args...)
+	cmd.Env = stripLLMKeys(os.Environ())
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("codex exec: %w: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}

--- a/internal/ai/goose_client.go
+++ b/internal/ai/goose_client.go
@@ -1,0 +1,50 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type GooseClient struct {
+	binary string
+}
+
+func NewGooseClient() *GooseClient {
+	return NewGooseClientWithBinary("goose")
+}
+
+func NewGooseClientWithBinary(binary string) *GooseClient {
+	return &GooseClient{binary: binary}
+}
+
+func (c *GooseClient) Reflect(ctx context.Context, prompt string) (string, TokenUsage, error) {
+	text, err := c.run(ctx, prompt)
+	return text, TokenUsage{}, err
+}
+
+func (c *GooseClient) Classify(ctx context.Context, systemPrompt, userContent string) (string, error) {
+	return c.run(ctx, systemPrompt+"\n\n"+userContent)
+}
+
+func (c *GooseClient) run(ctx context.Context, prompt string) (string, error) {
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultTimeout)
+		defer cancel()
+	}
+	args := []string{"run", "-q"}
+	args = append(args, prompt)
+	cmd := exec.CommandContext(ctx, c.binary, args...)
+	cmd.Env = stripLLMKeys(os.Environ())
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("goose run: %w: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}

--- a/internal/ai/opencode_client.go
+++ b/internal/ai/opencode_client.go
@@ -104,7 +104,7 @@ func (c *OpenCodeClient) subprocessEnv() ([]string, func(), error) {
 		env = append(env, kv)
 	}
 	env = append(env, "XDG_CONFIG_HOME="+scratch)
-	return stripAPIKey(env), func() { _ = os.RemoveAll(scratch) }, nil
+	return stripLLMKeys(env), func() { _ = os.RemoveAll(scratch) }, nil
 }
 
 // opencodeEvent is the minimal shape of one JSON line in `opencode run --format

--- a/internal/ai/source_provider.go
+++ b/internal/ai/source_provider.go
@@ -1,0 +1,85 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+)
+
+var errUnknownSource = errors.New("unknown source: no CLI backend available for this host")
+
+type SourceProvider struct {
+	backend cliBackend
+	name    string
+}
+
+// NewSourceProviderForSource returns a provider matching the host source.
+// Empty/unknown source falls back to best-available-on-PATH.
+func NewSourceProviderForSource(source string, cfgBinaries ...string) *SourceProvider {
+	claudeBin, opencodeBin := "", ""
+	if len(cfgBinaries) > 0 {
+		claudeBin = cfgBinaries[0]
+	}
+	if len(cfgBinaries) > 1 {
+		opencodeBin = cfgBinaries[1]
+	}
+	switch source {
+	case "claude-code":
+		return resolveCLI(claudeBin, "claude", "cli")
+	case "opencode":
+		return resolveCLI(opencodeBin, "opencode", "opencode")
+	case "codex":
+		// Codex doesn't have a Reflect/Classify-compatible CLI yet.
+		// Fall back to best available (same as unknown source).
+		return fallbackCLI(claudeBin, opencodeBin)
+	case "goose":
+		// Goose doesn't have a Reflect/Classify-compatible CLI yet.
+		return fallbackCLI(claudeBin, opencodeBin)
+	default:
+		return fallbackCLI(claudeBin, opencodeBin)
+	}
+}
+
+// resolveCLI resolves a specific CLI backend for the given source. Unlike
+// fallbackCLI, it does NOT cascade to other binaries — if the source-specific
+// binary isn't found, the provider is unavailable. This is intentional: when
+// the user's session used claude, we should use claude, not silently switch
+// to opencode.
+func resolveCLI(configured, defaultName, providerName string) *SourceProvider {
+	bin := configured
+	if bin == "" {
+		bin = defaultName
+	}
+	if _, err := exec.LookPath(bin); err != nil {
+		return &SourceProvider{backend: nil, name: "none"}
+	}
+	switch providerName {
+	case "cli":
+		return &SourceProvider{backend: NewCLIClientWithBinary(bin), name: "cli"}
+	case "opencode":
+		return &SourceProvider{backend: NewOpenCodeClientWithBinary(bin), name: "opencode"}
+	}
+	return &SourceProvider{backend: nil, name: "none"}
+}
+
+func fallbackCLI(claudeBin, opencodeBin string) *SourceProvider {
+	p := NewCLIProviderWithBinaries(claudeBin, opencodeBin)
+	return &SourceProvider{backend: p.backend, name: p.name}
+}
+
+func (p *SourceProvider) Name() string    { return p.name }
+func (p *SourceProvider) Available() bool { return p.backend != nil }
+
+func (p *SourceProvider) Reflect(ctx context.Context, prompt string) (string, TokenUsage, error) {
+	if p.backend == nil {
+		return "", TokenUsage{}, errUnknownSource
+	}
+	return p.backend.Reflect(ctx, prompt)
+}
+
+func (p *SourceProvider) Classify(ctx context.Context, systemPrompt, userContent string) (string, error) {
+	if p.backend == nil {
+		return "", errUnknownSource
+	}
+	return p.backend.Classify(ctx, systemPrompt, userContent)
+}

--- a/internal/ai/source_provider.go
+++ b/internal/ai/source_provider.go
@@ -16,12 +16,18 @@ type SourceProvider struct {
 // NewSourceProviderForSource returns a provider matching the host source.
 // Empty/unknown source falls back to best-available-on-PATH.
 func NewSourceProviderForSource(source string, cfgBinaries ...string) *SourceProvider {
-	claudeBin, opencodeBin := "", ""
+	var claudeBin, opencodeBin, codexBin, gooseBin string
 	if len(cfgBinaries) > 0 {
 		claudeBin = cfgBinaries[0]
 	}
 	if len(cfgBinaries) > 1 {
 		opencodeBin = cfgBinaries[1]
+	}
+	if len(cfgBinaries) > 2 {
+		codexBin = cfgBinaries[2]
+	}
+	if len(cfgBinaries) > 3 {
+		gooseBin = cfgBinaries[3]
 	}
 	switch source {
 	case "claude-code":
@@ -29,14 +35,11 @@ func NewSourceProviderForSource(source string, cfgBinaries ...string) *SourcePro
 	case "opencode":
 		return resolveCLI(opencodeBin, "opencode", "opencode")
 	case "codex":
-		// Codex doesn't have a Reflect/Classify-compatible CLI yet.
-		// Fall back to best available (same as unknown source).
-		return fallbackCLI(claudeBin, opencodeBin)
+		return resolveCLI(codexBin, "codex", "codex")
 	case "goose":
-		// Goose doesn't have a Reflect/Classify-compatible CLI yet.
-		return fallbackCLI(claudeBin, opencodeBin)
+		return resolveCLI(gooseBin, "goose", "goose")
 	default:
-		return fallbackCLI(claudeBin, opencodeBin)
+		return fallbackCLI(claudeBin, opencodeBin, codexBin, gooseBin)
 	}
 }
 
@@ -58,12 +61,16 @@ func resolveCLI(configured, defaultName, providerName string) *SourceProvider {
 		return &SourceProvider{backend: NewCLIClientWithBinary(bin), name: "cli"}
 	case "opencode":
 		return &SourceProvider{backend: NewOpenCodeClientWithBinary(bin), name: "opencode"}
+	case "codex":
+		return &SourceProvider{backend: NewCodexClientWithBinary(bin), name: "codex"}
+	case "goose":
+		return &SourceProvider{backend: NewGooseClientWithBinary(bin), name: "goose"}
 	}
 	return &SourceProvider{backend: nil, name: "none"}
 }
 
-func fallbackCLI(claudeBin, opencodeBin string) *SourceProvider {
-	p := NewCLIProviderWithBinaries(claudeBin, opencodeBin)
+func fallbackCLI(claudeBin, opencodeBin, codexBin, gooseBin string) *SourceProvider {
+	p := NewCLIProviderWithBinaries(claudeBin, opencodeBin, codexBin, gooseBin)
 	return &SourceProvider{backend: p.backend, name: p.name}
 }
 

--- a/internal/ai/source_provider_test.go
+++ b/internal/ai/source_provider_test.go
@@ -1,0 +1,68 @@
+package ai
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSourceProviderForSource(t *testing.T) {
+	dir := t.TempDir()
+	claude := filepath.Join(dir, "claude")
+	opencode := filepath.Join(dir, "opencode")
+	if err := os.WriteFile(claude, []byte("#!/bin/sh\nexit 0"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(opencode, []byte("#!/bin/sh\nexit 0"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		source string
+		name   string
+		ok     bool
+	}{
+		{"claude-code", "cli", true},
+		{"opencode", "opencode", true},
+		{"codex", "cli", true},         // no codex CLI impl yet — falls back to claude
+		{"goose", "cli", true},         // no goose CLI impl yet — falls back to claude
+		{"unknown-source", "cli", true}, // falls back to claude
+	}
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			p := NewSourceProviderForSource(tt.source, claude, opencode)
+			if p.Name() != tt.name {
+				t.Errorf("Name() = %q, want %q", p.Name(), tt.name)
+			}
+			if !p.Available() {
+				t.Error("expected available")
+			}
+		})
+	}
+}
+
+func TestSourceProviderUnavailable(t *testing.T) {
+	p := NewSourceProviderForSource("claude-code", "/nonexistent/claude")
+	if p.Available() {
+		t.Error("expected unavailable when binary not found")
+	}
+	if p.Name() != "none" {
+		t.Errorf("Name() = %q, want %q", p.Name(), "none")
+	}
+	_, _, err := p.Reflect(t.Context(), "test")
+	if err != errUnknownSource {
+		t.Errorf("expected errUnknownSource from Reflect, got %v", err)
+	}
+	_, err = p.Classify(t.Context(), "sys", "user")
+	if err != errUnknownSource {
+		t.Errorf("expected errUnknownSource from Classify, got %v", err)
+	}
+}
+
+func TestSourceProviderClassify(t *testing.T) {
+	p := &SourceProvider{backend: nil, name: "none"}
+	_, err := p.Classify(t.Context(), "sys", "user")
+	if err != errUnknownSource {
+		t.Errorf("expected errUnknownSource, got %v", err)
+	}
+}

--- a/internal/ai/source_provider_test.go
+++ b/internal/ai/source_provider_test.go
@@ -10,10 +10,18 @@ func TestSourceProviderForSource(t *testing.T) {
 	dir := t.TempDir()
 	claude := filepath.Join(dir, "claude")
 	opencode := filepath.Join(dir, "opencode")
+	codex := filepath.Join(dir, "codex")
+	goose := filepath.Join(dir, "goose")
 	if err := os.WriteFile(claude, []byte("#!/bin/sh\nexit 0"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(opencode, []byte("#!/bin/sh\nexit 0"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(codex, []byte("#!/bin/sh\nexit 0"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(goose, []byte("#!/bin/sh\nexit 0"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -24,13 +32,13 @@ func TestSourceProviderForSource(t *testing.T) {
 	}{
 		{"claude-code", "cli", true},
 		{"opencode", "opencode", true},
-		{"codex", "cli", true},         // no codex CLI impl yet — falls back to claude
-		{"goose", "cli", true},         // no goose CLI impl yet — falls back to claude
+		{"codex", "codex", true},
+		{"goose", "goose", true},
 		{"unknown-source", "cli", true}, // falls back to claude
 	}
 	for _, tt := range tests {
 		t.Run(tt.source, func(t *testing.T) {
-			p := NewSourceProviderForSource(tt.source, claude, opencode)
+			p := NewSourceProviderForSource(tt.source, claude, opencode, codex, goose)
 			if p.Name() != tt.name {
 				t.Errorf("Name() = %q, want %q", p.Name(), tt.name)
 			}
@@ -64,5 +72,35 @@ func TestSourceProviderClassify(t *testing.T) {
 	_, err := p.Classify(t.Context(), "sys", "user")
 	if err != errUnknownSource {
 		t.Errorf("expected errUnknownSource, got %v", err)
+	}
+}
+
+func TestSourceProviderCodexRoutesToRealBackend(t *testing.T) {
+	dir := t.TempDir()
+	codex := filepath.Join(dir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/bin/sh\nexit 0"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := NewSourceProviderForSource("codex", "", "", codex, "")
+	if p.Name() != "codex" {
+		t.Errorf("Name() = %q, want %q", p.Name(), "codex")
+	}
+	if !p.Available() {
+		t.Error("expected available")
+	}
+}
+
+func TestSourceProviderGooseRoutesToRealBackend(t *testing.T) {
+	dir := t.TempDir()
+	goose := filepath.Join(dir, "goose")
+	if err := os.WriteFile(goose, []byte("#!/bin/sh\nexit 0"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := NewSourceProviderForSource("goose", "", "", "", goose)
+	if p.Name() != "goose" {
+		t.Errorf("Name() = %q, want %q", p.Name(), "goose")
+	}
+	if !p.Available() {
+		t.Error("expected available")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,8 @@ type APIConfig struct {
 type CLIConfig struct {
 	ClaudeBinary   string `koanf:"claude_binary"`
 	OpenCodeBinary string `koanf:"opencode_binary"`
+	CodexBinary    string `koanf:"codex_binary"`
+	GooseBinary    string `koanf:"goose_binary"`
 }
 
 // ReflectionConfig holds memory consolidation settings.
@@ -91,6 +93,8 @@ var defaults = map[string]interface{}{
 	"reflection.auto_reflect":    false,
 	"cli.claude_binary":          "",
 	"cli.opencode_binary":        "",
+	"cli.codex_binary":           "",
+	"cli.goose_binary":           "",
 	"linking.enabled":            true,
 	"linking.threshold":          0.70,
 	"linking.demotion_threshold": 0.90,
@@ -143,6 +147,8 @@ func Load() (*Config, error) {
 		"GHOST_OBSIDIAN_VAULT_DIR":        "obsidian.vault_dir",
 		"GHOST_CLI_CLAUDE_BINARY":         "cli.claude_binary",
 		"GHOST_CLI_OPENCODE_BINARY":       "cli.opencode_binary",
+		"GHOST_CLI_CODEX_BINARY":          "cli.codex_binary",
+		"GHOST_CLI_GOOSE_BINARY":          "cli.goose_binary",
 		"GHOST_REFLECTION_AUTO_REFLECT":   "reflection.auto_reflect",
 		"GHOST_REFLECTION_AUTO_RESOLVE":   "reflection.auto_resolve",
 		"GHOST_REFLECTION_AUTO_SUPERSEDE": "reflection.auto_supersede",

--- a/internal/mcpinit/stophook.go
+++ b/internal/mcpinit/stophook.go
@@ -340,6 +340,7 @@ func spawnReflectIfConfigured(cwd, source string) {
 	if cfg.API.Key == "" && !ai.NewCLIProviderWithBinaries(cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary, cfg.CLI.CodexBinary, cfg.CLI.GooseBinary).Available() {
 		sp := ai.NewSourceProviderForSource(source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary, cfg.CLI.CodexBinary, cfg.CLI.GooseBinary)
 		if !sp.Available() {
+			slog.Warn("reflect: skipping — no CLI binary available", "source", source)
 			return
 		}
 	}

--- a/internal/mcpinit/stophook.go
+++ b/internal/mcpinit/stophook.go
@@ -94,9 +94,10 @@ func runStop(p hostevent.Payload, stdout io.Writer, stderr io.Writer, nudge bool
 		return
 	}
 
-	spawnResolveIfConfigured(p.CWD)
-	spawnSupersedeIfConfigured(p.CWD)
-	spawnReflectIfConfigured(p.CWD)
+	source := string(p.HostSource())
+	spawnResolveIfConfigured(p.CWD, source)
+	spawnSupersedeIfConfigured(p.CWD, source)
+	spawnReflectIfConfigured(p.CWD, source)
 
 	if !nudge || p.TranscriptPath == "" {
 		return
@@ -167,7 +168,7 @@ func cleanupTransientTranscript(p hostevent.Payload) {
 // Known limitation: resolution here depends on Store.ResolveProject's
 // path/basename match against the stored project row; a cwd with no matching
 // project is a silent no-op, same as an unconfigured user.
-func spawnResolveIfConfigured(cwd string) {
+func spawnResolveIfConfigured(cwd, source string) {
 	if cwd == "" {
 		return
 	}
@@ -222,6 +223,9 @@ func spawnResolveIfConfigured(cwd string) {
 	defer logFile.Close() //nolint:errcheck
 
 	cmd := exec.Command(exe, "resolve", projectName, "--apply")
+	if source != "" {
+		cmd.Args = append(cmd.Args, "--source", source)
+	}
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	detachProcess(cmd)
@@ -244,7 +248,7 @@ func spawnResolveIfConfigured(cwd string) {
 // Known limitation: resolution here depends on Store.ResolveProject's
 // path/basename match against the stored project row; a cwd with no matching
 // project is a silent no-op, same as an unconfigured user.
-func spawnSupersedeIfConfigured(cwd string) {
+func spawnSupersedeIfConfigured(cwd, source string) {
 	if cwd == "" {
 		return
 	}
@@ -299,6 +303,9 @@ func spawnSupersedeIfConfigured(cwd string) {
 	defer logFile.Close() //nolint:errcheck
 
 	cmd := exec.Command(exe, "supersede", projectName, "--apply")
+	if source != "" {
+		cmd.Args = append(cmd.Args, "--source", source)
+	}
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	detachProcess(cmd)
@@ -322,7 +329,7 @@ func spawnSupersedeIfConfigured(cwd string) {
 // Jaccard-only sqlite tier and rewrite every non-manual memory for no quality
 // gain, so the spawn is skipped entirely — before the DB is even opened, so
 // this stays a cheap read-only no-op.
-func spawnReflectIfConfigured(cwd string) {
+func spawnReflectIfConfigured(cwd, source string) {
 	if cwd == "" {
 		return
 	}
@@ -331,7 +338,10 @@ func spawnReflectIfConfigured(cwd string) {
 		return
 	}
 	if cfg.API.Key == "" && !ai.NewCLIProviderWithBinaries(cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary).Available() {
-		return
+		sp := ai.NewSourceProviderForSource(source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary)
+		if !sp.Available() {
+			return
+		}
 	}
 
 	dataDir, err := config.DataDir()
@@ -373,6 +383,9 @@ func spawnReflectIfConfigured(cwd string) {
 	defer logFile.Close() //nolint:errcheck
 
 	cmd := exec.Command(exe, "reflect", projectName, "--apply", "--require-llm")
+	if source != "" {
+		cmd.Args = append(cmd.Args, "--source", source)
+	}
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	detachProcess(cmd)

--- a/internal/mcpinit/stophook.go
+++ b/internal/mcpinit/stophook.go
@@ -337,8 +337,8 @@ func spawnReflectIfConfigured(cwd, source string) {
 	if err != nil || !cfg.Reflection.AutoReflect {
 		return
 	}
-	if cfg.API.Key == "" && !ai.NewCLIProviderWithBinaries(cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary).Available() {
-		sp := ai.NewSourceProviderForSource(source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary)
+	if cfg.API.Key == "" && !ai.NewCLIProviderWithBinaries(cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary, cfg.CLI.CodexBinary, cfg.CLI.GooseBinary).Available() {
+		sp := ai.NewSourceProviderForSource(source, cfg.CLI.ClaudeBinary, cfg.CLI.OpenCodeBinary, cfg.CLI.CodexBinary, cfg.CLI.GooseBinary)
 		if !sp.Available() {
 			return
 		}

--- a/internal/mcpinit/stophook_test.go
+++ b/internal/mcpinit/stophook_test.go
@@ -355,7 +355,7 @@ func TestSpawnResolveIfConfigured_NoOpWhenDisabled(t *testing.T) {
 	// ghost.db, the pidfile, or resolve.log.
 	dataHome := isolatedHome(t)
 
-	spawnResolveIfConfigured("/tmp/does-not-matter")
+	spawnResolveIfConfigured("/tmp/does-not-matter", "")
 
 	if _, err := os.Stat(filepath.Join(dataHome, "ghost")); !os.IsNotExist(err) {
 		t.Errorf("expected ghost data dir to never be created when auto_resolve is disabled, stat err = %v", err)
@@ -370,7 +370,7 @@ func TestSpawnSupersedeIfConfigured_NoOpWhenDisabled(t *testing.T) {
 	// ghost.db, the pidfile, or supersede.log.
 	dataHome := isolatedHome(t)
 
-	spawnSupersedeIfConfigured("/tmp/does-not-matter")
+	spawnSupersedeIfConfigured("/tmp/does-not-matter", "")
 
 	if _, err := os.Stat(filepath.Join(dataHome, "ghost")); !os.IsNotExist(err) {
 		t.Errorf("expected ghost data dir to never be created when auto_supersede is disabled, stat err = %v", err)
@@ -385,7 +385,7 @@ func TestSpawnReflectIfConfigured_NoOpWhenDisabled(t *testing.T) {
 	// pidfile, or reflect.log.
 	dataHome := isolatedHome(t)
 
-	spawnReflectIfConfigured("/tmp/does-not-matter")
+	spawnReflectIfConfigured("/tmp/does-not-matter", "")
 
 	if _, err := os.Stat(filepath.Join(dataHome, "ghost")); !os.IsNotExist(err) {
 		t.Errorf("expected ghost data dir to never be created when auto_reflect is disabled, stat err = %v", err)
@@ -406,7 +406,7 @@ func TestSpawnReflectIfConfigured_NoOpWithoutLLM(t *testing.T) {
 	}
 	t.Setenv("PATH", t.TempDir()) // no claude, no opencode
 
-	spawnReflectIfConfigured("/tmp/does-not-matter")
+	spawnReflectIfConfigured("/tmp/does-not-matter", "")
 
 	if _, err := os.Stat(filepath.Join(dataHome, "ghost")); !os.IsNotExist(err) {
 		t.Errorf("expected no ghost data dir when no LLM is available, stat err = %v", err)


### PR DESCRIPTION
## Summary

Source-aware LLM provider selection: the stop hook now routes reflect/resolve/supersede through the same CLI backend the user was paying for in their session, instead of always defaulting to .

## What changed

- **SourceProvider** maps host source strings (claude-code, opencode, codex, goose) to their matching CLI subprocess
- **Stop hook** extracts source from contract envelope and passes `--source` to spawned processes
- **`--source` flag** added to reflect, resolve, and supersede commands
- **CodexClient** (`codex exec --sandbox read-only`) and **GooseClient** (`goose run -q`) backends added
- Config fields: `cli.codex_binary`, `cli.goose_binary` (env: `GHOST_CLI_CODEX_BINARY`, `GHOST_CLI_GOOSE_BINARY`)
- All LLM API keys stripped from subprocess env to prevent double-billing

## Source → CLI mapping

| Source | Backend | Command |
|--------|---------|---------|
| claude-code | CLIClient | `claude -p --setting-sources project,local` |
| opencode | OpenCodeClient | `opencode run --format json --pure` |
| codex | CodexClient | `codex exec --sandbox read-only` |
| goose | GooseClient | `goose run -q` |

Unknown/empty source falls back to best-available-on-PATH (claude > opencode > codex > goose).