### PR TITLE
fix(mcp): quiet stderr for client-spawned sessions

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -101,7 +101,10 @@ func runMCP() {
 		fmt.Fprintln(os.Stderr, "To set up the integration, run: ghost mcp init")
 		fmt.Fprintln(os.Stderr, "")
 	}
-	logWriter, logLevel := mcpLogConfig(isTerminalFile(os.Stderr))
+	logWriter, logLevel, closeLog := mcpLogConfig(isTerminalFile(os.Stderr))
+	if closeLog != nil {
+		defer closeLog()
+	}
 	cfg, logger, store := bootstrap(logWriter, logLevel)
 	defer store.Close() //nolint:errcheck
 
@@ -1389,10 +1392,12 @@ func bootstrap(logWriter io.Writer, logLevel slog.Level) (*config.Config, *slog.
 // server is spawned by a client (stderr not a terminal), routine INFO logs
 // are dropped and only WARN+ reaches stderr, unless GHOST_LOG_FILE redirects
 // the full stream to a file. Interactive runs (stderr is a terminal) keep
-// INFO on stderr. GHOST_DEBUG always restores Debug level.
-func mcpLogConfig(stderrTerminal bool) (io.Writer, slog.Level) {
+// INFO on stderr. GHOST_DEBUG always restores Debug level. The returned
+// closeLog is non-nil when a file was opened and must be called on shutdown.
+func mcpLogConfig(stderrTerminal bool) (io.Writer, slog.Level, func()) {
 	level := slog.LevelInfo
 	writer := io.Writer(os.Stderr)
+	var closeLog func()
 
 	if path := os.Getenv("GHOST_LOG_FILE"); path != "" {
 		if f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644); err != nil {
@@ -1402,6 +1407,7 @@ func mcpLogConfig(stderrTerminal bool) (io.Writer, slog.Level) {
 			}
 		} else {
 			writer = f
+			closeLog = func() { _ = f.Close() }
 		}
 	} else if !stderrTerminal {
 		level = slog.LevelWarn
@@ -1410,7 +1416,7 @@ func mcpLogConfig(stderrTerminal bool) (io.Writer, slog.Level) {
 	if os.Getenv("GHOST_DEBUG") != "" {
 		level = slog.LevelDebug
 	}
-	return writer, level
+	return writer, level, closeLog
 }
 
 // cliLogLevel is the stderr log level for interactive CLI commands: Info,

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -1397,6 +1397,9 @@ func mcpLogConfig(stderrTerminal bool) (io.Writer, slog.Level) {
 	if path := os.Getenv("GHOST_LOG_FILE"); path != "" {
 		if f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: cannot open GHOST_LOG_FILE %q: %v\n", path, err)
+			if !stderrTerminal {
+				level = slog.LevelWarn
+			}
 		} else {
 			writer = f
 		}

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -101,7 +101,8 @@ func runMCP() {
 		fmt.Fprintln(os.Stderr, "To set up the integration, run: ghost mcp init")
 		fmt.Fprintln(os.Stderr, "")
 	}
-	cfg, logger, store := bootstrap()
+	logWriter, logLevel := mcpLogConfig(isTerminalFile(os.Stderr))
+	cfg, logger, store := bootstrap(logWriter, logLevel)
 	defer store.Close() //nolint:errcheck
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -389,7 +390,7 @@ Flags:
 		os.Exit(1)
 	}
 
-	cfg, logger, store := bootstrap()
+	cfg, logger, store := bootstrap(os.Stderr, cliLogLevel())
 	defer store.Close() //nolint:errcheck
 
 	ctx := context.Background()
@@ -742,7 +743,7 @@ cli.opencode_binary) — requires one of the two.`)
 		os.Exit(1)
 	}
 
-	cfg, logger, store := bootstrap()
+	cfg, logger, store := bootstrap(os.Stderr, cliLogLevel())
 	defer store.Close() //nolint:errcheck
 	ctx := context.Background()
 
@@ -824,7 +825,7 @@ cli.claude_binary / cli.opencode_binary) — requires one of the two.`)
 		os.Exit(1)
 	}
 
-	cfg, logger, store := bootstrap()
+	cfg, logger, store := bootstrap(os.Stderr, cliLogLevel())
 	defer store.Close() //nolint:errcheck
 	ctx := context.Background()
 
@@ -981,7 +982,7 @@ Irreversible. Refuses to delete _global.`)
 		os.Exit(1)
 	}
 
-	_, _, store := bootstrap()
+	_, _, store := bootstrap(os.Stderr, cliLogLevel())
 	defer store.Close() //nolint:errcheck
 	ctx := context.Background()
 
@@ -1341,12 +1342,18 @@ func runBench() {
 	fmt.Print(bench.FormatResults(results))
 }
 
-func bootstrap() (*config.Config, *slog.Logger, *memory.Store) {
+// bootstrap loads config, opens the database, and returns the wiring every
+// command shares. logWriter/logLevel come from the caller: interactive CLI
+// commands log INFO to stderr, while the MCP server resolves a quiet default
+// (see mcpLogConfig) so stderr stays clean for MCP clients that surface it.
+func bootstrap(logWriter io.Writer, logLevel slog.Level) (*config.Config, *slog.Logger, *memory.Store) {
+	logger := slog.New(slog.NewTextHandler(logWriter, &slog.HandlerOptions{Level: logLevel}))
+
 	configPath, created, err := config.EnsureConfigFile()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: could not create config file: %v\n", err)
+		logger.Warn("could not create config file", "error", err)
 	} else if created {
-		fmt.Fprintf(os.Stderr, "Created config file: %s\n", configPath)
+		logger.Info("created config file", "path", configPath)
 	}
 
 	cfg, err := config.Load()
@@ -1354,12 +1361,6 @@ func bootstrap() (*config.Config, *slog.Logger, *memory.Store) {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-
-	logLevel := slog.LevelInfo
-	if os.Getenv("GHOST_DEBUG") != "" {
-		logLevel = slog.LevelDebug
-	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
 
 	dataDir, err := config.DataDir()
 	if err != nil {
@@ -1383,9 +1384,49 @@ func bootstrap() (*config.Config, *slog.Logger, *memory.Store) {
 	return cfg, logger, store
 }
 
+// mcpLogConfig resolves the log writer and minimum level for `ghost mcp`.
+// MCP protocol traffic occupies stdout, so stderr must stay clean: when the
+// server is spawned by a client (stderr not a terminal), routine INFO logs
+// are dropped and only WARN+ reaches stderr, unless GHOST_LOG_FILE redirects
+// the full stream to a file. Interactive runs (stderr is a terminal) keep
+// INFO on stderr. GHOST_DEBUG always restores Debug level.
+func mcpLogConfig(stderrTerminal bool) (io.Writer, slog.Level) {
+	level := slog.LevelInfo
+	writer := io.Writer(os.Stderr)
+
+	if path := os.Getenv("GHOST_LOG_FILE"); path != "" {
+		if f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: cannot open GHOST_LOG_FILE %q: %v\n", path, err)
+		} else {
+			writer = f
+		}
+	} else if !stderrTerminal {
+		level = slog.LevelWarn
+	}
+
+	if os.Getenv("GHOST_DEBUG") != "" {
+		level = slog.LevelDebug
+	}
+	return writer, level
+}
+
+// cliLogLevel is the stderr log level for interactive CLI commands: Info,
+// or Debug when GHOST_DEBUG is set.
+func cliLogLevel() slog.Level {
+	if os.Getenv("GHOST_DEBUG") != "" {
+		return slog.LevelDebug
+	}
+	return slog.LevelInfo
+}
+
 // isTerminal reports whether stdin is connected to a terminal.
 func isTerminal() bool {
-	fi, err := os.Stdin.Stat()
+	return isTerminalFile(os.Stdin)
+}
+
+// isTerminalFile reports whether f is connected to a terminal.
+func isTerminalFile(f *os.File) bool {
+	fi, err := f.Stat()
 	if err != nil {
 		return false
 	}

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -546,3 +546,22 @@ func TestMCPLogConfig_DebugWins(t *testing.T) {
 		t.Fatalf("level = %v, want Debug", level)
 	}
 }
+
+// TestMCPLogConfig_UnopenableFileFallsBackQuiet: a GHOST_LOG_FILE that cannot
+// be opened must not silently restore INFO logging to stderr in client-spawned
+// mode — that would leak the very noise the quiet default removes.
+func TestMCPLogConfig_UnopenableFileFallsBackQuiet(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "adir")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GHOST_LOG_FILE", dir) // existing directory: open for write fails
+	t.Setenv("GHOST_DEBUG", "")
+	writer, level := mcpLogConfig(false)
+	if level != slog.LevelWarn {
+		t.Fatalf("level = %v, want Warn (quiet fallback)", level)
+	}
+	if writer != io.Writer(os.Stderr) {
+		t.Fatal("writer must fall back to stderr")
+	}
+}

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -490,24 +490,30 @@ func targetNames(targets []clientTarget) []string {
 func TestMCPLogConfig_QuietWhenSpawned(t *testing.T) {
 	t.Setenv("GHOST_LOG_FILE", "")
 	t.Setenv("GHOST_DEBUG", "")
-	writer, level := mcpLogConfig(false)
+	writer, level, closeLog := mcpLogConfig(false)
 	if level != slog.LevelWarn {
 		t.Fatalf("level = %v, want Warn", level)
 	}
 	if writer != io.Writer(os.Stderr) {
 		t.Fatal("writer must be stderr")
 	}
+	if closeLog != nil {
+		t.Fatal("no file opened, closer must be nil")
+	}
 }
 
 func TestMCPLogConfig_InfoWhenTerminal(t *testing.T) {
 	t.Setenv("GHOST_LOG_FILE", "")
 	t.Setenv("GHOST_DEBUG", "")
-	writer, level := mcpLogConfig(true)
+	writer, level, closeLog := mcpLogConfig(true)
 	if level != slog.LevelInfo {
 		t.Fatalf("level = %v, want Info (interactive debugging)", level)
 	}
 	if writer != io.Writer(os.Stderr) {
 		t.Fatal("writer must be stderr")
+	}
+	if closeLog != nil {
+		t.Fatal("no file opened, closer must be nil")
 	}
 }
 
@@ -518,9 +524,12 @@ func TestMCPLogConfig_FileRedirect(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "ghost.log")
 	t.Setenv("GHOST_LOG_FILE", logPath)
 	t.Setenv("GHOST_DEBUG", "")
-	writer, level := mcpLogConfig(false)
+	writer, level, closeLog := mcpLogConfig(false)
 	if level != slog.LevelInfo {
 		t.Fatalf("level = %v, want Info (full stream to file)", level)
+	}
+	if closeLog == nil {
+		t.Fatal("file opened, closer must be non-nil")
 	}
 	f, ok := writer.(*os.File)
 	if !ok {
@@ -528,7 +537,10 @@ func TestMCPLogConfig_FileRedirect(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{Level: level}))
 	logger.Info("hello from test")
-	_ = f.Close()
+	closeLog()
+	if _, err := f.Write([]byte("after close")); err == nil {
+		t.Fatal("closer must actually close the file")
+	}
 	data, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatal(err)
@@ -541,7 +553,7 @@ func TestMCPLogConfig_FileRedirect(t *testing.T) {
 func TestMCPLogConfig_DebugWins(t *testing.T) {
 	t.Setenv("GHOST_LOG_FILE", "")
 	t.Setenv("GHOST_DEBUG", "1")
-	_, level := mcpLogConfig(false)
+	_, level, _ := mcpLogConfig(false)
 	if level != slog.LevelDebug {
 		t.Fatalf("level = %v, want Debug", level)
 	}
@@ -557,11 +569,14 @@ func TestMCPLogConfig_UnopenableFileFallsBackQuiet(t *testing.T) {
 	}
 	t.Setenv("GHOST_LOG_FILE", dir) // existing directory: open for write fails
 	t.Setenv("GHOST_DEBUG", "")
-	writer, level := mcpLogConfig(false)
+	writer, level, closeLog := mcpLogConfig(false)
 	if level != slog.LevelWarn {
 		t.Fatalf("level = %v, want Warn (quiet fallback)", level)
 	}
 	if writer != io.Writer(os.Stderr) {
 		t.Fatal("writer must fall back to stderr")
+	}
+	if closeLog != nil {
+		t.Fatal("no file opened, closer must be nil")
 	}
 }

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -483,3 +483,66 @@ func targetNames(targets []clientTarget) []string {
 	}
 	return names
 }
+
+// TestMCPLogConfig_QuietWhenSpawned guards the #373 fix: a client-spawned
+// server (stderr not a terminal) must drop routine INFO logs from stderr so
+// MCP clients that surface stderr don't leak them into the UI.
+func TestMCPLogConfig_QuietWhenSpawned(t *testing.T) {
+	t.Setenv("GHOST_LOG_FILE", "")
+	t.Setenv("GHOST_DEBUG", "")
+	writer, level := mcpLogConfig(false)
+	if level != slog.LevelWarn {
+		t.Fatalf("level = %v, want Warn", level)
+	}
+	if writer != io.Writer(os.Stderr) {
+		t.Fatal("writer must be stderr")
+	}
+}
+
+func TestMCPLogConfig_InfoWhenTerminal(t *testing.T) {
+	t.Setenv("GHOST_LOG_FILE", "")
+	t.Setenv("GHOST_DEBUG", "")
+	writer, level := mcpLogConfig(true)
+	if level != slog.LevelInfo {
+		t.Fatalf("level = %v, want Info (interactive debugging)", level)
+	}
+	if writer != io.Writer(os.Stderr) {
+		t.Fatal("writer must be stderr")
+	}
+}
+
+// TestMCPLogConfig_FileRedirect: GHOST_LOG_FILE must divert the full stream
+// (INFO included) to the file even when spawned by a client, keeping stderr
+// clean while preserving logs for debugging.
+func TestMCPLogConfig_FileRedirect(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "ghost.log")
+	t.Setenv("GHOST_LOG_FILE", logPath)
+	t.Setenv("GHOST_DEBUG", "")
+	writer, level := mcpLogConfig(false)
+	if level != slog.LevelInfo {
+		t.Fatalf("level = %v, want Info (full stream to file)", level)
+	}
+	f, ok := writer.(*os.File)
+	if !ok {
+		t.Fatalf("writer is %T, want *os.File", writer)
+	}
+	logger := slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{Level: level}))
+	logger.Info("hello from test")
+	_ = f.Close()
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "hello from test") {
+		t.Fatalf("log file missing the info line, got %q", data)
+	}
+}
+
+func TestMCPLogConfig_DebugWins(t *testing.T) {
+	t.Setenv("GHOST_LOG_FILE", "")
+	t.Setenv("GHOST_DEBUG", "1")
+	_, level := mcpLogConfig(false)
+	if level != slog.LevelDebug {
+		t.Fatalf("level = %v, want Debug", level)
+	}
+}


### PR DESCRIPTION
Fixes #373.

## Problem

`ghost mcp` emitted `level=INFO` lines to stderr at startup and on session events. MCP clients that surface stderr (rather than fully capturing it) leak these into the UI — the same failure class as the opencode TUI leak fixed in #374, but server-side, so it affects every client installer (claude-code, opencode, codex, goose).

## Change

- `runMCP` resolves logging via new `mcpLogConfig()`:
  - stderr is a terminal (interactive debugging) → INFO on stderr, as before
  - client-spawned (stderr not a terminal) → WARN+ only; routine INFO is dropped
  - `GHOST_LOG_FILE=/path` → full stream (INFO) redirected to the file, stderr stays clean
  - `GHOST_DEBUG` still forces Debug
- `bootstrap()` now takes the log writer and level; its config-creation notices ("created config file" etc.) go through the logger so they respect the same policy instead of writing to stderr directly
- Interactive CLI commands (reflect/supersede/resolve/project delete) keep INFO-to-stderr via `cliLogLevel()`

## Tests

- `TestMCPLogConfig_*`: quiet-when-spawned, INFO-when-terminal, file redirect (INFO lands in file), GHOST_DEBUG wins
- Verified end-to-end: spawned-session smoke test went from INFO noise to zero stderr bytes during a normal session