### PR TITLE
chore(ai,reflection): remove ContextForModel and ExtractionPrompt

### DIFF
--- a/internal/ai/models.go
+++ b/internal/ai/models.go
@@ -2,7 +2,6 @@ package ai
 
 import (
 	"encoding/json"
-	"strings"
 )
 
 const (
@@ -15,11 +14,6 @@ const (
 	ModelSonnet46 = "claude-sonnet-4-6"
 	ModelHaiku45  = "claude-haiku-4-5-20251001"
 	ModelOpus46   = "claude-opus-4-6"
-
-	// Context window sizes by model family.
-	ContextOpus46   = 1_000_000
-	ContextSonnet46 = 1_000_000
-	ContextHaiku45  = 200_000
 )
 
 // SystemBlock is a system prompt block for the Claude API.
@@ -111,18 +105,4 @@ type apiRequest struct {
 	System    []SystemBlock `json:"system,omitempty"`
 	Stream    bool          `json:"stream"`
 	Messages  []Message     `json:"messages"`
-}
-
-// ContextForModel returns the context window size for a given model ID.
-func ContextForModel(model string) int {
-	switch {
-	case strings.Contains(model, "opus-4-6"):
-		return ContextOpus46
-	case strings.Contains(model, "sonnet-4-5"), strings.Contains(model, "sonnet-4-6"):
-		return ContextSonnet46
-	case strings.Contains(model, "haiku"):
-		return ContextHaiku45
-	default:
-		return 200_000
-	}
 }

--- a/internal/reflection/prompt.go
+++ b/internal/reflection/prompt.go
@@ -105,31 +105,3 @@ Return ONLY the JSON object, no other text.`)
 func quoteData(s string) string {
 	return "«" + strings.NewReplacer("«", "<<", "»", ">>").Replace(s) + "»"
 }
-
-// ExtractionPrompt is the system prompt for per-exchange memory extraction.
-const ExtractionPrompt = `You analyze a conversation between a developer and their personal assistant (Ghost). Extract project-specific facts, patterns, or decisions worth remembering for future sessions.
-
-Extract:
-- Architecture: how the codebase is organized, key abstractions
-- Decisions: why something was done a certain way, what alternatives were rejected
-- Patterns: recurring code patterns, naming conventions
-- Conventions: formatting, testing, commit message style
-- Gotchas: bugs found, tricky behavior, edge cases discovered
-- Dependencies: key libraries, versions, integration notes
-- Preferences: developer's preferred approaches or tools
-
-Do NOT extract:
-- Transient conversation details ("the user asked about X")
-- Generic programming facts ("Go uses goroutines for concurrency")
-- Anything that's just restating what the code does without insight
-- Secrets, API keys, passwords, or personal data
-
-Importance scale:
-- 0.9-1.0: Architecture decisions, critical gotchas, project identity
-- 0.7-0.8: Useful patterns, conventions, dependencies
-- 0.5-0.6: Minor facts, preferences
-
-Return ONLY a JSON array. Each item:
-{"category": "architecture|decision|pattern|convention|gotcha|dependency|preference|fact", "content": "specific observation", "importance": 0.0-1.0, "tags": ["tag1"]}
-
-Return [] if nothing worth remembering.`


### PR DESCRIPTION
## Summary
Removes two dead symbols: `ai.ContextForModel` (internal/ai/models.go) and `reflection.ExtractionPrompt` (internal/reflection/prompt.go). Both have zero usages on main (grep-verified before opening).

Rebased from an Aug 17 branch; dead-code status re-verified today.