### PR TITLE
fix(config): add GHOST_OLLAMA_URL env override

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ linking:
   threshold: 0.70                        # min cosine similarity to auto-link memories
 ```
 
-Note: env-var names map underscores to config dots, so keys that themselves contain underscores (e.g. `embedding.ollama_url`) must be set in a config file, not via env.
+Note: env-var names map underscores to config dots, so keys that themselves contain underscores (e.g. `embedding.ollama_url`, `obsidian.vault_dir`) need an explicit shortcut rather than the generic `GHOST_*` mapping; `GHOST_OLLAMA_URL` and `GHOST_OBSIDIAN_VAULT_DIR` are provided for exactly that. Running Ghost inside a VM with Ollama on the host? Point it at the host's gateway IP instead of hand-editing the config file, e.g. `GHOST_OLLAMA_URL=http://10.0.2.2:11434` (the default host-gateway address for UTM/QEMU on macOS; other hypervisors use their own convention, such as `host.docker.internal` for Docker Desktop).
 
 ## Benchmarks
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,6 +152,7 @@ func Load() (*Config, error) {
 		"GHOST_REFLECTION_AUTO_REFLECT":   "reflection.auto_reflect",
 		"GHOST_REFLECTION_AUTO_RESOLVE":   "reflection.auto_resolve",
 		"GHOST_REFLECTION_AUTO_SUPERSEDE": "reflection.auto_supersede",
+		"GHOST_OLLAMA_URL":                "embedding.ollama_url",
 	}
 	for envKey, koanfKey := range envOverrides {
 		if val := os.Getenv(envKey); val != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -151,6 +151,28 @@ func TestLoad_ObsidianVaultDirEnvOverride(t *testing.T) {
 	}
 }
 
+func TestLoad_OllamaURLEnvOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Clear interfering env vars.
+	unsetEnvVars(t, []string{"GHOST_API_KEY", "ANTHROPIC_API_KEY"})
+
+	// The generic _ → . transformer would map this to embedding.ollama.url,
+	// missing the embedding.ollama_url key — the explicit override must catch it.
+	t.Setenv("GHOST_OLLAMA_URL", "http://10.0.2.2:11434")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Embedding.OllamaURL != "http://10.0.2.2:11434" {
+		t.Errorf("embedding.ollama_url = %q, want %q (explicit env override)", cfg.Embedding.OllamaURL, "http://10.0.2.2:11434")
+	}
+}
+
 func TestLoad_YAMLFileOverride(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)


### PR DESCRIPTION
### **User description**
## Summary
The generic GHOST_* → config-key transformer maps every underscore to a dot, so GHOST_EMBEDDING_OLLAMA_URL silently lands on the nonexistent `embedding.ollama.url` key instead of `embedding.ollama_url` — same class of bug already fixed for GHOST_OBSIDIAN_VAULT_DIR. Adds an explicit-override entry for the Ollama URL and documents pointing it at a VM host.

Rebased onto current main (conflict with the env-override map grown by #377 resolved; vet + tests pass).


___

### **PR Type**
Bug fix


___

### **Description**
- Add explicit `GHOST_OLLAMA_URL` env override for embedding config

- Fix missing config key from generic underscore mapping

- Update test coverage for Ollama URL environment override

- Document VM host access pattern in README


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Environment Variable"] --> B["Explicit Override Map"]
  B --> C["Correct Config Key"]
  C --> D["Ollama Client Connection"]
  E["README Documentation"] --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Add Ollama URL env override entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/config/config.go

<ul><li>Added <code>GHOST_OLLAMA_URL</code> to env override mapping<br> <li> Maps to <code>embedding.ollama_url</code> config key<br> <li> Fixes generic underscore transformation issue</ul>


</details>


  </td>
  <td><a href="https://github.com/wcatz/ghost/pull/382/files#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_test.go</strong><dd><code>Add Ollama URL override test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/config/config_test.go

<ul><li>Added test for <code>GHOST_OLLAMA_URL</code> env override<br> <li> Verifies correct config key mapping<br> <li> Uses explicit test environment setup</ul>


</details>


  </td>
  <td><a href="https://github.com/wcatz/ghost/pull/382/files#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document Ollama URL override usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated documentation about env-var limitations<br> <li> Added <code>GHOST_OLLAMA_URL</code> as explicit shortcut<br> <li> Documented VM host access with gateway IP example</ul>


</details>


  </td>
  <td><a href="https://github.com/wcatz/ghost/pull/382/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

