### PR TITLE
chore(ci): PR-Agent reliability and coverage upgrades

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -2,13 +2,17 @@ name: PR Agent
 
 on:
   pull_request:
-    # review_requested (not synchronize): a fresh review per push burns Go
-    # quota every commit, and the original plan ("Re-review policy: NOT on
-    # synchronize; manual /review instead") still holds — pr_agent_job is
-    # not a required branch-protection context (workflow_run-triggered
-    # workflows attach to the wrong SHA for that; see pr-loop.yml), so a
-    # stale context on a new head SHA cannot block merge.
-    types: [opened, reopened, ready_for_review, review_requested]
+    # Re-review policy: every code push gets fresh bot eyes (synchronize);
+    # docs-only pushes skip the trigger entirely so they don't burn quota.
+    # Trade-off: a PR whose FIRST push is docs-only gets no automatic
+    # review at all (paths filters apply to opened too) — request one via
+    # /review comment for that case. The merge gate is native conversation
+    # resolution on inline threads; pr_agent_job is not a required
+    # branch-protection context.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+    types: [opened, reopened, ready_for_review, review_requested, synchronize]
   issue_comment:
     types: [created]
 
@@ -110,7 +114,16 @@ jobs:
             Do not report style preferences handled by golangci-lint.
             Verify your findings against the code before posting —
             false positives erode trust. If unsure, say "needs verification"
-            rather than asserting a bug.
+            rather than asserting a bug. Treat issue or PR references in the
+            description as context links, not compliance targets — never
+            grade ticket compliance against them unless they are formally
+            linked issues.
+
+          # Prompt budget for large diffs: default 32000 clipped a 2.5k-line
+          # PR's review (plan doc skipped on token budget). big-pickle holds
+          # 64k (custom_model_max_tokens above), so 48k leaves headroom for
+          # the response while covering full-diff reviews.
+          config.max_model_tokens: "48000"
 
           github_action_config.auto_review: "true"
           # On-demand only (/improve comment): per-finding suggestion
@@ -123,4 +136,4 @@ jobs:
           # and have hallucinated project-specific names. Findings live in
           # the review + inline threads; no description is posted.
           github_action_config.auto_describe: "false"
-          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested"]'
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested", "synchronize"]'

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -12,6 +12,11 @@ repo_context_max_lines = 500
 # Don't re-post the same suggestion on every push — fingerprint
 # markers deduplicate across runs.
 persistent_inline_comments = true
+# Fail the job loudly when a tool errors out. Observed 2026-08-25: an
+# /improve hung on the Zen endpoint, ai_timeout killed the LLM calls,
+# and the action exited GREEN with zero output — log jumped straight
+# from "Number of PR chunk calls" to completion.
+propagate_tool_errors = true
 
 [best_practices]
 # Auto-detect from best_practices.md at repo root.


### PR DESCRIPTION
## Summary
Four evidence-backed bot upgrades from the 2026-08-25 ability testing:

1. **propagate_tool_errors = true** (in .pr_agent.toml) — an /improve hung on Zen, ai_timeout killed it, and the job exited **green with zero output**. Now tool errors fail loudly.
2. **Re-review on synchronize**, docs-only paths ignored — code pushes get fresh bot eyes automatically; README-only pushes don't burn quota. Trade-off documented: a PR whose first push is docs-only needs a manual /review.
3. **max_model_tokens 32000 → 48000** — default clipped the 2.5k-line #383 review (plan doc skipped); big-pickle holds 64k.
4. **Anti-ticket-hallucination instruction** — the bot graded #382 'partially compliant' against unrelated merged #377 via a body mention; instructions now say description references are context links, not compliance targets.

## Post-merge step (branch protection)
Drop the now-stale required check so docs-only pushes can't block merges — remove pr_agent_job from Settings → Branches → required checks (conversation resolution remains the merge gate).

## Test plan
- [ ] Bot reviews this PR on opened
- [ ] Push a follow-up commit → synchronize fires a fresh review automatically
- [ ] Simulated LLM failure surfaces as a red job, not silent success