### PR TITLE
fix(ci): match real bot login in review-thread filters

### DIFF
--- a/.github/workflows/best-practices-loop.yml
+++ b/.github/workflows/best-practices-loop.yml
@@ -2,7 +2,7 @@
 #
 # Closes the gap vs CodeRabbit's automatic learning: mines review
 # findings the PR-Agent made on merged PRs (resolved threads authored by
-# github-actions[bot]) and distills recurring ones into proposed
+# github-actions) and distills recurring ones into proposed
 # best_practices.md additions. Output lands as a DRAFT PR — never merged
 # automatically, so the model's suggestions always pass a human gate and
 # get reviewed by PR-Agent itself (dogfooding).
@@ -61,7 +61,7 @@ jobs:
             | .reviewThreads.nodes[]
             | select(.isResolved)
             | .comments.nodes[]
-            | select(.author.login == "github-actions[bot]")
+            | select((.author.login // "") | startswith("github-actions"))
             | "--- FINDING (PR #\($pr.number) \($pr.title)) ---\n\(.body)\n"
           ' prs.json > findings.txt
           echo "findings bytes: $(wc -c < findings.txt)"

--- a/.github/workflows/pr-loop.yml
+++ b/.github/workflows/pr-loop.yml
@@ -137,11 +137,11 @@ jobs:
           # accepted trade-off for never letting a dead thread block merge.
           STALE="$(echo "$THREADS" | jq '[.reviewThreads.nodes[]
             | select(.isResolved==false and .isOutdated==true)
-            | select(.comments.nodes[0].author.login=="github-actions[bot]") | .id]')"
+            | select((.comments.nodes[0].author.login // "") | startswith("github-actions")) | .id]')"
 
           LIVE="$(echo "$THREADS" | jq '[.reviewThreads.nodes[]
             | select(.isResolved==false and .isOutdated==false)
-            | select(.comments.nodes[0].author.login=="github-actions[bot]")]')"
+            | select((.comments.nodes[0].author.login // "") | startswith("github-actions"))]')"
 
           N_STALE="$(jq length <<<"$STALE")"
           N_LIVE="$(jq length <<<"$LIVE")"


### PR DESCRIPTION
## Summary
GraphQL reports review-thread comment authors as `github-actions`, not `github-actions[bot]`. Two workflows compared against the wrong string:

- **pr-loop.yml** stale-thread sweeper — auto-resolve could never match a PR-Agent thread; would have silently no-op'd forever (never triggered yet because no stale threads existed)
- **best-practices-loop.yml** corpus filter — every run distills an empty corpus

Observed live: first `workflow_dispatch` of the learning loop ran green but skipped distillation (findings bytes: 0); direct GraphQL on #383's resolved thread shows author `github-actions`.

Both filters now match on the `github-actions` prefix, covering both login forms.

## Evidence
- Run 32899015264: distill skipped, empty corpus
- GraphQL: PR #383 thread author = `github-actions`, isResolved=true