### PR TITLE
docs(ci): correct paths-ignore trade-off wording per PR-Agent review

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -3,7 +3,7 @@ name: PR Agent
 on:
   pull_request:
     # Re-review policy: every code push gets fresh bot eyes (synchronize);
-    # docs-only pushes skip the trigger entirely so they don't burn quota.
+    # docs-only pushes skip the trigger so they do not burn Go quota.
     # Trade-offs: a PR whose FIRST push is docs-only gets no automatic
     # review until a code-containing push fires synchronize (paths filters
     # apply to opened too) — request one via /review comment for that

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     # Re-review policy: every code push gets fresh bot eyes (synchronize);
     # docs-only pushes skip the trigger entirely so they don't burn quota.
-    # Trade-off: a PR whose FIRST push is docs-only gets no automatic
-    # review at all (paths filters apply to opened too) — request one via
-    # /review comment for that case. The merge gate is native conversation
+    # Trade-offs: a PR whose FIRST push is docs-only gets no automatic
+    # review until a code-containing push fires synchronize (paths filters
+    # apply to opened too) — request one via /review comment for that
+    # case; likewise a docs-only follow-up push on an existing code PR
+    # does not re-trigger. The merge gate is native conversation
     # resolution on inline threads; pr_agent_job is not a required
     # branch-protection context.
     paths-ignore:


### PR DESCRIPTION
## Summary
Addresses both focus areas from PR-Agent's review of #384:

1. **Misleading trade-off comment** (its finding) — a docs-only-first PR *does* get reviewed once a code-containing push fires `synchronize`; the old wording ('no automatic review at all') overstated it.
2. **Synchronize + paths-ignore interaction** — now states explicitly that docs-only follow-up pushes on existing code PRs don't re-trigger.

Comment-only change; no behavioral difference.