### PR TITLE
fix(supersede): skip pairs whose endpoint a concurrent reflect pass replaced

### DIFF
--- a/internal/supersede/supersede.go
+++ b/internal/supersede/supersede.go
@@ -166,6 +166,27 @@ type Result struct {
 	Created       int // supersedes links written (0 in dry-run)
 	CausesCreated int // CAUSES verdicts (causes links written when apply)
 	Reclassified  int // existing links whose relation changed or was invalidated
+	StaleSkipped  int
+}
+
+// endpointsExist reports whether every given memory ID is still live. Used
+// to detect memories replaced by a concurrent reflect pass between candidate
+// selection and link write.
+func endpointsExist(ctx context.Context, store vectorStore, ids ...string) (bool, error) {
+	mems, err := store.GetByIDs(ctx, ids)
+	if err != nil {
+		return false, err
+	}
+	got := make(map[string]bool, len(mems))
+	for _, m := range mems {
+		got[m.ID] = true
+	}
+	for _, id := range ids {
+		if !got[id] {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // Run selects fresh candidates, unions them with previously-created llm
@@ -184,6 +205,11 @@ type Result struct {
 // update is skipped (skip-if-unchanged) — reclassifying it would repeat the
 // same verdict for no reason. Fresh candidates are always classified
 // regardless, since SelectCandidates already bounds their cost.
+//
+// Pairs whose endpoints are replaced by a concurrent reflect pass (the stop
+// hook spawns both for the same session) are dropped and counted in
+// Result.StaleSkipped rather than failing the pass — the pair no longer
+// exists, so there is nothing to link.
 //
 // If any classification in the batch came from a fallback provider, apply is
 // skipped entirely for the whole batch (mirroring internal/resolve) — a
@@ -257,6 +283,39 @@ func Run(ctx context.Context, store vectorStore, cls Classifier, projectID strin
 	}
 
 	res := Result{Candidates: len(all)}
+
+	// Existence re-check before any LLM spend: the stop hook spawns
+	// reflect and supersede for the same session, and reflect's
+	// consolidation replaces rows (delete + new IDs) while this pass is
+	// running. A pair whose endpoint already vanished would burn a
+	// classify call and then die on the FK at write time.
+	allIDs := make([]string, 0, len(all)*2)
+	for _, c := range all {
+		allIDs = append(allIDs, c.NewerID, c.OlderID)
+	}
+	aliveMems, err := store.GetByIDs(ctx, allIDs)
+	if err != nil {
+		return res, nil, fmt.Errorf("existence check: %w", err)
+	}
+	aliveSet := make(map[string]bool, len(aliveMems))
+	for _, m := range aliveMems {
+		aliveSet[m.ID] = true
+	}
+	live := all[:0]
+	for _, c := range all {
+		if aliveSet[c.NewerID] && aliveSet[c.OlderID] {
+			live = append(live, c)
+			continue
+		}
+		res.StaleSkipped++
+		if logger != nil {
+			logger.Info("supersede: dropping stale pair (endpoint replaced by a concurrent pass)",
+				"newer", c.NewerID, "older", c.OlderID)
+		}
+	}
+	all = live
+	res.Candidates = len(all)
+
 	var classified []Classified
 	anyFallback := false
 	for _, c := range all {
@@ -293,6 +352,24 @@ func Run(ctx context.Context, store vectorStore, cls Classifier, projectID strin
 
 	if apply {
 		for _, c := range classified {
+			// Pre-write existence check: the candidate was alive at
+			// selection (and possibly at the batch check above), but a
+			// concurrent reflect pass may have replaced it during the
+			// classify loop. Writing then would die on the FK and abort
+			// the whole pass; skipping is always correct — the pair no
+			// longer exists, so there is nothing to link.
+			pairAlive, err := endpointsExist(ctx, store, c.NewerID, c.OlderID)
+			if err != nil {
+				return res, nil, fmt.Errorf("stale check %s→%s: %w", c.NewerID, c.OlderID, err)
+			}
+			if !pairAlive {
+				res.StaleSkipped++
+				if logger != nil {
+					logger.Info("supersede: skipping write, endpoint replaced by a concurrent pass",
+						"newer", c.NewerID, "older", c.OlderID)
+				}
+				continue
+			}
 			switch c.Relation {
 			case RelationSupersedes:
 				if err := store.CreateLink(ctx, c.NewerID, c.OlderID, string(RelationSupersedes), c.Similarity, "llm"); err != nil {

--- a/internal/supersede/supersede_test.go
+++ b/internal/supersede/supersede_test.go
@@ -441,3 +441,40 @@ func TestRun_MixedFallbackAndPrimary_SkipsApply(t *testing.T) {
 		t.Errorf("CreateLink must not be called when any candidate in the batch came from a fallback provider, even if others were confirmed via primary; found %d links", len(pairs))
 	}
 }
+
+// TestRun_SkipsPairWhoseEndpointVanishedMidRun reproduces the observed
+// production failure: the stop hook spawns reflect and supersede for the
+// same session, and reflect's consolidation replaces rows while supersede
+// is inside its classify loop. The pair was alive at selection time, so it
+// reaches classification; by write time one endpoint is gone. Run must skip
+// the pair (counting StaleSkipped) instead of dying on the FK constraint —
+// there is nothing to link once the memory no longer exists.
+func TestRun_SkipsPairWhoseEndpointVanishedMidRun(t *testing.T) {
+	store, db := seed(t)
+	ctx := context.Background()
+
+	v1 := add(t, store, db, "kubernetes cluster runs version 1.27", []float32{1, 0, 0}, "2026-01-01 00:00:00")
+	v2 := add(t, store, db, "kubernetes upgraded to 1.29", []float32{0.99, 0.01, 0}, "2026-04-01 00:00:00")
+
+	// Simulate reflect replacing v1 (delete + new row) while supersede is
+	// classifying: on the first Classify call, drop v1 from the store.
+	cls := &mockClassifier{verdict: func(_, _ string) Relation {
+		_ = store.Delete(ctx, v1)
+		return RelationSupersedes
+	}}
+
+	res, _, err := Run(ctx, store, cls, "p", 0.9, true, nil)
+	if err != nil {
+		t.Fatalf("Run must not fail on a mid-run replaced endpoint: %v", err)
+	}
+	if res.Created != 0 {
+		t.Errorf("got Created=%d, want 0 (endpoint gone before write)", res.Created)
+	}
+	if res.StaleSkipped != 1 {
+		t.Errorf("got StaleSkipped=%d, want 1", res.StaleSkipped)
+	}
+	pairs, _ := store.SupersedesWithin(ctx, []string{v1, v2})
+	if len(pairs) != 0 {
+		t.Errorf("found %d links for a deleted endpoint; want none", len(pairs))
+	}
+}


### PR DESCRIPTION
## Summary
The stop hook spawns reflect and supersede for the same session-end. Reflect's consolidation replaces rows (delete old IDs + insert new); when that lands while supersede is inside its LLM classify loop, the pair's endpoints are dead by write time and the **entire pass aborts on the FK constraint**.

Observed 2026-08-25 in `~/.local/share/ghost/supersede.log`, immediately after a `Applied: 22 memories consolidated` reflect run: 47 classify errors + 14 `FOREIGN KEY constraint failed` link rejections, all on memory IDs verified absent from the DB.

## Fix
Two guards in `Run`:
1. Batch existence re-check before the classify loop — drops already-stale pairs and saves the LLM calls
2. Per-pair pre-write check — a mid-run replacement skips that write instead of killing the pass

Both count into `Result.StaleSkipped`. Skipping is always correct: the pair no longer exists, so there is nothing to link.

## Test plan
- [x] `TestRun_SkipsPairWhoseEndpointVanishedMidRun` deletes an endpoint inside the classifier mock (simulating reflect racing supersede)
- [x] Red/green proven: fails on main's code with the exact production FK error, passes with the fix
- [x] Full supersede/memory/resolve suites green