### PR TITLE
fix(opencode): bound client.session.list() in the plugin's config() hook

### DIFF
--- a/internal/mcpinit/opencode_ghost.ts
+++ b/internal/mcpinit/opencode_ghost.ts
@@ -73,6 +73,25 @@ const renderStartContext = (cwd: string): Promise<string> =>
 		child.on("close", () => resolve(out))
 	})
 
+// Races a promise against a deadline, resolving to `fallback` if the deadline
+// wins. The loser is left to settle on its own — never awaited, never thrown
+// away forcibly, just ignored. Needed because `config()` runs during
+// opencode's own startup: an RPC back into the SDK client (e.g.
+// client.session.list()) can depend on server state that isn't up yet, and
+// without a bound it stalls config() — and therefore all of opencode's
+// startup, since nothing past config() runs until it resolves — forever.
+const withTimeout = <T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> =>
+	new Promise((resolve) => {
+		const timer = setTimeout(() => resolve(fallback), ms)
+		promise.then((v) => {
+			clearTimeout(timer)
+			resolve(v)
+		}, () => {
+			clearTimeout(timer)
+			resolve(fallback)
+		})
+	})
+
 export const GhostPlugin: Plugin = async ({ client, directory }) => {
 	const log = async (level: "info" | "warn" | "error", message: string) => {
 		try {
@@ -223,7 +242,11 @@ export const GhostPlugin: Plugin = async ({ client, directory }) => {
 				// back to the startup cwd.
 				let ctxCwd = directory ?? process.cwd()
 				try {
-					const sessions = await client.session.list()
+					// This RPC round-trips through opencode's own server, which
+					// is still coming up during config() — bound it so a slow or
+					// not-yet-ready server degrades to the startup cwd instead of
+					// stalling config() (and all of opencode's startup) forever.
+					const sessions = await withTimeout(client.session.list(), 1500, { data: [] as unknown[] })
 					if (Array.isArray(sessions.data) && sessions.data.length > 0) {
 						const recent = sessions.data.reduce((a, b) =>
 							(a.time?.updated ?? 0) >= (b.time?.updated ?? 0) ? a : b)

--- a/internal/mcpinit/opencode_test.go
+++ b/internal/mcpinit/opencode_test.go
@@ -39,6 +39,24 @@ func writeStub(t *testing.T, binDir, name string) string {
 	return path
 }
 
+// TestRenderOpencodeGhostPlugin_ConfigSessionListIsBounded guards against a
+// reintroduced deadlock: the plugin's config() hook calls client.session.list()
+// to find the most-recently-used session directory, but that's an RPC back
+// into opencode's own server, which is still coming up during config()
+// resolution. An unbounded await there stalls config() — and all of
+// opencode's startup, since nothing past config() runs until it resolves —
+// forever, with the ghost MCP server never even spawned. See the 2026-08-25
+// "opencode won't load" investigation: reproduced on two machines (one memory
+// -starved, one idle with 67GB free), confirmed via GHOST_LOG_FILE+GHOST_DEBUG
+// that ghost was never invoked during the hang, and confirmed disabling only
+// this plugin fixed it.
+func TestRenderOpencodeGhostPlugin_ConfigSessionListIsBounded(t *testing.T) {
+	src := renderOpencodeGhostPlugin("/usr/local/bin/ghost")
+	if !strings.Contains(src, "withTimeout(client.session.list()") {
+		t.Error("client.session.list() in config() must be wrapped in a timeout — an unbounded await there deadlocks opencode's own startup (config() never returns, so ghost's MCP entry is never even read)")
+	}
+}
+
 func TestRunOpencode_NoClaudeRequired(t *testing.T) {
 	home, xdg := setupOpencodeTestEnv(t)
 	want := renderOpencodeGhostPlugin(filepath.Join(home, "bin", "ghost"))


### PR DESCRIPTION
## Summary
- The opencode lifecycle plugin's `config()` hook awaits `client.session.list()` to find the most-recently-used session directory for passive context injection. That call is an RPC back into opencode's own server, which is still coming up during `config()` resolution — left unbounded, it can deadlock: `config()` never returns, so opencode never gets to reading `cfg.mcp` and spawning ghost's MCP server at all.
- Wraps that call in a 1.5s timeout race (`withTimeout`), falling back to the startup cwd on timeout, same as the existing error fallback.

## Root cause investigation
Reported as "0.27.0 broke opencode, won't load." The `opencode_ghost.ts` plugin is byte-identical between v0.26.1 and v0.27.0 (this bug predates the tag, just newly triggered/noticed), so the fix targets the actual defect rather than reverting anything from that release.

Reproduced on two machines:
- A memory-constrained dev laptop (845MB free / 9.5GB swapped) — intermittent ~80s stalls.
- An idle 78GB server with 67GB free (`ada@mr-slave`) — deterministic hang on every `opencode run`, confirmed 4/4.

On both, `GHOST_LOG_FILE` + `GHOST_DEBUG=1` (inherited by any child ghost would spawn) showed **zero ghost invocation** during the hang — ghost was never even exec'd. Disabling only the plugin (leaving all other config untouched) fixed startup instantly on both machines. That isolates the defect to the plugin's `config()` hook itself, not to ghost's Go binary.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/mcpinit/...` — all pass, including a new regression test (`TestRenderOpencodeGhostPlugin_ConfigSessionListIsBounded`) that fails against the pre-fix template and passes against the fix
- [x] Built the fix, installed it via `ghost mcp init --client opencode` on both affected machines, verified live:
  - Local (arm64, memory-constrained): went from failing most attempts to 2/3 clean runs (remaining slowness there is unrelated memory pressure, not this bug)
  - `ada@mr-slave` (amd64, idle): 5/5 clean runs, ~6s each, after being 0/4 (100% hang) before the fix