### PR TITLE
feat(routing): configurable default project for home-dir sessions

### DIFF
--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -75,7 +75,12 @@ func main() {
 				runProjectDelete()
 				return
 			}
+			if len(os.Args) > 2 && os.Args[2] == "merge" {
+				runProjectMerge()
+				return
+			}
 			fmt.Fprintln(os.Stderr, "Usage: ghost project delete <name-or-id> [--apply]")
+			fmt.Fprintln(os.Stderr, "       ghost project merge <old-name-or-id> <new-name-or-id>")
 			os.Exit(1)
 		case "upgrade":
 			runUpgrade()
@@ -1045,6 +1050,74 @@ Irreversible. Refuses to delete _global.`)
 	ctx := context.Background()
 
 	if err := runProjectDeleteCore(ctx, store, os.Stdout, os.Stdin, projectName, apply); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runProjectMergeCore implements the merge behind `ghost project merge`.
+// Both arguments resolve through ResolveProject (id, name, path-prefix, or
+// basename); merging reassigns every child record to the surviving project —
+// preserving memory IDs, links, and pin state — and deletes the old project
+// row. Non-destructive to records, so no confirmation gate (unlike delete).
+func runProjectMergeCore(ctx context.Context, store *memory.Store, out io.Writer, oldArg, newArg string) error {
+	oldID, oldName := resolveForMerge(ctx, store, oldArg)
+	newID, newName := resolveForMerge(ctx, store, newArg)
+	if oldID == "" {
+		return fmt.Errorf("project %q not found; known projects: %s", oldArg, strings.Join(knownProjectNames(ctx, store), ", "))
+	}
+	if newID == "" {
+		return fmt.Errorf("project %q not found; known projects: %s", newArg, strings.Join(knownProjectNames(ctx, store), ", "))
+	}
+	if oldID == newID {
+		return fmt.Errorf("refusing to merge a project into itself (%q)", oldID)
+	}
+	if _, err := fmt.Fprintf(out, "Merging %q (%s) into %q (%s)\n", oldName, oldID, newName, newID); err != nil {
+		return err
+	}
+	if err := store.MergeProject(ctx, oldID, newID); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(out, "merged: all records from %q now belong to %q\n", oldName, newName)
+	return err
+}
+
+func resolveForMerge(ctx context.Context, store *memory.Store, arg string) (string, string) {
+	id, name, err := store.ResolveProject(ctx, arg)
+	if err != nil {
+		return "", ""
+	}
+	return id, name
+}
+
+func knownProjectNames(ctx context.Context, store *memory.Store) []string {
+	names, err := store.ListProjectNames(ctx)
+	if err != nil {
+		return nil
+	}
+	return names
+}
+
+// runProjectMerge implements `ghost project merge <old> <new>`.
+func runProjectMerge() {
+	args := os.Args[3:]
+	var positional []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			fmt.Fprintf(os.Stderr, "error: unknown flag %q\n", a)
+			os.Exit(1)
+		}
+		positional = append(positional, a)
+	}
+	if len(positional) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: ghost project merge <old-name-or-id> <new-name-or-id>")
+		os.Exit(1)
+	}
+
+	_, _, store := bootstrap(os.Stderr, cliLogLevel())
+	defer store.Close() //nolint:errcheck
+
+	if err := runProjectMergeCore(context.Background(), store, os.Stdout, positional[0], positional[1]); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -580,3 +580,80 @@ func TestMCPLogConfig_UnopenableFileFallsBackQuiet(t *testing.T) {
 		t.Fatal("no file opened, closer must be nil")
 	}
 }
+
+func TestRunProjectMergeCore(t *testing.T) {
+	newStore := func(t *testing.T) *memory.Store {
+		t.Helper()
+		db, err := memory.OpenDB(":memory:")
+		if err != nil {
+			t.Fatalf("OpenDB: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		s := memory.NewStore(db, logger)
+		if err := s.EnsureProject(context.Background(), "old-proj", "/tmp/old", "old-name"); err != nil {
+			t.Fatalf("EnsureProject old: %v", err)
+		}
+		if err := s.EnsureProject(context.Background(), "new-proj", "/tmp/new", "new-name"); err != nil {
+			t.Fatalf("EnsureProject new: %v", err)
+		}
+		return s
+	}
+
+	t.Run("merges by name and preserves memory IDs", func(t *testing.T) {
+		store := newStore(t)
+		ctx := context.Background()
+		id, err := store.Create(ctx, "old-proj", memory.Memory{
+			Category: "fact", Content: "a fact that must survive the merge", Source: "manual", Importance: 0.5, Tags: []string{},
+		})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+
+		var out bytes.Buffer
+		if err := runProjectMergeCore(ctx, store, &out, "old-name", "new-name"); err != nil {
+			t.Fatalf("runProjectMergeCore: %v", err)
+		}
+
+		got, err := store.GetAll(ctx, "new-proj", 10)
+		if err != nil {
+			t.Fatalf("GetAll after merge: %v", err)
+		}
+		found := false
+		for _, m := range got {
+			if m.ID == id {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("memory %s missing from new-proj after merge", id)
+		}
+		for _, m := range got {
+			if m.ID == id && m.ProjectID != "new-proj" {
+				t.Errorf("memory project_id = %q, want new-proj", m.ProjectID)
+			}
+		}
+		oldID, _, _ := store.ResolveProject(ctx, "old-name")
+		if oldID != "" {
+			t.Errorf("old project still resolves after merge: %q", oldID)
+		}
+	})
+
+	t.Run("same project refused", func(t *testing.T) {
+		store := newStore(t)
+		var out bytes.Buffer
+		err := runProjectMergeCore(context.Background(), store, &out, "new-name", "new-proj")
+		if err == nil || !strings.Contains(err.Error(), "itself") {
+			t.Fatalf("expected self-merge refusal, got: %v", err)
+		}
+	})
+
+	t.Run("unknown project errors with known listing", func(t *testing.T) {
+		store := newStore(t)
+		var out bytes.Buffer
+		err := runProjectMergeCore(context.Background(), store, &out, "nope", "new-name")
+		if err == nil || !strings.Contains(err.Error(), `project "nope" not found`) {
+			t.Fatalf("expected not-found error, got: %v", err)
+		}
+	})
+}

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -657,3 +657,32 @@ func TestRunProjectMergeCore(t *testing.T) {
 		}
 	})
 }
+
+func TestRunProjectMergeCore_RefusesGlobal(t *testing.T) {
+	db, err := memory.OpenDB(":memory:")
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	store := memory.NewStore(db, logger)
+	ctx := context.Background()
+	if err := store.EnsureProject(ctx, "proj", "/tmp/proj", "test-project"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+	if err := store.EnsureProject(ctx, "_global", "_global", "global"); err != nil {
+		t.Fatalf("EnsureProject _global: %v", err)
+	}
+
+	for _, tc := range []struct{ oldArg, newArg string }{
+		{"_global", "test-project"},
+		{"global", "test-project"}, // resolves to _global by name
+		{"test-project", "_global"},
+	} {
+		var out bytes.Buffer
+		err := runProjectMergeCore(ctx, store, &out, tc.oldArg, tc.newArg)
+		if err == nil || !strings.Contains(err.Error(), "_global") {
+			t.Errorf("merge %q -> %q: expected _global refusal, got: %v", tc.oldArg, tc.newArg, err)
+		}
+	}
+}

--- a/docs/superpowers/specs/2026-08-26-home-dir-default-project.md
+++ b/docs/superpowers/specs/2026-08-26-home-dir-default-project.md
@@ -1,0 +1,71 @@
+# Home-Dir Session Routing → Configurable Default Project — Design
+
+Issue: #391. Status: implemented in this spec's branch.
+
+## Corrected root cause (2026-08-26 investigation)
+
+The issue presumed current ghost still mints hash-named buckets for
+unmatched cwds. It does not, and hasn't since v0.8.0:
+
+- The 12-hex IDs (`6bdc098af7f5`, `4c1e5f85af17`, …) were minted by the
+  original Phase A+B daemon (`internal/project/context.go`, commit
+  `340d14c`): `ID = hex(sha256(absPath)[:6])`. That subsystem was deleted in
+  the v0.8.0 MCP-only strip (`9aff8a7`). No hashing exists anywhere in
+  current Go/TS code.
+- Today every creation path is name-keyed: MCP saves require `project_id`
+  and create-on-first-save under the caller-provided string
+  (mcpserver.go save handler → `EnsureProject(id, "", id)`).
+- The live problem is therefore *steering*, not bucket-minting: sessions
+  whose cwd matches no project (`~`, `/`) inject no project context ("no
+  project matched this directory"), so models saving discoveries must invent
+  a project_id — the origin of the stray name buckets (`quack`,
+  `traderjoes`, `clanker`, `undying-codex`).
+
+## Design
+
+### 1. Config knob
+
+    routing:
+      default_project: infrastructure   # empty = feature off (default)
+
+- `RoutingConfig{DefaultProject}` in internal/config; layered through the
+  existing koanf stack. Env override `GHOST_ROUTING_DEFAULT_PROJECT` joins
+  the explicit envOverrides map (underscore-in-key precedent).
+- Empty value = zero behavior change everywhere.
+
+### 2. Session-context routing (the steering lever)
+
+Shared helper in internal/mcpinit used by the session-start context render
+(`loadSessionContext`) and the stop hook's three resolution sites:
+
+    resolveSessionProject(store, cwd):
+      id, name := store.ResolveProject(cwd); hit → return
+      if DefaultProject == "" → return miss (unchanged)
+      if cwd != $HOME && cwd != "/" → return miss (unchanged)
+      return store.ResolveProject(DefaultProject)  // miss degrades to today
+
+Deliberate narrowness:
+
+- Only `$HOME` and `/` route to the default. Other unmatched dirs keep
+  today's behavior — a session under `/tmp/x` saying nothing is safer than
+  silently writing into `infrastructure`.
+- An explicit non-empty `project_id` on any tool call is never overridden:
+  create-on-first-save semantics stay intact for deliberate names.
+- A configured-but-nonexistent default behaves as if unset.
+
+The knob accepts anything `ResolveProject` accepts (name, basename, id),
+resolved at use time — renames don't break config.
+
+### 3. `ghost project merge <old> <new>`
+
+Exposes the previously unreachable `Store.MergeProject` (reassigns all child
+records preserving memory IDs/links/pins, deletes the old row — tx-wrapped,
+already store-tested). Both args go through `ResolveProject`; ambiguity or
+miss errors out with the known-projects listing; `old == new` is rejected.
+This replaces #348's hand-written SQL as the sanctioned consolidation path.
+
+## Out of scope
+
+- Gating auto-creation by root-set (`~/git/*`) — unnecessary now that
+  creation is name-keyed and steering handles the home-dir case.
+- MCP exposure of project merge (admin operation; CLI suffices).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,15 @@ type Config struct {
 	Reflection ReflectionConfig `koanf:"reflection"`
 	Linking    LinkingConfig    `koanf:"linking"`
 	Obsidian   ObsidianConfig   `koanf:"obsidian"`
+	Routing    RoutingConfig    `koanf:"routing"`
+}
+
+// RoutingConfig steers sessions whose cwd matches no known project.
+type RoutingConfig struct {
+	// DefaultProject is the project (name or id, resolved at use time) that
+	// home-dir and filesystem-root sessions fall back to for memory context.
+	// Empty disables the fallback entirely — the historical default.
+	DefaultProject string `koanf:"default_project"`
 }
 
 // APIConfig holds Claude API settings (used by reflection only).
@@ -101,6 +110,7 @@ var defaults = map[string]interface{}{
 	"obsidian.vault_dir":         "",
 	"obsidian.interval":          "30s",
 	"obsidian.auto_sync":         false,
+	"routing.default_project":    "",
 }
 
 // Load reads configuration with layered precedence.
@@ -153,6 +163,7 @@ func Load() (*Config, error) {
 		"GHOST_REFLECTION_AUTO_RESOLVE":   "reflection.auto_resolve",
 		"GHOST_REFLECTION_AUTO_SUPERSEDE": "reflection.auto_supersede",
 		"GHOST_OLLAMA_URL":                "embedding.ollama_url",
+		"GHOST_ROUTING_DEFAULT_PROJECT":   "routing.default_project",
 	}
 	for envKey, koanfKey := range envOverrides {
 		if val := os.Getenv(envKey); val != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,6 +84,65 @@ func TestDataDir_WithXDGDataHome(t *testing.T) {
 	}
 }
 
+func TestLoad_RoutingDefaultProjectEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	unsetEnvVars(t, []string{"GHOST_API_KEY", "ANTHROPIC_API_KEY", "GHOST_ROUTING_DEFAULT_PROJECT"})
+
+	t.Setenv("GHOST_ROUTING_DEFAULT_PROJECT", "infrastructure")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Routing.DefaultProject != "infrastructure" {
+		t.Errorf("expected routing.default_project=infrastructure from env, got %q", cfg.Routing.DefaultProject)
+	}
+}
+
+func TestLoad_DefaultProjectFromYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	unsetEnvVars(t, []string{"GHOST_API_KEY", "ANTHROPIC_API_KEY", "GHOST_ROUTING_DEFAULT_PROJECT"})
+
+	cfgDir := filepath.Join(tmpDir, "ghost")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yamlCfg := "routing:\n  default_project: infrastructure\n"
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte(yamlCfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Routing.DefaultProject != "infrastructure" {
+		t.Errorf("expected routing.default_project=infrastructure from yaml, got %q", cfg.Routing.DefaultProject)
+	}
+}
+
+func TestLoad_DefaultProjectEmptyByDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	unsetEnvVars(t, []string{"GHOST_API_KEY", "ANTHROPIC_API_KEY", "GHOST_ROUTING_DEFAULT_PROJECT"})
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Routing.DefaultProject != "" {
+		t.Errorf("expected routing.default_project empty by default, got %q", cfg.Routing.DefaultProject)
+	}
+}
+
 func TestLoad_GhostEnvOverrides(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)

--- a/internal/mcpinit/hook.go
+++ b/internal/mcpinit/hook.go
@@ -405,10 +405,12 @@ func loadSessionContext(cwd string) (projectID, project string, memories []sessi
 	}
 	defer db.Close() //nolint:errcheck
 
-	// Resolve cwd to a project: id, name, path-prefix, then basename fallback (see Store.ResolveProject).
+	// Resolve cwd to a project: id, name, path-prefix, then basename fallback
+	// (see Store.ResolveProject); home-dir/root sessions additionally fall
+	// back to routing.default_project when configured (issue #391).
 	store := memory.NewStore(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	projectID, project, err = store.ResolveProject(context.Background(), cwd)
-	if err != nil || projectID == "" {
+	projectID, project = resolveSessionProject(context.Background(), store, cwd)
+	if projectID == "" {
 		return
 	}
 

--- a/internal/mcpinit/routing.go
+++ b/internal/mcpinit/routing.go
@@ -1,0 +1,68 @@
+package mcpinit
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/wcatz/ghost/internal/config"
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+// resolveSessionProject resolves a session cwd to a project, falling back to
+// config routing.default_project for home-dir and filesystem-root sessions
+// (issue #391). Everything else — direct hits, other unmatched dirs, an unset
+// or unresolvable default — behaves exactly as a plain ResolveProject call.
+func resolveSessionProject(ctx context.Context, store *memory.Store, cwd string) (id, name string) {
+	id, name = resolve(ctx, store, cwd)
+	if id != "" {
+		return id, name
+	}
+	def := defaultProjectForSessions()
+	if def == "" || !isHomeOrRoot(cwd) {
+		return "", ""
+	}
+	return resolve(ctx, store, def) // "" on miss: degrade to today's no-match behavior
+}
+
+func resolve(ctx context.Context, store *memory.Store, input string) (string, string) {
+	id, name, err := store.ResolveProject(ctx, input)
+	if err != nil {
+		return "", ""
+	}
+	return id, name
+}
+
+func defaultProjectForSessions() string {
+	cfg, err := config.Load()
+	if err != nil {
+		return ""
+	}
+	return cfg.Routing.DefaultProject
+}
+
+// isHomeOrRoot reports whether cwd is the user's home directory or the
+// filesystem root — the two cwds that mean "not really working in a project".
+func isHomeOrRoot(cwd string) bool {
+	if cwd == "/" {
+		return true
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	if cwd == home {
+		return true
+	}
+	// The session cwd may reach home through a symlink or trailing form;
+	// compare resolved paths too.
+	evalCwd, err := filepath.EvalSymlinks(cwd)
+	if err != nil {
+		return false
+	}
+	evalHome, err := filepath.EvalSymlinks(home)
+	if err != nil {
+		return false
+	}
+	return evalCwd == evalHome
+}

--- a/internal/mcpinit/routing_test.go
+++ b/internal/mcpinit/routing_test.go
@@ -1,0 +1,99 @@
+package mcpinit
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+// TestResolveSessionProject covers the home-dir/root fallback routing added
+// for issue #391: an unmatched cwd normally resolves to nothing, but with
+// routing.default_project configured a $HOME or "/" session falls back to it.
+func TestResolveSessionProject(t *testing.T) {
+	setup := func(t *testing.T, defaultProject string) *memory.Store {
+		t.Helper()
+		t.Setenv("GHOST_ROUTING_DEFAULT_PROJECT", defaultProject)
+		db, err := memory.OpenDB(":memory:")
+		if err != nil {
+			t.Fatalf("OpenDB: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		store := memory.NewStore(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		if err := store.EnsureProject(context.Background(), "infra", "/home/wayne/git/infra", "infrastructure"); err != nil {
+			t.Fatalf("EnsureProject: %v", err)
+		}
+		return store
+	}
+
+	t.Run("direct path hit needs no routing", func(t *testing.T) {
+		store := setup(t, "")
+		id, name := resolveSessionProject(context.Background(), store, "/home/wayne/git/infra/internal/x")
+		if id != "infra" || name != "infrastructure" {
+			t.Fatalf("got (%q, %q), want (infra, infrastructure)", id, name)
+		}
+	})
+
+	t.Run("home cwd falls back to configured default", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", home)
+		store := setup(t, "infrastructure")
+		id, name := resolveSessionProject(context.Background(), store, home)
+		if id != "infra" || name != "infrastructure" {
+			t.Fatalf("got (%q, %q), want (infra, infrastructure)", id, name)
+		}
+	})
+
+	t.Run("filesystem root falls back to configured default", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", home)
+		store := setup(t, "infrastructure")
+		id, _ := resolveSessionProject(context.Background(), store, "/")
+		if id != "infra" {
+			t.Fatalf("got %q, want infra", id)
+		}
+	})
+
+	t.Run("no default configured behaves as today", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", home)
+		store := setup(t, "")
+		id, name := resolveSessionProject(context.Background(), store, home)
+		if id != "" || name != "" {
+			t.Fatalf("got (%q, %q), want empty", id, name)
+		}
+	})
+
+	t.Run("non-home unmatched cwd never routes", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", home)
+		store := setup(t, "infrastructure")
+		other := filepath.Join(home, "unrelated")
+		if err := os.MkdirAll(other, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		id, name := resolveSessionProject(context.Background(), store, other)
+		if id != "" || name != "" {
+			t.Fatalf("got (%q, %q), want empty — only HOME and / may route", id, name)
+		}
+	})
+
+	t.Run("configured but nonexistent default degrades to miss", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", home)
+		store := setup(t, "does-not-exist")
+		id, name := resolveSessionProject(context.Background(), store, home)
+		if id != "" || name != "" {
+			t.Fatalf("got (%q, %q), want empty", id, name)
+		}
+	})
+}

--- a/internal/mcpinit/stophook.go
+++ b/internal/mcpinit/stophook.go
@@ -192,8 +192,8 @@ func spawnResolveIfConfigured(cwd, source string) {
 	defer db.Close() //nolint:errcheck
 
 	store := memory.NewStore(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	projectID, projectName, err := store.ResolveProject(context.Background(), cwd)
-	if err != nil || projectID == "" || projectName == "" {
+	projectID, projectName := resolveSessionProject(context.Background(), store, cwd)
+	if projectID == "" || projectName == "" {
 		return
 	}
 
@@ -272,8 +272,8 @@ func spawnSupersedeIfConfigured(cwd, source string) {
 	defer db.Close() //nolint:errcheck
 
 	store := memory.NewStore(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	projectID, projectName, err := store.ResolveProject(context.Background(), cwd)
-	if err != nil || projectID == "" || projectName == "" {
+	projectID, projectName := resolveSessionProject(context.Background(), store, cwd)
+	if projectID == "" || projectName == "" {
 		return
 	}
 
@@ -360,8 +360,8 @@ func spawnReflectIfConfigured(cwd, source string) {
 	defer db.Close() //nolint:errcheck
 
 	store := memory.NewStore(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	projectID, projectName, err := store.ResolveProject(context.Background(), cwd)
-	if err != nil || projectID == "" || projectName == "" {
+	projectID, projectName := resolveSessionProject(context.Background(), store, cwd)
+	if projectID == "" || projectName == "" {
 		return
 	}
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -243,7 +243,14 @@ func (s *Store) EnsureProject(ctx context.Context, id, path, name string) error 
 
 // MergeProject reassigns all child records from oldID to newID, then deletes
 // the old project row. Use this to unify duplicate project entries.
+// Refuses _global on either side, mirroring DeleteProject: merging away from
+// _global would delete its project row and silently stop global injection
+// everywhere; merging into it would dump an arbitrary bucket into every
+// session's context.
 func (s *Store) MergeProject(ctx context.Context, oldID, newID string) error {
+	if oldID == "_global" || newID == "_global" {
+		return fmt.Errorf("refusing to merge the _global project (old=%q new=%q)", oldID, newID)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.mergeProjectLocked(ctx, oldID, newID)

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -4105,3 +4105,35 @@ func TestStoreUpsert_StrengthenDirectionForSupersede(t *testing.T) {
 		t.Fatalf("supersede orientation would pick the wrong row as newer: got %s, want B (%s)", firstID, idB)
 	}
 }
+
+func TestMergeProject_RefusesGlobal(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	if err := s.EnsureProject(ctx, "target", "/tmp/target", "target"); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+	if err := s.EnsureProject(ctx, "_global", "_global", "global"); err != nil {
+		t.Fatalf("EnsureProject _global: %v", err)
+	}
+
+	t.Run("as source refuses like DeleteProject", func(t *testing.T) {
+		err := s.MergeProject(ctx, "_global", "target")
+		if err == nil || !strings.Contains(err.Error(), "_global") {
+			t.Fatalf("expected _global refusal, got: %v", err)
+		}
+		var n int
+		if err := s.db.QueryRow(`SELECT COUNT(*) FROM projects WHERE id = '_global'`).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n != 1 {
+			t.Fatalf("_global project row disturbed after refused merge: count=%d", n)
+		}
+	})
+
+	t.Run("as target refuses", func(t *testing.T) {
+		err := s.MergeProject(ctx, "target", "_global")
+		if err == nil || !strings.Contains(err.Error(), "_global") {
+			t.Fatalf("expected _global refusal, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Closes #391

## Corrected root cause (investigated this session)
The issue presumed current ghost still mints hash-named buckets. It can't — and hasn't since v0.8.0: the 12-hex IDs came from the pre-v0.8.0 daemon's `sha256(path)[:6]` scheme (`internal/project/context.go`, commit 340d14c, deleted in 9aff8a7). Verified: all seven legacy 12-hex rows match `sha256(cwd)[:12]` exactly; no hashing exists in current Go/TS. Today's real gap is *steering*: home-dir/root sessions inject no project context, so models invent project_ids on save (the quack/traderjoes/clanker pattern).

## What ships
- **Config knob** `routing.default_project` (yaml + `GHOST_ROUTING_DEFAULT_PROJECT`), empty = off
- **Session routing**: unmatched cwd that is $HOME or `/` falls back to the configured default for context injection — session-start hook, opencode context render, and all three stop-hook worker sites. Explicit project_ids and non-home unmatched dirs are never overridden; a configured-but-missing default degrades to today's behavior.
- **`ghost project merge <old> <new>`**: exposes the previously unreachable Store.MergeProject (tx-wrapped, preserves memory IDs/links/pins) as the sanctioned consolidation path — replaces #348's hand-written SQL. Resolves both args via ResolveProject, refuses self-merge, lists known projects on miss.

Spec: docs/superpowers/specs/2026-08-26-home-dir-default-project.md

## Test plan
- [x] config: env override / yaml / empty-by-default
- [x] routing helper: 6 subtests (direct hit, home→default, root→default, unset, non-home guard, missing default)
- [x] merge core: merge-preserves-IDs, self-merge refusal, unknown-project listing
- [x] Live E2E: `GHOST_ROUTING_DEFAULT_PROJECT=infrastructure ghost context --cwd ~` injects infrastructure context; without var → unchanged; with var + /tmp → still unrouted
- [x] go vet ./... clean, full go test ./... green