### PR TITLE
chore(ci): invariant-parity review lenses for PR-Agent

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -37,6 +37,17 @@ require_score_review = true
 require_todo_scan = true
 require_can_be_split_review = true
 
+# Compliance checks alone miss invariant-class bugs. Observed 2026-08-26
+# (#394): a PR exposed Store.MergeProject via a new CLI command and scored
+# 92/fully-compliant while missing that DeleteProject refuses _global but
+# MergeProject did not. These lenses direct attention at exactly that class.
+extra_instructions = """
+Beyond diff-vs-issue compliance, apply these lenses and report findings per lens:
+1. Invariant parity: when a PR adds a caller of an existing internal API (new CLI command, MCP tool, or store method), read that API's full implementation chain down to the deepest layer it touches, and compare its guard clauses against sibling mutators on the same resource (e.g. DeleteProject refuses _global — any new destructive or reassigning operation on projects must refuse it too).
+2. Protected resources: the _global project row, production DB rows, subprocess env keys. Verify refusal paths exist at the deepest implementation layer, not only at the wrapper the PR introduced.
+3. Behavior preservation at modified call sites: confirm replacement error-handling logic covers the same failure modes as before (e.g. an `err != nil` check replaced by an empty-string check must be equivalent for every path that previously returned err).
+"""
+
 [pr_code_suggestions]
 # Post high-confidence suggestions as committable inline code comments
 # (GitHub suggestion blocks the author can accept with one click).

--- a/best_practices.md
+++ b/best_practices.md
@@ -32,3 +32,8 @@
 - Strip API keys from subprocess environments (ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOSE_PROVIDER__API_KEY)
 - Never log or commit secrets
 - SOPS-encrypted secrets only — never git restore encrypted files
+
+## Project Invariants
+- The `_global` project is protected: every destructive or reassigning project operation (`DeleteProject`, `MergeProject`, any future op that deletes project rows or moves child records) must refuse `_global` on either side, with the refusal implemented at the store layer so all callers inherit it
+- New callers of existing store/provider APIs inherit that API's guard clauses — when exposing one through a new CLI command or MCP tool, read the full implementation first and preserve its refusals at the deepest layer
+- Error-handling replacements at call sites must cover the same failure modes they replace (an empty-string miss-check is only equivalent to `err != nil` if every error path also returns empty)


### PR DESCRIPTION
Follow-up to the #394 self-review (where PR-Agent scored 92/fully-compliant but missed that `ghost project merge` exposed `Store.MergeProject` without `DeleteProject`'s `_global` refusal).

## Change
- **[pr_reviewer] extra_instructions** — three explicit review lenses:
  1. *Invariant parity*: new callers of existing internal APIs get their implementation chain read down to the deepest layer, guard clauses compared against sibling mutators
  2. *Protected resources*: refusal paths verified at the deepest implementation layer, not just the wrapper
  3. *Behavior preservation*: replacement error-handling must cover the same failure modes as before
- **best_practices.md → Project Invariants**: same rules as durable repo conventions, so they reach every review run AND future agent sessions

## Honest limits (worth stating)
Prompt lenses raise the odds, they don't guarantee catches — LLM reviewers miss things regardless of instructions. The structural mitigations remain: invariants live in the store layer where all callers inherit them, and self-review before merge stays mandatory.

## Test plan
- [x] Config-only change; CI on this PR validates workflow + settings parse (apply_repo_settings runs on default branch post-merge)