### PR TITLE
fix(obsidian): retry initial export failure instead of dying silently

### DIFF
--- a/internal/obsidian/sync.go
+++ b/internal/obsidian/sync.go
@@ -23,8 +23,13 @@ func Sync(ctx context.Context, ex *Exporter, db *sql.DB, vaultDir, projectFilter
 	if err != nil {
 		return err
 	}
+	// The initial export takes the same failure path as a tick export: log
+	// and keep looping. Returning here would kill auto-sync permanently on a
+	// transient startup blip (vault volume not yet mounted, busy disk), and
+	// silently — the tick loop is what logs. last was captured before the
+	// attempt, so the very next tick retries without needing another commit.
 	if err := ex.Export(ctx, vaultDir, projectFilter); err != nil {
-		return err
+		ex.Logger.Warn("obsidian sync: initial export failed, will retry next tick", "error", err)
 	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/internal/obsidian/sync_test.go
+++ b/internal/obsidian/sync_test.go
@@ -3,6 +3,7 @@ package obsidian
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -118,7 +119,9 @@ func TestSyncRetriesFailedExport(t *testing.T) {
 	if _, err := writeStore.Create(ctx, "p1", memory.Memory{Category: "fact", Content: "second memory", Importance: 0.7, Source: "mcp"}); err != nil {
 		t.Fatal(err)
 	}
-	waitFor(t, func() bool { return strings.Contains(buf.String(), "export failed") })
+	waitForDebug(t, "export failed log after injected ReadDir failure", func() bool {
+		return strings.Contains(buf.String(), "export failed")
+	}, func() string { return buf.String() })
 
 	// Fix the vault. NO further commits: only a retained baseline retries.
 	readDirFn.Store(os.ReadDir)
@@ -153,6 +156,11 @@ func (l *logBuffer) String() string {
 
 func waitFor(t *testing.T, cond func() bool) {
 	t.Helper()
+	waitForDebug(t, "condition", cond, nil)
+}
+
+func waitForDebug(t *testing.T, what string, cond func() bool, debug func() string) {
+	t.Helper()
 	// Generous deadline: these tests drive a real 50ms ticker, and under
 	// `go test -race ./...` scheduler contention can delay a tick well past a
 	// tight bound. A passing condition is met in well under a second; the
@@ -165,5 +173,9 @@ func waitFor(t *testing.T, cond func() bool) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatalf("condition not met within %s", deadline)
+	msg := fmt.Sprintf("%s: not met within %s", what, deadline)
+	if debug != nil {
+		msg += "\nlog buffer:\n" + debug()
+	}
+	t.Fatal(msg)
 }


### PR DESCRIPTION
CI on #395 failed twice in `TestSyncRetriesFailedExport` (`go test -race`), waiting 30s for an `export failed` log that provably never fired — the failure dump showed an empty log buffer. Reproduced locally at `-count=15 -race` (5/5 hangs).

## Root cause
`Sync`'s **initial** export error path returned the error directly — no log, no retry (sync.go:26-28). Under race-instrumented scheduling, the test's injected `ReadDir` fault can land *mid-initial-pass* (the orphan scan shares the same seam at vault.go:159), so pass one dies after writing its first file and the goroutine exits. The tick loop always logged-and-retried; the initial path did neither.

This is a real production bug the flake surfaced: any transient startup blip (vault volume not yet mounted, busy disk) would permanently kill `obsidian auto_sync` with zero diagnostics.

## Fix
- Initial export takes the same path as a tick export: `Warn` + keep looping. Baseline is captured before the attempt, so the next tick retries without needing another commit.
- `waitFor` gains a debug variant dumping the log buffer on timeout (this diagnosis required it; generic 'condition not met' cost a round-trip).

## Test plan
- [x] Previously-red stress config now green: `-run TestSyncRetriesFailedExport -count=15 -race` (was 5/5 FAIL, now ok in 4.4s)
- [x] Full obsidian package: `-race -count=1` and plain, both green
- [x] go vet ./... clean