### PR TITLE
docs(cli): sync command references with shipped subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,15 +282,18 @@ The server ships with embedded instructions that teach the agent when to save, w
 
 ```text
 ghost mcp                    # Run MCP server on stdio (used by your MCP client)
-ghost mcp init [--client claude|opencode|codex|goose] [--dry-run]  # Configure MCP client integration (default: Claude Code)
+ghost mcp init [--client claude|opencode|codex|goose|all] [--dry-run]  # Configure MCP client integration (default: Claude Code)
 ghost mcp status [--client claude|opencode|codex|goose]    # Deep health checks (incl. Ollama reachability, model presence)
 ghost hook <event> --source <host>  # Contract-v1 lifecycle hook (session-start, stop, session-end)
 ghost reflect <project>      # Memory consolidation (dry-run by default; --apply, --restore, --tier)
 ghost resolve <project>      # De-weight resolved-evidence memories from injection (dry-run by default; --apply)
 ghost supersede <project>    # Link superseded memories (dry-run by default; --apply, --threshold)
+ghost project delete <name> [flags]  # Permanently delete a project and everything under it (dry-run by default; --apply + name re-type to confirm)
+ghost project merge <old> <new>      # Merge one project into another: child records are reassigned to the survivor, memory IDs/links/pins preserved
 ghost bench [--sweep]        # Retrieval-quality benchmark on the built-in dataset
 ghost obsidian export        # Mirror memories to an Obsidian vault (one-way; --out, --project)
 ghost obsidian sync          # Keep the vault mirror fresh (--interval; polls for DB changes)
+ghost context [--cwd <dir>]  # Print the passive session-start context block (for opencode)
 ghost upgrade                # Self-update from GitHub Releases (linux/macOS; Windows: re-download)
 ghost version                # Print version
 ```

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -1389,6 +1389,8 @@ Commands:
   resolve <project> [flags]   Mark resolved evidence memories (dry-run by default, --apply to write)
   project delete <name> [flags]  Permanently delete a project and everything under it
                               (dry-run by default, --apply + name re-type to confirm)
+  project merge <old> <new>   Merge one project into another; child records move to the
+                              survivor with memory IDs, links, and pin state preserved
   obsidian export [flags]     Mirror memories to an Obsidian vault (one-way)
   obsidian sync [flags]       Keep the vault mirror fresh (polls for DB changes)
   context [--cwd <dir>]       Print the passive session-start context block (for opencode)


### PR DESCRIPTION
Fixes #398

Two-line docs sync: README's command reference and the CLI's own `printUsage` now match the shipped CLI (`go run ./cmd/ghost --help`).

**README gains:** `project delete` (#313), `project merge` (#394), `context [--cwd <dir>]`, and `all` in mcp init's `--client` list.
**printUsage gains:** the missing `project merge` line.

Deliberately NOT added: `all` for `mcp status` — verified runMCPStatus rejects it (cmd/ghost/main.go:270); only init fans out via runAllClients.

No behavior change; `go vet` + full `go test ./...` pass.