### PR TITLE
chore(ci): silence review intro text and ticket compliance section

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -23,6 +23,17 @@ propagate_tool_errors = true
 enable_global_best_practices = true
 
 [pr_reviewer]
+# Drop the canned "Here are some key observations to aid the review
+# process:" opener — pure noise, the table speaks for itself.
+enable_intro_text = false
+
+# Disable the native 🎫 ticket-compliance section (require_ticket_
+# analysis_review defaults true): when a PR formally links an issue it
+# grades diff-vs-ticket and mislabels clean PRs "Partially compliant"
+# (observed 2026-08-26 on #399 with all requirements fulfilled). The
+# merge gate is conversation resolution, not bot grading.
+require_ticket_analysis_review = false
+
 # Anchor key issues as inline comments on diff lines instead of
 # listing them only in the summary table (matches the old CodeRabbit
 # comment style more closely).


### PR DESCRIPTION
Two `[pr_reviewer]` flags in `.pr_agent.toml`, both verified against the pinned action source (`4ebd5c5`):

- `enable_intro_text = false` — drops the canned "Here are some key observations to aid the review process:" opener (gate confirmed at pr_agent/algo/utils.py:178-180; default true in settings/configuration.toml:121)
- `require_ticket_analysis_review = false` — kills the native 🎫 ticket-compliance section, which graded diff-vs-issue and mislabeled a fully-clean PR (all requirements fulfilled) as "Partially compliant" on #399

Deliberately not changed here: the "PR Reviewer Guide" heading — renaming needs upstream `review_heading`, present only in unreleased main, absent through v0.43.0. Tracked for the next pin bump.

Known separate issue (not bundled): the verdict-card format contract at `.pr_agent.toml` extra_instructions is inert — the workflow env's extra_instructions overrides it per documented precedence.
