### PR TITLE
feat(init): auto-detect MCP clients on PATH when --client omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ The server ships with embedded instructions that teach the agent when to save, w
 
 ```text
 ghost mcp                         # Run MCP server on stdio (used by your MCP client)
-ghost mcp init [--client claude|opencode|codex|goose|all] [--dry-run]  # Configure MCP client integration (default: Claude Code)
+ghost mcp init [--client claude|opencode|codex|goose|all] [--dry-run]  # Configure MCP client (auto-detects when --client omitted)
 ghost mcp status [--client claude|opencode|codex|goose]                # Deep health checks (incl. Ollama reachability, model presence)
 ghost hook <event> --source <host>   # Contract-v1 lifecycle hook (session-start, stop, session-end)
 ghost reflect <project> [flags]      # Memory consolidation (dry-run by default; --apply, --restore, --tier, --source)
@@ -302,7 +302,7 @@ ghost upgrade                        # Self-update from GitHub Releases (linux/m
 ghost version                        # Print version
 ```
 
-`ghost mcp init` and `ghost mcp status` default to Claude Code; `--client opencode` targets opencode instead, installing a single lifecycle plugin to `~/.config/opencode/plugins/ghost-opencode.ts` that self-registers the MCP server and bridges stop events (opencode's own config file is never modified; re-running init repairs an outdated plugin in place).
+`ghost mcp init` auto-detects which MCP clients are on PATH and installs for all of them. When only one is found, it installs for that one; when multiple are found, it installs for all; when none are found, it errors with install instructions. Use `--client` to override and target a specific client (e.g. `--client opencode` installs a single lifecycle plugin to `~/.config/opencode/plugins/ghost-opencode.ts` that self-registers the MCP server and bridges stop events — opencode's own config file is never modified; re-running init repairs an outdated plugin in place).
 
 When `reflection.auto_resolve` is enabled in config (default off), the stop hook also spawns `ghost resolve <project> --apply` as a detached background process after each session, so resolved-evidence memories get marked automatically without waiting for a manual run. This never blocks the hook itself — the spawn is fire-and-forget, logged to `resolve.log` in the ghost data directory. If the Anthropic API is out of credit at spawn time, the spawned process fails and logs the failure; it does not degrade to a lower-quality answer.
 

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -176,18 +176,30 @@ func parseMCPClient(args []string) (string, error) {
 
 // clientTarget pairs a display name with its `mcp init` installer.
 type clientTarget struct {
-	name string
-	run  func(w io.Writer, dryRun bool) error
+	name   string
+	binary string // binary name to detect on PATH
+	run    func(w io.Writer, dryRun bool) error
 }
 
 // mcpInitTargets lists every installable client in run order.
 func mcpInitTargets() []clientTarget {
 	return []clientTarget{
-		{"claude", mcpinit.Run},
-		{"opencode", mcpinit.RunOpencode},
-		{"codex", mcpinit.RunCodex},
-		{"goose", mcpinit.RunGoose},
+		{"claude", "claude", mcpinit.Run},
+		{"opencode", "opencode", mcpinit.RunOpencode},
+		{"codex", "codex", mcpinit.RunCodex},
+		{"goose", "goose", mcpinit.RunGoose},
 	}
+}
+
+// detectClients returns the names of clients whose binaries are found on PATH.
+func detectClients() []string {
+	var found []string
+	for _, t := range mcpInitTargets() {
+		if _, err := exec.LookPath(t.binary); err == nil {
+			found = append(found, t.name)
+		}
+	}
+	return found
 }
 
 // runAllClients installs ghost into every target sequentially, continuing past
@@ -207,22 +219,45 @@ func runAllClients(stdout, stderr io.Writer, dryRun bool, targets []clientTarget
 }
 
 // runMCPInit configures an MCP client to use Ghost as its memory system.
-// Defaults to Claude Code; --client opencode targets opencode instead; --client
-// all installs into every supported client sequentially.
+// When --client is omitted, detects which clients are on PATH and installs
+// for all of them (or just the one found). --client all installs into every
+// supported client unconditionally.
 func runMCPInit() {
 	client, err := parseMCPClient(os.Args[3:])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-	if client == "" {
-		client = "claude"
-	}
 
 	dryRun := false
 	for _, a := range os.Args[3:] {
 		if a == "--dry-run" {
 			dryRun = true
+		}
+	}
+
+	// Auto-detect when --client is omitted.
+	if client == "" {
+		detected := detectClients()
+		switch len(detected) {
+		case 0:
+			fmt.Fprintf(os.Stderr, "error: no supported MCP client found on PATH\n"+
+				"  Install one of: Claude Code, opencode, codex, goose\n"+
+				"  Or specify explicitly: ghost mcp init --client <name>\n")
+			os.Exit(1)
+		case 1:
+			client = detected[0]
+		default:
+			fmt.Fprintf(os.Stderr, "Detected clients: %s\n"+
+				"  Installing for all detected clients.\n"+
+				"  Use --client to target a specific one.\n\n",
+				strings.Join(detected, ", "))
+			failed := runAllClients(os.Stdout, os.Stderr, dryRun, mcpInitTargetsFor(detected))
+			if len(failed) > 0 {
+				fmt.Fprintf(os.Stderr, "\ncompleted with failures: %s\n", strings.Join(failed, ", "))
+				os.Exit(1)
+			}
+			return
 		}
 	}
 
@@ -250,6 +285,21 @@ func runMCPInit() {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// mcpInitTargetsFor returns clientTargets filtered to the given names.
+func mcpInitTargetsFor(names []string) []clientTarget {
+	nameSet := make(map[string]bool, len(names))
+	for _, n := range names {
+		nameSet[n] = true
+	}
+	var targets []clientTarget
+	for _, t := range mcpInitTargets() {
+		if nameSet[t.name] {
+			targets = append(targets, t)
+		}
+	}
+	return targets
 }
 
 // runMCPStatus checks the health of the Ghost ↔ MCP client integration.
@@ -1383,6 +1433,7 @@ Usage:
 Commands:
   mcp                         Start MCP server on stdio (used by Claude Code)
   mcp init [--client claude|opencode|codex|goose|all] [--dry-run]  Configure MCP client integration
+                                                         (auto-detects when --client is omitted)
   mcp status [--client claude|opencode|codex|goose]                Check MCP client integration health
   reflect <project> [flags]   Memory consolidation (dry-run by default, --apply to save)
   supersede <project> [flags] Link superseded memories (dry-run by default, --apply to write)

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -419,10 +419,10 @@ func TestBuildClassifyProvider_KeySetBuildsRegardless(t *testing.T) {
 func TestRunAllClients(t *testing.T) {
 	t.Run("continues past failures and reports them", func(t *testing.T) {
 		targets := []clientTarget{
-			{"ok-first", func(w io.Writer, dryRun bool) error { return nil }},
-			{"boom", func(w io.Writer, dryRun bool) error { return fmt.Errorf("kaput") }},
-			{"ok-last", func(w io.Writer, dryRun bool) error { return nil }},
-			{"boom2", func(w io.Writer, dryRun bool) error { return fmt.Errorf("kaput too") }},
+			{"ok-first", "", func(w io.Writer, dryRun bool) error { return nil }},
+			{"boom", "", func(w io.Writer, dryRun bool) error { return fmt.Errorf("kaput") }},
+			{"ok-last", "", func(w io.Writer, dryRun bool) error { return nil }},
+			{"boom2", "", func(w io.Writer, dryRun bool) error { return fmt.Errorf("kaput too") }},
 		}
 		var stdout, stderr bytes.Buffer
 		failed := runAllClients(&stdout, &stderr, false, targets)
@@ -445,8 +445,8 @@ func TestRunAllClients(t *testing.T) {
 	})
 	t.Run("all succeed returns empty", func(t *testing.T) {
 		targets := []clientTarget{
-			{"a", func(w io.Writer, dryRun bool) error { return nil }},
-			{"b", func(w io.Writer, dryRun bool) error { return nil }},
+			{"a", "", func(w io.Writer, dryRun bool) error { return nil }},
+			{"b", "", func(w io.Writer, dryRun bool) error { return nil }},
 		}
 		var stdout, stderr bytes.Buffer
 		if failed := runAllClients(&stdout, &stderr, true, targets); len(failed) != 0 {

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -484,6 +484,49 @@ func targetNames(targets []clientTarget) []string {
 	return names
 }
 
+// TestDetectClients verifies that detectClients returns only the names of
+// clients whose binaries are findable on PATH.
+func TestDetectClients(t *testing.T) {
+	// Create a temp dir with stub binaries for two of the four clients.
+	dir := t.TempDir()
+	writeStub(t, dir, "opencode")
+	writeStub(t, dir, "goose")
+
+	// Override PATH to include only our temp dir.
+	t.Setenv("PATH", dir)
+
+	got := detectClients()
+	want := []string{"opencode", "goose"}
+	if len(got) != len(want) {
+		t.Fatalf("detectClients() = %v, want %v", got, want)
+	}
+	for i, name := range want {
+		if got[i] != name {
+			t.Errorf("detectClients()[%d] = %q, want %q", i, got[i], name)
+		}
+	}
+}
+
+// TestDetectClients_EmptyPath verifies that detectClients returns nil when
+// no client binaries are on PATH.
+func TestDetectClients_EmptyPath(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	got := detectClients()
+	if len(got) != 0 {
+		t.Fatalf("detectClients() = %v, want empty", got)
+	}
+}
+
+// writeStub creates an executable stub script at binDir/name.
+func writeStub(t *testing.T, binDir, name string) string {
+	t.Helper()
+	path := filepath.Join(binDir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 // TestMCPLogConfig_QuietWhenSpawned guards the #373 fix: a client-spawned
 // server (stderr not a terminal) must drop routine INFO logs from stderr so
 // MCP clients that surface stderr don't leak them into the UI.


### PR DESCRIPTION
## Summary

When `--client` is omitted from `ghost mcp init`, auto-detects which MCP clients (claude, opencode, codex, goose) are on PATH and installs for all of them.

- 1 client found → installs for that one
- Multiple found → installs for all (with a notice)
- None found → errors with install instructions
- `--client` provided → uses that (existing behavior preserved)

## Changes

- Added `detectClients()` function using `exec.LookPath`
- Added `mcpInitTargetsFor()` to filter targets by name
- Updated `runMCPInit()` to auto-detect when no flag provided
- Updated help text and README

## Testing

`go vet ./...` and `go test ./cmd/ghost/...` pass.