### PR TITLE
fix: comment/docs drift across codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,15 +3,15 @@
 ## Stack
 - Go 1.26+ CLI application
 - SQLite with FTS5 for memory persistence (modernc.org/sqlite — pure Go, no CGO)
-- Claude API (manual HTTP client) — used by reflection only
+- Claude API (manual HTTP client) — used by reflection, resolve, and supersede
 - MCP server via modelcontextprotocol/go-sdk (stdio transport)
 
 ## Architecture
-- `cmd/ghost/main.go` — CLI entrypoint; subcommands: mcp, hook, reflect, resolve, supersede, project, obsidian, bench, upgrade, version
+- `cmd/ghost/main.go` — CLI entrypoint; subcommands: mcp, hook, reflect, resolve, supersede, project, obsidian, bench, upgrade, version, context
 - `internal/ai/` — Claude API client (non-streaming Reflect call, used by reflection + resolve + supersede); `Provider` seam (`anthropicClient`/`SamplingProvider`) with `FallbackProvider` credit-exhaustion fallover for resolve/supersede
 - `internal/memory/` — SQLite CRUD, FTS5 search, vector search, time-decay scoring
 - `internal/mcpserver/` — MCP server: 20 tools + 4 resources + 2 prompts (`recall_project`, `record_decision`)
-- `internal/mcpinit/` — `ghost mcp init`, `ghost mcp status`, `ghost hook <event> --source <host>` (contract-v1 lifecycle dispatch; installers: claude-code, opencode plugin-only, codex TOML+hooks.json, goose Agent-Plugins package; goose field aliasing lives in hostevent.Parse)
+- `internal/mcpinit/` — `ghost mcp init`, `ghost mcp status`, `ghost hook <event> --source <host>` (contract-v1 lifecycle dispatch; installers: claude-code, opencode plugin, codex TOML+hooks.json, goose Agent-Plugins package; goose field aliasing lives in hostevent.Parse)
 - `internal/claudeimport/` — One-time import of Claude Code auto-memory on first contact
 - `internal/embedding/` — Ollama async vectorization worker
 - `internal/linking/` — Background worker linking similar memories into a graph

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -911,9 +911,8 @@ cli.opencode_binary) — requires one of the two.`)
 // keyword prefilter proposes candidates; Haiku adjudicates each with a crisp
 // conclusion-vs-evidence question biased to KEEP. Dry-run by default; --apply
 // writes resolved_at. Re-runnable and reversible: any later Upsert/UpdateMemory
-// of a memory clears its resolved_at. Standalone command, never a hook — the
-// stop-hook contract forbids DB access on that path. See the
-// resolution-classifier spec.
+// of a memory clears its resolved_at. The stop hook spawns this as a
+// detached --apply process (internal/mcpinit/stophook.go).
 func runResolve() {
 	var projectName string
 	var source string
@@ -1449,6 +1448,7 @@ Commands:
   mcp init [--client claude|opencode|codex|goose|all] [--dry-run]  Configure MCP client integration
                                                          (auto-detects when --client is omitted)
   mcp status [--client claude|opencode|codex|goose]                Check MCP client integration health
+  hook <event> [--source <host>]  Lifecycle hook for MCP clients (session-start, stop)
   reflect <project> [flags]   Memory consolidation (dry-run by default, --apply to save)
   supersede <project> [flags] Link superseded memories (dry-run by default, --apply to write)
   resolve <project> [flags]   Mark resolved evidence memories (dry-run by default, --apply to write)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,17 +5,21 @@
 Ghost runs as a single binary with one primary mode:
 
 ```
-ghost mcp              MCP server on stdio (used by Claude Code, Cursor, Goose)
-ghost mcp init         Configure Claude Code integration
+ghost mcp              MCP server on stdio (used by Claude Code, Cursor, Goose, opencode)
+ghost mcp init         Configure MCP client integration (four hosts: claude, opencode, codex, goose)
 ghost mcp status       Health check
-ghost hook session-start --source claude-code   SessionStart hook (called by Claude Code)
-ghost hook stop --source claude-code        Stop hook — save-nudge, blocks stop once (called by Claude Code)
+ghost hook session-start --source <host>   SessionStart hook (called by MCP clients)
+ghost hook stop --source <host>        Stop hook — save-nudge, blocks stop once (called by MCP clients)
 ghost reflect <project>    Manual memory consolidation
 ghost supersede <project>  LLM-classified 'supersedes' link creation
 ghost obsidian export|sync One-way Markdown vault mirror
 ghost bench [--sweep]      Retrieval-quality benchmark
 ghost upgrade          Self-update from GitHub Releases (sha256-verified)
 ghost version          Print version
+ghost context [--cwd <dir>]       Print the passive session-start context block (for opencode)
+ghost resolve <project>    Mark resolved-evidence memories (dry-run by default, --apply to write)
+ghost project delete <name> [--apply]   Permanently delete a project and everything under it (dry-run by default)
+ghost project merge <old> <new>   Merge one project into another; child records move to the survivor with memory IDs, links, and pin state preserved
 ```
 
 ## Package Map
@@ -23,8 +27,7 @@ ghost version          Print version
 ```
 cmd/ghost/main.go          CLI entrypoint + subcommand dispatch
 internal/
-  ai/                      Claude API client (used by reflection and supersede)
-    client.go              HTTP client, Reflect(), CountTokens() — non-streaming
+  ai/                      LLM backends: Anthropic HTTP client + 4 CLI backends (claude, opencode, codex, goose) + sampling provider + source-aware routing; client.go: Reflect(); models.go: Message/TokenUsage; cost.go: per-model pricing; used by reflection, resolve, and supersede
     models.go              Message, ContentBlock, SystemBlock, TokenUsage
     cost.go                Per-model pricing, CostForUsage()
   config/                  Layered configuration (koanf)
@@ -37,7 +40,7 @@ internal/
     worker.go              Sweeps embedded memories, links cosine neighbors ≥ threshold
   supersede/               ghost supersede — 'supersedes' link creation
     supersede.go           Candidate selection (cosine proposes, created_at directs), Run()
-    haiku.go               LLM classifier confirming genuine replacements
+    haiku.go               LLM classifier for 3-way SUPERSEDES/CAUSES/NEITHER classification
   bench/                   ghost bench — retrieval-quality benchmark harness
     dataset.go             JSONL dataset loading + seeding with embedding fixtures
     runner.go              Graded conditions (fts/vector/hybrid)
@@ -49,27 +52,37 @@ internal/
     store.go               SQLite CRUD, FTS5 search, time-decay scoring
     schema.go              DDL (embedded Go string constant — the single source of truth)
     vector.go              Cosine similarity, hybrid RRF search
-    links.go               Memory links: edge CRUD (related/supersedes)
+    links.go               Memory links: edge CRUD (related/supersedes/contradicts/elaborates/causes)
+  resolve/                 ghost resolve — keyword prefilter + LLM classify → resolved_at
   mcpserver/               MCP server (stdio transport)
-    mcpserver.go           20 tools + 4 resources via go-sdk
+    mcpserver.go           20 tools + 4 resources + 2 prompts via go-sdk
   hostevent/               Normalized host-event contract: envelope parse, capability matrix, transcript scanners
-  mcpinit/                 Host integration setup — contract-v1 lifecycle dispatch, installers (Claude Code, opencode)
+  mcpinit/                 Host integration setup — contract-v1 lifecycle dispatch, installers (Claude Code, opencode, codex, goose)
     init.go                ghost mcp init — registers server, imports memories, writes redirects
     status.go              ghost mcp status — health check
     opencode_ghost.ts      Embedded opencode lifecycle plugin (session.status→idle → contract)
     hook.go                ghost hook session-start — injects project context
     stophook.go            ghost hook stop — save-nudge, blocks stop once when nothing was saved
+  obsidian/                One-way Markdown vault mirror (ghost export → PRAGMA data_version sync)
+    export.go              Export memories to Markdown vault
+    sync.go                Keep vault mirror fresh (PRAGMA data_version polling)
+    render.go              Render memory blocks as Markdown
+  linking/                 Memory auto-linking
+    worker.go              Sweeps embedded memories, links cosine neighbors ≥ threshold
   claudeimport/            One-time import of Claude Code auto-memory files
     import.go              Scans ~/.claude/projects/*/memory/*.md, upserts into Ghost
   reflection/              Memory consolidation
     consolidator.go        Consolidator interface + TieredConsolidator
-    tier_haiku.go          Haiku LLM consolidation (requires ANTHROPIC_API_KEY)
+    tier_haiku.go          Haiku LLM consolidation (requires ANTHROPIC_API_KEY or use CLI tier)
     tier_sqlite.go         Local Jaccard similarity consolidation (free, always available)
     prompt.go              BuildReflectionPrompt()
   provider/                Interface contracts
     provider.go            LLMProvider, MemoryStore
   selfupdate/              Self-update from GitHub releases
     selfupdate.go          LatestRelease, Download, ExtractBinary, Replace
+  eval/                    End-to-end pipeline grader
+    eval/cycle             Pipeline grader: inject annotated corpus via real MCP save, run supersede/resolve/reflect, grade vs annotations, write Markdown scorecard
+    eval/cycle/corpus      Load/validate JSONL corpus; harness-only annotations never reach the save path
 ```
 
 ## Data Flow
@@ -99,7 +112,7 @@ Claude Code / Cursor → stdio JSON-RPC → mcpserver
 
 ### SessionStart Hook
 ```
-Claude Code session opens
+MCP client session opens
   → ghost hook session-start --source claude-code (stdin: JSON with cwd + projectPath)
   → lookupProject(db, cwd)           # path-prefix match OR name fallback
   → buildProjectContext(store, id)   # top memories + tasks + decisions + globals
@@ -111,9 +124,8 @@ Claude Code session opens
 ```
 ghost reflect <project> --apply
   → store.GetAll()           # existing memories
-  → store.GetRecentExchanges() # recent conversation history
   → TieredConsolidator.Consolidate()
-      → HaikuConsolidator (if ANTHROPIC_API_KEY set)
+      → HaikuConsolidator (if configured with Anthropic key or via CLI)
           → Anthropic API (haiku model)
       → SQLiteConsolidator (fallback)
           → Jaccard token similarity, merge >50% overlap
@@ -155,8 +167,6 @@ A link-graph expansion bonus was evaluated and removed (dominated by a deeper ve
 | `memories` | Core store (category, content, importance, tags, source, pinned) |
 | `memories_fts` | FTS5 virtual table (porter unicode61 tokenizer) |
 | `memory_embeddings` | Vector embeddings (float32 blob) |
-| `conversations` | Conversation sessions (project, mode, timestamps) |
-| `messages` | Conversation messages (role, content) |
 | `ghost_state` | Per-project state (interaction count, learned context) |
 | `token_usage` | Per-request token + cost tracking |
 | `tasks` | Task tracker (title, status, priority, description) |

--- a/internal/ai/cli_provider.go
+++ b/internal/ai/cli_provider.go
@@ -7,25 +7,26 @@ import (
 )
 
 // errNoCLIBackend is returned when no subprocess LLM binary is available.
-var errNoCLIBackend = errors.New("no CLI LLM backend available (install claude or opencode)")
+var errNoCLIBackend = errors.New("no CLI LLM backend available (install claude, opencode, codex, or goose)")
 
-// cliBackend is the shared capability of the two subprocess LLM clients.
+// cliBackend is the shared capability of the subprocess LLM clients.
 type cliBackend interface {
 	Reflect(ctx context.Context, prompt string) (string, TokenUsage, error)
 	Classify(ctx context.Context, systemPrompt, userContent string) (string, error)
 }
 
-// CLIProvider resolves the best available CLI backend — claude first, then
-// opencode — and delegates to it, so callers need no knowledge of which binary
-// is installed. It satisfies reflection's reflector interface and ai.Provider,
-// so it drops in wherever CLIClient is used.
+// CLIProvider resolves the best available CLI backend — priority: claude >
+// opencode > codex > goose — and delegates to it, so callers need no knowledge
+// of which binary is installed. It satisfies reflection's reflector interface
+// and ai.Provider, so it drops in wherever CLIClient is used.
 type CLIProvider struct {
 	backend cliBackend
 	name    string
 }
 
 // NewCLIProvider picks the best backend available on PATH: claude if present,
-// else opencode if present, else an unavailable provider.
+// else opencode if present, else codex if present, else goose if present,
+// else an unavailable provider.
 func NewCLIProvider() *CLIProvider {
 	return NewCLIProviderWithBinaries("", "", "", "")
 }
@@ -70,7 +71,7 @@ func NewCLIProviderWithBinaries(claudeBinary, opencodeBinary, codexBinary, goose
 	return &CLIProvider{backend: nil, name: "none"}
 }
 
-// Name reports which backend was selected ("cli", "opencode", or "none").
+// Name reports which backend was selected ("cli", "opencode", "codex", "goose", or "none").
 func (p *CLIProvider) Name() string { return p.name }
 
 // Available reports whether any subprocess LLM backend is on PATH.

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// Client is a Claude API client with streaming and tool_use support.
+// Client is a Claude API client for non-streaming reflection calls.
 type Client struct {
 	apiKey     string
 	httpClient *http.Client

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -1,5 +1,10 @@
-// internal/ai/provider.go
 package ai
+
+// Package ai provides LLM backends for Ghost: Anthropic HTTP client, 4 CLI
+// subprocess adapters (claude/opencode/codex/goose), MCP sampling provider,
+// source-aware routing, and the FallbackProvider for credit-exhaustion fallover.
+//
+// Key types: Client, Reflector, Provider, Classifier, TokenUsage, CostForUsage.
 
 import (
 	"context"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,7 +43,7 @@ type RoutingConfig struct {
 	DefaultProject string `koanf:"default_project"`
 }
 
-// APIConfig holds Claude API settings (used by reflection only).
+// APIConfig holds Claude API settings (used by reflection, resolve, and supersede classifiers).
 type APIConfig struct {
 	Key string `koanf:"key"`
 }

--- a/internal/mcpinit/init_test.go
+++ b/internal/mcpinit/init_test.go
@@ -373,8 +373,8 @@ func TestShellQuoteDispatch(t *testing.T) {
 
 func TestGhostPermissions_Complete(t *testing.T) {
 	// Verify the canonical list has the expected count.
-	if len(ghostPermissions) != 19 {
-		t.Errorf("expected 19 ghost permissions, got %d", len(ghostPermissions))
+	if len(ghostPermissions) != 20 {
+		t.Errorf("expected 20 ghost permissions, got %d", len(ghostPermissions))
 	}
 
 	// All should start with the correct prefix.

--- a/internal/mcpinit/settings.go
+++ b/internal/mcpinit/settings.go
@@ -1,4 +1,5 @@
-// Package mcpinit configures Claude Code to use Ghost as its memory system.
+// Package mcpinit configures MCP clients (Claude Code, opencode, codex, goose)
+// to use Ghost as their memory system.
 package mcpinit
 
 import (
@@ -23,6 +24,7 @@ var ghostPermissions = []string{
 	"mcp__ghost__ghost_memory_search",
 	"mcp__ghost__ghost_memory_update",
 	"mcp__ghost__ghost_project_context",
+	"mcp__ghost__ghost_project_delete",
 	"mcp__ghost__ghost_resolve",
 	"mcp__ghost__ghost_save_global",
 	"mcp__ghost__ghost_search_all",

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1,5 +1,11 @@
 package memory
 
+// Package memory provides the SQLite-backed persistence layer for Ghost memories,
+// including CRUD operations, FTS5 search, hybrid vector/FTS retrieval, time-decay
+// scoring with category-aware decay, pin exemptions, project lifecycle management,
+// tasks, decisions, memory links (supersedes/contradicts/elaborates/causes), and
+// cost/token tracking.
+
 import (
 	"context"
 	"database/sql"
@@ -739,7 +745,7 @@ const DecayRankingSQL = `
 `
 
 // GetTopMemories returns the top N memories ranked by composite score
-// with category-aware time decay and pinned boost.
+// with category-aware time decay and pinned exemption.
 func (s *Store) GetTopMemories(ctx context.Context, projectID string, limit int) ([]Memory, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1373,34 +1379,6 @@ func (s *Store) UpdateLearnedContext(ctx context.Context, projectID, learnedCont
 	return err
 }
 
-// --- Conversation persistence ---
-
-// CreateConversation starts a new conversation.
-func (s *Store) CreateConversation(ctx context.Context, projectID, mode string) (string, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	var id string
-	err := s.db.QueryRowContext(ctx, `
-		INSERT INTO conversations (project_id, mode)
-		VALUES (?, ?)
-		RETURNING id
-	`, projectID, mode).Scan(&id)
-	return id, err
-}
-
-// AppendMessage adds a message to a conversation.
-func (s *Store) AppendMessage(ctx context.Context, conversationID, role, content string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO messages (conversation_id, role, content)
-		VALUES (?, ?, ?)
-	`, conversationID, role, content)
-	return err
-}
-
 // RecordUsage saves token usage for cost tracking.
 func (s *Store) RecordUsage(ctx context.Context, projectID, model string, usage TokenUsage) error {
 	s.mu.Lock()
@@ -1527,6 +1505,7 @@ func scanMemories(rows *sql.Rows) ([]Memory, error) {
 
 // sanitizeFTS strips FTS5 special operators from text to prevent query injection.
 // Extracts plain words and quotes each one so they're treated as literals.
+//
 // upsertMergeThreshold is the minimum Jaccard similarity between full token
 // sets for Upsert to treat two memories as duplicates. Matches the 0.5 gate
 // reflection's SQLite tier uses (internal/reflection/tier_sqlite.go), so

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -75,10 +75,6 @@ type MemoryStore interface {
 	MergeProject(ctx context.Context, oldID, newID string) error
 	DeleteProject(ctx context.Context, input string, apply bool) (memory.DeleteProjectSummary, error)
 
-	// Conversation persistence
-	CreateConversation(ctx context.Context, projectID, mode string) (string, error)
-	AppendMessage(ctx context.Context, conversationID, role, content string) error
-
 	// State
 	IncrementInteraction(ctx context.Context, projectID string) (int, error)
 	GetLearnedContext(ctx context.Context, projectID string) (string, error)

--- a/internal/reflection/consolidator.go
+++ b/internal/reflection/consolidator.go
@@ -1,5 +1,11 @@
 package reflection
 
+// Package reflection performs memory consolidation: HaikuConsolidator (Anthropic API)
+// for intelligent merge, tier_sqlite.go (Jaccard similarity) for deterministic
+// fallback, and TieredConsolidator that tries tiers in priority order with a quality
+// gate rejecting LLM tiers that fall below the 30% threshold. Mechanical tiers
+// are exempt from the quality gate.
+
 import (
 	"context"
 	"fmt"

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -6,9 +6,8 @@
 // Design mirrors internal/supersede: a cheap local prefilter proposes
 // candidates, an LLM Classifier adjudicates each with a crisp one-word
 // question (biased to KEEP), and — with apply — the confirmed set is stamped
-// via SetResolved. The real Classifier will live behind an LLM implementation
-// added in a later task. The command is a standalone `ghost resolve` batch,
-// never a hook: the stop hook contract forbids DB access on that path
+// via SetResolved. The LLM Classifier implementation lives in haiku.go.
+// The stop hook spawns `ghost resolve --apply` as a detached background process
 // (internal/mcpinit/stophook.go). The pass is re-runnable and idempotent —
 // already-resolved rows are excluded by ResolveCandidates.
 package resolve


### PR DESCRIPTION
Fixes stale comments, dead code, and documentation drift identified in audit.

**Go code comments fixed:**
- ai.Client: remove streaming/tool_use claim (non-streaming only)
- resolve package doc: classifier exists, stop hook spawns resolve --apply
- cli_provider: four backends (claude/opencode/codex/goose), not two
- GetTopMemories: pinned is exemption, not boost
- mcpinit package comment: four hosts, not just Claude Code
- config: API used by reflection+resolve+supersede, not reflection only
- runResolve: stop hook spawns detached --apply process

**Dead code removed:**
- CreateConversation/AppendMessage from store.go and provider.go (tables dropped by migrateV5)

**Other fixes:**
- Add ghost_project_delete to mcpinit permissions (was missing 20th tool)
- Fix printUsage to include hook command
- Fix docs/architecture.md drift (runtime commands, ai/ description, CountTokens, GetRecentExchanges, mcpinit hosts, conversations/messages tables, package map)
- Fix CLAUDE.md drift (API usage, context command, mcpinit hosts)
- Add package comments to ai, memory, reflection packages
- Fix sanitizeFTS comment placement on upsertMergeThreshold

All tests pass.