### PR TITLE
chore: fix .gitignore ghost pattern and duplicate linking entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-ghost
+/ghost
 *.exe
 *.dll
 *.so

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,8 +67,6 @@ internal/
     export.go              Export memories to Markdown vault
     sync.go                Keep vault mirror fresh (PRAGMA data_version polling)
     render.go              Render memory blocks as Markdown
-  linking/                 Memory auto-linking
-    worker.go              Sweeps embedded memories, links cosine neighbors ≥ threshold
   claudeimport/            One-time import of Claude Code auto-memory files
     import.go              Scans ~/.claude/projects/*/memory/*.md, upserts into Ghost
   reflection/              Memory consolidation


### PR DESCRIPTION
## Summary
Two small housekeeping fixes in the docs/ignore config.

## Changes
1. **.gitignore** — anchored the bare `ghost` pattern to the repo root (`/ghost`). The bare pattern was matching the `cmd/ghost/` source directory, so `git add cmd/ghost/newfile.go` was silently rejected as ignored (required `git add -f`). Now it only matches the built binary at the repo root.
2. **docs/architecture.md** — removed the duplicated `linking/` package-map entry (it appeared twice).

## Verification
- `go vet ./...` clean
- `go build ./cmd/ghost` clean
- `go test ./...` clean
- Confirmed `git add cmd/ghost/...` now works without `-f`