### PR TITLE
docs(injection): category-aware session injection selection spec + plan

### DIFF
--- a/docs/superpowers/plans/2026-09-08-category-aware-injection.md
+++ b/docs/superpowers/plans/2026-09-08-category-aware-injection.md
@@ -1,0 +1,380 @@
+# Category-Aware Session Injection Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bias the `SessionStart` hook's 15-slot injection budget toward high-signal, hard-to-derive categories (`gotcha`/`convention`/`preference`/`decision`) without growing the token footprint, and shrink per-memory formatting to a leaner `[category] «content»` shape. Net effect: same or smaller footprint, higher utility per token.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-category-aware-injection-design.md`
+
+**Decided parameters (2026-09-08 sign-off):**
+- `behavior_floor` default = **8** (of 15)
+- compact formatting: shipped **unconditional**
+- MCP resource path: **doc-only** (no behavior change)
+
+**Architecture:** All behavior changes are confined to `internal/mcpinit/hook.go` (add a category-priority two-pass selection replacing the current single-pass in `loadSessionContext`, and a compact render in `formatSessionContext`). Config surface added to `internal/config/config.go` + `config.example.yaml` + defaults. Tests in `internal/mcpinit/hook_test.go`. No schema changes, no new dependencies.
+
+---
+
+## Setup
+
+- [ ] **Step 0: Isolated worktree**
+
+```bash
+cd /home/wayne/git/ghost
+git worktree add .worktrees/category-aware-injection -b feat/category-aware-injection
+cd .worktrees/category-aware-injection
+go build ./... && go test ./internal/mcpinit/... ./internal/memory/... ./internal/config/...
+```
+
+Expected: build succeeds, existing tests pass (clean baseline).
+
+---
+
+### Task 1: Add `injection` config block
+
+**Files:**
+- Modify: `internal/config/config.go` (struct + defaults)
+- Modify: `internal/config/config.example.yaml`
+- Test: `internal/config/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/config/config_test.go`:
+
+```go
+func TestInjectionConfigDefaults(t *testing.T) {
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Injection.BehaviorFloor != 8 {
+		t.Errorf("injection.behavior_floor = %d, want 8", cfg.Injection.BehaviorFloor)
+	}
+	want := map[string]bool{"gotcha": true, "convention": true, "preference": true, "decision": true}
+	if len(cfg.Injection.BehaviorCategories) != len(want) {
+		t.Fatalf("behavior_categories = %v, want 4 entries", cfg.Injection.BehaviorCategories)
+	}
+	for _, c := range cfg.Injection.BehaviorCategories {
+		if !want[c] {
+			t.Errorf("unexpected behavior category %q", c)
+		}
+	}
+	if cfg.Injection.CategoryWeights != nil {
+		t.Errorf("category_weights default should be nil, got %v", cfg.Injection.CategoryWeights)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/... -run TestInjectionConfigDefaults -v`
+Expected: FAIL — `cfg.Injection` field doesn't exist yet (compile error) or zero values.
+
+- [ ] **Step 3: Implement**
+
+In `internal/config/config.go`, add to the `Config` struct (after `Linking`):
+
+```go
+	Injection  InjectionConfig  `koanf:"injection"`
+```
+
+And the struct + defaults:
+
+```go
+// InjectionConfig controls how the SessionStart hook selects which project
+// memories to inject. It biases the limited slot budget toward high-signal,
+// hard-to-derive categories (gotcha/convention/preference/decision) without
+// growing the total footprint. behavior_floor of 0 disables the bias entirely
+// (pure DecayRankingSQL selection, the historical behavior).
+type InjectionConfig struct {
+	BehaviorFloor      int                `koanf:"behavior_floor"`
+	BehaviorCategories []string           `koanf:"behavior_categories"`
+	CategoryWeights    map[string]float64 `koanf:"category_weights"`
+}
+```
+
+In `defaults` map:
+
+```go
+	"injection.behavior_floor":      8,
+	"injection.behavior_categories": []string{"gotcha", "convention", "preference", "decision"},
+	// category_weights intentionally absent — nil means "all 1.0"
+```
+
+- [ ] **Step 4: Add to config.example.yaml**
+
+Under a new `injection:` block, document the keys. Match the existing example style (annotated defaults).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/config/... -v`
+Expected: all PASS including `TestInjectionConfigDefaults` and existing tests (no defaults displaced).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config.example.yaml internal/config/config_test.go
+git commit -m "feat(config): add injection config block (behavior_floor, behavior_categories, category_weights)"
+```
+
+---
+
+### Task 2: Two-pass category-priority selection in `loadSessionContext`
+
+**Files:**
+- Modify: `internal/mcpinit/hook.go` (the memory query + cap block in `loadSessionContext`, ~lines 441-485)
+- Test: `internal/mcpinit/hook_test.go`
+
+**Reference (read-only):** `internal/memory/store.go:749-767` `GetTopMemories` and `internal/memory/store.go:735` `DecayRankingSQL`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// TestInjection_RespectsBehaviorFloor: ≥9 behavioral + ≥6 descriptive
+// memories -> at least behavior_floor (8) behavioral injected, rest filled
+// from descriptive, total ≤ sessionMemoriesCap (15).
+func TestInjection_RespectsBehaviorFloor(t *testing.T) {
+	// fixture: project p1 with 10 gotcha + 10 architecture memories,
+	// all same importance so decay is the only discriminator.
+	// Expect >= 8 gotcha in output, total == 15.
+}
+
+// TestInjection_SparseBehaviorals: only 3 gotcha memories -> those 3 get in,
+// remaining 12 filled from architecture/fact (floor is a max, not over-inject).
+// Expect exactly 3 gotcha, 12 total, no phantom category-invention.
+func TestInjection_SparseBehaviorals(t *testing.T) { /* ... */ }
+
+// TestInjection_FloorZero_MatchesLegacy: behavior_floor=0 -> selection equals
+// current behavior (rank-only by DecayRankingSQL). Regression parity pin.
+func TestInjection_FloorZero_MatchesLegacy(t *testing.T) { /* ... */ }
+```
+
+Use the existing `HandleSessionStartHook` fixture pattern from `TestSessionInjectionRespectsNewCap` (xdg temp dir, `memory.OpenDB`, insert project + memories, `json.Marshal` cwd, parse output, count occurrences of category labels in the `**Memories (...):**` block).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/mcpinit/... -run 'TestInjection_(RespectsBehaviorFloor|SparseBehaviorals|FloorZero_MatchesLegacy)' -v`
+Expected: FAIL — current single-pass rank-only selection won't guarantee the behavioral floor.
+
+- [ ] **Step 3: Implement the two-pass selection**
+
+In `internal/mcpinit/hook.go`, inside `loadSessionContext`, load the config once and replace the single-pass query block with a two-pass selection. Fetch an over-fetch set (e.g. `sessionMemoriesCap*3`) so both passes have enough candidates:
+
+```go
+	cfg, _ := config.Load()
+	floor := sessionMemoriesCap
+	if cfg != nil {
+		floor = cfg.Injection.BehaviorFloor
+	}
+	if floor < 0 {
+		floor = 0
+	}
+	if floor > sessionMemoriesCap {
+		floor = sessionMemoriesCap
+	}
+	behav cats := cfg.Injection.BehaviorCategories (or default 4)
+	weights := cfg.Injection.CategoryWeights
+
+	// Pass 1: behavioral memories, ordered by DecayRankingSQL * category_weight.
+	rows, err := db.Query(`
+		SELECT id, category, content, pinned FROM memories
+		WHERE project_id = ? AND resolved_at IS NULL
+		ORDER BY (`+memory.DecayRankingSQL+`) DESC
+		LIMIT ?
+	`, projectID, sessionMemoriesCap*3)
+	// ...scan all into a slice of sessionMemory (with Category)...
+
+	// Partition: behavioral vs rest (by behaviorCategories set).
+	// Rank both by (DecayRankingSQL * weight). Weight = weights[cat] or 1.0.
+	// Compute DecayRankingSQL score in Go for ordering within each partition
+	// (reuse the formula — see store.go decayFactor / the Go mirror).
+
+	// Select: take min(floor, len(behavioral)) behavioral highest-ranked, then
+	// fill from rest (excluding chosen IDs) up to sessionMemoriesCap.
+	// Preserve stable order.
+```
+
+**Important:** the existing code computes SQL-side ordering; for the weighted pass-1 ordering you'll need the score in Go. **Reuse the existing Go mirror** `decayFactor` in `internal/memory/vector.go:250` (it mirrors `DecayRankingSQL` exactly — do not duplicate the formula). Multiply by the per-category weight.
+
+Then apply the **existing** demotion + truncation unchanged (they already run on the merged `memories` slice — keep `DemotionPenalties`/`StableDemote`/`memories[:sessionMemoriesCap]` as-is after the two passes produce the merged list).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/mcpinit/... -run 'TestInjection_(RespectsBehaviorFloor|SparseBehaviorals|FloorZero_MatchesLegacy)' -v` then the full `go test ./internal/mcpinit/... -v`
+Expected: all PASS (and existing cap/backfill tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcpinit/hook.go internal/mcpinit/hook_test.go
+git commit -m "feat(mcpinit): two-pass category-priority injection selection"
+```
+
+---
+
+### Task 3: Compact injection formatting (drop memory ID)
+
+**Files:**
+- Modify: `internal/mcpinit/hook.go` (`formatSessionContext`, line 223-225)
+- Modify: `internal/mcpinit/hook_test.go` (assertions that grep for the 32-hex ID / old shape)
+- Check: opencode plugin context file expectations (`internal/mcpinit/opencode_ghost.ts` embeds the render — verify no downstream parser depends on the ID)
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// TestFormatSessionContext_CompactMemoryLine: injected memory lines are
+// "- [category] «content»" with no backticked 32-hex ID and no importance/
+// tags prefix.
+func TestFormatSessionContext_CompactMemoryLine(t *testing.T) { /* ... */ }
+```
+
+Also add a negative guard: output must NOT contain a regex like `[0-9A-F]{32}` in the memories section.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/mcpinit/... -run TestFormatSessionContext_CompactMemoryLine -v`
+Expected: FAIL — current line is `- [category] \`ID\` «content»`.
+
+- [ ] **Step 3: Implement**
+
+In `formatSessionContext`, change the memory rendering block:
+
+```go
+	// Compact form: category + content only. The 32-hex memory ID and any
+	// importance/tags prefix are dropped — they're near-unused by the model
+	// in the injected block (the interactive ghost_project_context / search
+	// tools surface the ID when needed) and cost ~35-60 bytes per memory.
+	// The «...» delimiters are retained as the indirect-injection defense.
+	for _, m := range memories {
+		fmt.Fprintf(&sb, "- [%s] %s\n", m.Category, quoteData(m.Content))
+	}
+```
+
+(Leave the globals and tasks/decisions rendering unchanged.)
+
+- [ ] **Step 4: Update existing tests that assert the old shape**
+
+Search `internal/mcpinit/hook_test.go` for assertions on the memories block format (e.g. any that match a backticked ID after `[category]`). Update to the compact form.
+
+- [ ] **Step 5: Check opencode plugin expectations**
+
+Inspect `internal/mcpinit/opencode_ghost.ts` — confirm it just surfaces the opaque context string (does not regex-parse memory IDs). If it does parse IDs, it must be updated in the same change. Verify with a grep for `[0-9A-F]{32}` / `ghost_` / backtick-ID patterns in the .ts.
+
+- [ ] **Step 6: Run full hook tests**
+
+Run: `go test ./internal/mcpinit/... -v`
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/mcpinit/hook.go internal/mcpinit/hook_test.go internal/mcpinit/opencode_ghost.ts
+git commit -m "feat(mcpinit): compact injected memory lines (drop 32-hex ID, keep category + content)"
+```
+
+---
+
+### Task 4: MCP resource doc wording (doc-only)
+
+**Files:**
+- Modify: `internal/mcpserver/mcpserver.go` (the `ghost_project_context` tool description, ~line 581)
+- Modify: `docs/architecture.md` (data-flow / injection section)
+
+- [ ] **Step 1: Update the tool description**
+
+The `ghost_project_context` description already says "NOT needed at session start (hook already injects this)". Strengthen it to make the distinction explicit:
+
+```
+"Get Ghost's accumulated knowledge about a project: the full top-20 memories (with IDs, pins, tags) plus learned context — the COMPLETE detail surface. The SessionStart hook injects a condensed 15-memory selection without IDs; use this when you need the full set, IDs, or pins, or after switching projects mid-session."
+```
+
+- [ ] **Step 2: Update architecture.md**
+
+In the "Data Flow → MCP Server" section, add a one-line note distinguishing the hook's condensed selection from the resource's complete payload.
+
+- [ ] **Step 3: Verify no tests assert the old description**
+
+Run: `go test ./internal/mcpserver/... ./internal/mcpinit/... -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/mcpserver/mcpserver.go docs/architecture.md
+git commit -m "docs(mcpserver): clarify hook (condensed) vs resource (complete) injection surfaces"
+```
+
+---
+
+### Task 5: Bench / evals
+
+**Files:**
+- New or modify: `internal/bench/` injection-budget suite (or extend eval-cycle harness)
+
+- [ ] **Step 1: Add an injection-budget bench suite**
+
+Measure bytes of the rendered injection block over the real ghost-project corpus (58 memories) before/after, asserting:
+- total bytes not greater than the legacy render over the same corpus;
+- `behavior_floor` satisfied (≥8 behavioral when available) for a representative corpus.
+
+Reuse the existing `internal/bench` grading style (see `runner.go`/`staleness.go`). Wire a `ghost bench` flag (e.g. `--injection`) or a standalone `TestBenchInjectionBudget`.
+
+- [ ] **Step 2: Run and record results**
+
+Run the bench; record numbers in `docs/benchmarks.md` (bytes before vs after, behavioral hit-rate). This is the evidence that the trade is a net win, matching the `docs/benchmarks.md` convention for retrieval quality.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/bench/ docs/benchmarks.md
+git commit -m "feat(bench): injection-budget suite proving category-priority + compact render"
+```
+
+---
+
+### Task 6: Full regression pass and vet
+
+**Files:** none (verification-only)
+
+- [ ] **Step 1: go vet**
+
+Run: `go vet ./...`
+Expected: clean.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `go test ./...`
+Expected: all packages PASS.
+
+- [ ] **Step 3: Manual smoke test in this repo**
+
+```bash
+go run ./cmd/ghost hook session-start <<< '{"cwd": "'"$(pwd)"'", "source": "startup"}' | head -c 2000
+```
+
+Expected: `## Ghost context: ghost`, ≤15 memories in compact `[category] «...»` form (no backticked 32-hex IDs), ≥8 gotcha/convention/preference/decision if the project has them, ≤8 globals, still-dropped duplicate content.
+
+```bash
+go run ./cmd/ghost hook session-start <<< '{"cwd": "'"$(pwd)"'", "source": "compact"}'
+```
+Expected: one-line pointer (unchanged from 08-03 work).
+
+```bash
+# Verify floor=0 reproduces legacy selection
+ghost hook session-start <<< '{"cwd": "'"$(pwd)"'", "source": "startup"}' \
+  > /tmp/floor8.txt
+GHOST_INJECTION_FLOOR=0 ... compare (via a config file with behavior_floor: 0)
+```
+Expected: floor=0 output matches the pre-change behavior ordering.
+
+---
+
+## Execution Handoff
+
+Plan complete at `docs/superpowers/plans/2026-09-08-category-aware-injection.md`. Spec at `docs/superpowers/specs/2026-09-08-category-aware-injection-design.md`.
+
+**Execution options:**
+1. **Subagent-driven (recommended)** — dispatch a fresh subagent per task, review between tasks.
+2. **Inline execution** — run tasks in-session with checkpoints.
+
+After implementation, use `superpowers:finishing-a-development-branch` to merge/PR — never push directly to `main`.

--- a/docs/superpowers/specs/2026-09-08-category-aware-injection-design.md
+++ b/docs/superpowers/specs/2026-09-08-category-aware-injection-design.md
@@ -1,0 +1,150 @@
+# Category-Aware Session Injection Selection Design
+
+> **Status:** Proposed — not yet implemented.
+> **Related prior work:** `2026-08-03-hook-injection-cost-reduction` (landed) and `2026-08-03-subagent-injection-gating-design` (landed), `2026-08-20-search-time-decay-design` (landed). This feature builds on those but is **new** — none of the prior work re-weights injection *selection* by category; it ranks purely by composite decayed score.
+
+## Problem
+
+Ghost's `SessionStart` hook injects the top project memories into every session's system prompt. Today the selection is purely rank-by-`DecayRankingSQL` (importance × category-aware time-decay × pin-exemption) — it does **not** prefer one category over another beyond what decay already encodes.
+
+The measured/estimated footprint is ~2–3.5k tokens for 15 project memories + 8 globals + tasks + decisions (`docs/superpowers/plans/2026-08-03-hook-injection-cost-reduction.md`, memory `CAAA0E9DCDBF53524BEEBF56240D0A99`). That overhead is justified **only if the slots are spent on high-signal content**.
+
+The current mix spends several slots on low-value-for-injection memories:
+
+- **Descriptive** `architecture` / `fact` memories (project layout, god-package sizes, "this component is 1706 LOC") that the model can reconstruct by reading source — near-zero marginal value in a session prompt, they are *derivable*.
+- **Behavioral / experiential** `gotcha` / `convention` / `preference` / `decision` memories (SOPS workflow, mr-slave is the build host, DCO sign-off, blobs-deadlock tel the same story) that are *irreplaceable* — no amount of source reading recovers them, and re-discovering them costs turns or causes incidents.
+
+A `gotcha` and an `architecture` memory at the same decayed score currently get equal injection airtime even though the gotcha is almost always worth more per token for agentic coding.
+
+## Goal
+
+Make the session-injection selection **category-aware**: bias the injected set toward the high-signal, hard-to-derive categories (`gotcha`, `convention`, `preference`, `decision`) while still retaining the best of the decaying, descriptive categories — without growing the token budget.
+
+Combined with the formatting-optimization subordinate goal (option (c) both), the net effect is **same or smaller footprint, higher utility per token**.
+
+## Non-Goals
+
+- **Not** a full replacement of `DecayRankingSQL`. Search (`ghost_memory_search`) and `GetTopMemories` keep their current ranking semantics.
+- **Not** removing memory categories.
+- **Not** a per-user UI; knobs are config-file flags only.
+- **Not** touching the MCP resource path's parity contract beyond documenting it (the resource is a separate, distinct payload — see Scope).
+
+## Current State (verified in code, 2026-09-08)
+
+- `internal/mcpinit/hook.go`:
+  - `sessionMemoriesCap = 15` (line 308), `globalsCap = 8` (line 296)
+  - Project ranking uses `memory.DecayRankingSQL` (shared constant) `ORDER BY (...) DESC LIMIT cap*2`, then near-duplicate demotion via `memory.DemotionPenalties` + `memory.StableDemote`, then `memories[:sessionMemoriesCap]`.
+  - Globals ranked by `pinned DESC, importance DESC, updated_at DESC`, capped at 8, with `globalsDemotionThreshold = 0.85`.
+  - Content truncated: project at 200 bytes, globals at 300 bytes (`truncateUTF8`).
+- `internal/memory/store.go`:
+  - `DecayRankingSQL` (line 735) — the shared composite-score fragment.
+  - `GetTopMemories` (line 749) — the MCP-tool path, `WHERE project_id=? OR project_id='_global'`, rank-only.
+- Two distinct injection paths exist:
+  1. **Hook** (`loadSessionContext` → `formatSessionContext`): 15 project + 8 globals + tasks + decisions + learned.
+  2. **MCP resource** (`ghost://project/{id}/context`, `mcpserver.go:buildProjectContext`): 20 project + 15 globals + decisions + learned. Not automatically injected; only read if the client pins/lists it.
+
+## Design
+
+### Core idea: category-priority blending
+
+Introduce a **category weight** applied to the *injection-selection* ranking (NOT to the search/`GetTopMemories` path) so the hook's 15-slot budget is spent to satisfy two goals in order:
+
+1. **Hard floor for high-signal categories** — reserve a minimum number of slots for `gotcha` / `convention` / `preference` / `decision` if the project has them.
+2. **Decayed-score fill** — the remaining slots are filled by the current `DecayRankingSQL` ranking so the best *of the rest* (including descriptive `architecture`/`fact`) still gets in.
+
+This is a **two-pass selection**, not a wholesale re-rank:
+
+- **Pass 1 (prioritized):** take the top `categoryQuota` by `DecayRankingSQL` from categories in `{gotcha, convention, preference, decision}`.
+- **Pass 2 (fill):** fill up to `sessionMemoriesCap - len(pass1)` from `DecayRankingSQL` overall, excluding the already-chosen IDs.
+- Apply the existing near-duplicate demotion to the merged result, then truncate in-place (same post-processing as today).
+
+**Rationale for two-pass over a single weighted formula:** a single score like `score * categoryBoost` is hard to reason about and can be gamed by importance inflation; the two-pass model makes the guarantee explicit and testable ("at most N descriptive slots, at least M behavioral slots when available"). It also cleanly bounds behavior even when categories are sparse.
+
+### Config surface
+
+Add an `injection` config block (new) with sane defaults, keeping behavior identical to today when unset (backwards compatible):
+
+```yaml
+injection:
+  # Slots reserved for high-signal, hard-to-derive categories.
+  # 0 disables the two-pass behavior (pure DecayRankingSQL, current behavior).
+  behavior_floor: 8        # 0..sessionMemoriesCap; default 8 of 15
+  behavior_categories:     # what counts as "behavioral"
+    - gotcha
+    - convention
+    - preference
+    - decision
+  # Optional per-category boost for the pass-1 ordering (default all 1.0).
+  category_weights: {}     # e.g. {gotcha: 1.0, convention: 0.9, ...}
+```
+
+- `behavior_floor` default: 8 (just over half of 15; matches the observation that behavioral categories dominate value).
+- `behavior_floor: 0` → exactly today's behavior (the two-pass degenerates to a single pass).
+- `category_weights` multiplies the `DecayRankingSQL` score *only within* Pass 1 (ordering preference among behavioral categories); omitted categories get 1.0.
+
+Config struct (`internal/config/config.go`):
+
+```go
+// InjectionConfig controls how the SessionStart hook selects which project
+// memories to inject. It biases the limited slot budget toward high-signal,
+// hard-to-derive categories (gotcha/convention/preference/decision) without
+// growing the total footprint.
+type InjectionConfig struct {
+    BehaviorFloor     int               `koanf:"behavior_floor"`
+    BehaviorCategories []string         `koanf:"behavior_categories"`
+    CategoryWeights   map[string]float64`koanf:"category_weights"`
+}
+```
+
+Add `Injection InjectionConfig \`koanf:"injection"\`` to `Config`, defaults in `defaults`, and document in `config.example.yaml`.
+
+### Formatting optimization
+
+- The per-memory formatting in `formatSessionContext` is ~40–60 bytes of tokens (`[category]` `` `ID` `` `(importance[pin][tags])` + `«...»`).
+- **Keep** the `«...»` data delimiters (mandatory — indirect-injection defense, `quoteData`).
+- **Drop** the full 32-hex ID from the injected list (keep it only in debug/verbose). The ID adds ~35 bytes but is nearly never used by the model in the injected block; when it needs the ID it calls `ghost_memory_search`/`ghost_project_context`. Replace with a compact `[category]` label only. (Note: the MCP *resource* path keeps IDs, since that's the interactive query surface.)
+- **Drop** the `(importance …)` and `tags:` prefixes from the injected list; category is the only discriminator the model needs up front.
+
+Net effect per memory: ~45–60 bytes saved → ~700–900 bytes (~200–250 tokens) shaved off the typical 15-memory injection, on top of the retained gains from the 08-03 plan.
+
+### Resource/hook parity
+
+- The MCP resource (`ghost://project/{id}/context`, 20+15) remains the "full detail" surface and is **unchanged** — it already serves IDs, pins, tags, learned context for pinned/on-demand reads.
+- Document in both the hook's tool description and the resource's description that the hook is a *condensed* selection and the resource is the *complete* one, so a client that pins the resource still gets full fidelity. No code change needed to the resource; only doc wording.
+
+### Open tasks and decisions are unchanged
+
+Task and decision injection already favor `active`/`pending`/`blocked` (open) items; this feature does not alter them.
+
+## Backwards Compatibility
+
+- `behavior_floor: 0` (or an absent `injection` block) reproduces today's exact selection. The change is additive/config-gated.
+- The formatting shrink (`ID`/`importance`/`tags` removal) changes the *shape* of the injected block unconditionally. This is a deliberate behavior change with a test to lock it; flag it in the plan/PR so downstream parsers (the opencode plugin's context file) are checked.
+- Existing `hook_test.go` assertions that grep for exact memory IDs / `(importance` in injected output must be updated in the same change.
+
+## Testing / Bench
+
+- **Unit tests** (`internal/mcpinit/hook_test.go`):
+  - `TestInjection_RespectsBehaviorFloor`: a project with ≥9 behavioral + ≥6 descriptive memories injects ≥ `behavior_floor` behavioral and fills the rest; total ≤ 15.
+  - `TestInjection_SparseBehaviorals`: a project with only 3 behavioral memories still fills the other 12 slots from descriptive — floor is a *max* of available, not a hard over-inject.
+  - `TestInjection_FloorZero_MatchesLegacy`: with `behavior_floor: 0`, selection equals the old behavior (regression/parity pin).
+  - `TestInjection_FormattingDropIdAndImportance`: injected lines are `- [category] «…»` with no `(importance` and no full 32-hex ID.
+- **Bench / evals:** extend `internal/bench` with an injection-budget suite (or reuse the eval-cycle harness) asserting that a large real-ish corpus (like the ghost project's own 58 memories) yields a focused, category-balanced injection and measurably fewer total bytes than the current formatting. This mirrors how `docs/benchmarks.md` documents retrieval quality.
+
+## Risks / Open Questions
+
+- **Is category always a good proxy for value?** A stale/wrong `gotcha` injected at high weight is worse than a current `architecture` note. Mitigation: `behavior_floor` is bounded (not 100%), decay still applies within Pass 1, and the existing near-duplicate demotion + `resolve`-marking surfaces stale behavioral memories too. Accept for v1; revisit with a data-driven study if needed.
+- **Floor vs. availability semantics:** floor is a *cap on behaviorals that get injected by default*, and pass 2 fills the remainder — it never invents behavioral slots when none exist. Confirm this reading in review.
+- **Config naming:** `behavior_floor` / `behavior_categories` are novel keys. Confirm they read well and match Ghost's existing config vocabulary (`linking.demotion_threshold`, etc.).
+
+## Decision Points to Confirm Before Implementation
+
+1. Default `behavior_floor` (proposal: 8) — or start conservative at 0 (opt-in) and validate the value via bench before enabling by default.
+2. The formatting shrink — accept unconditional, or gate behind `injection.compact_format: true` default-on for the opencode plugin only initially?
+3. Whether to touch the MCP resource path at all (proposal: doc-only, no behavior change).
+
+## Out of Scope (tracked separately)
+
+- **Two non-syncing Ghost DBs** (laptop vs mr-slave) — separate feature, not part of injection selection.
+- **Content truncation cap (2000 chars) loss** — separate memory-fidelity fix, unrelated to selection.
+- **Reflection cross-contamination** — separate reflection-quality work.


### PR DESCRIPTION
## Summary

Documents the plan for making Ghost's SessionStart hook injection **category-aware** — biasing the 15-slot budget toward high-signal, hard-to-derive categories (gotcha/convention/preference/decision) without growing the token footprint, plus a compact injection format.

This is docs only (spec + implementation plan) — no code changes yet. Implements the decision recorded in Ghost (decision 372AD1531F4B77C3A9F2B92AD8031CFF).

## Contents

- **Spec:** `docs/superpowers/specs/2026-09-08-category-aware-injection-design.md`
  - Two-pass floor+fill selection (Pass 1 reserves behavior_floor=8 behavioral slots, Pass 2 fills the rest from DecayRankingSQL)
  - Compact injection formatting (drop 32-hex ID, keep [category] + «...» delimiters)
  - Config surface (`injection.behavior_floor`, `behavior_categories`, `category_weights`)
  - Backwards compat (floor:0 = legacy), testing/bench, risks
- **Plan:** `docs/superpowers/plans/2026-09-08-category-aware-injection.md`
  - 6 tasks: injection config block, two-pass selection, compact format, MCP resource doc wording, bench, regression+vet

## Sign-off

Decision points confirmed with Wayne: floor=8, compact_format unconditional, MCP resource = doc-only.