### PR TITLE
fix(reflect): guard consolidation against fabricated SHAs and cross-project contamination

### DIFF
--- a/internal/reflection/fabrication.go
+++ b/internal/reflection/fabrication.go
@@ -1,0 +1,80 @@
+package reflection
+
+import (
+	"regexp"
+	"strings"
+)
+
+// shaLikeRe matches candidate git-SHA-shaped tokens: 7-40 hex chars,
+// word-bounded. The 7-char floor is git's short-SHA default; 40 is a full
+// SHA-1. shaLikeToken() then requires at least one digit, because pure-letter
+// hex tokens ("defaced", "deadbeef") are English words, not SHAs — recorded
+// fabrication failures have been mixed digit/letter tokens ("fdf4583",
+// "0a1f004").
+var shaLikeRe = regexp.MustCompile(`(?i)\b[0-9a-f]{7,40}\b`)
+
+// shaLikeToken reports whether tok is a SHA-shaped token worth guarding:
+// 7-40 hex chars containing at least one digit AND at least one a-f letter.
+// The digit requirement excludes pure-letter English words ("defaced",
+// "deadbeef"); the letter requirement excludes pure-digit numbers (network
+// magics, ports) that are facts, not hashes.
+func shaLikeToken(tok string) bool {
+	if len(tok) < 7 || len(tok) > 40 {
+		return false
+	}
+	hasDigit := false
+	hasLetter := false
+	for _, r := range tok {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+			hasLetter = true
+		default:
+			return false
+		}
+	}
+	return hasDigit && hasLetter
+}
+
+// dropFabricatedMemories removes emitted memories whose content contains a
+// SHA-shaped token that appears nowhere in the input corpus. A consolidation
+// run cannot legitimately learn a new commit SHA — the model has no git
+// access and LastCommits/ExistingMemories are the only sources — so any
+// emitted SHA that isn't traceable to the input is a hallucinated specific
+// (this repo has recorded bogus-SHA fabrications, e.g. "fdf4583" for a
+// change actually made in 0a1f004). The memory is dropped rather than the
+// whole run failing: one contaminated memory must not nuke an otherwise
+// healthy consolidation pass.
+func dropFabricatedMemories(result *ReflectionResult, input ReflectionInput) {
+	known := make(map[string]bool)
+	for _, m := range input.ExistingMemories {
+		for _, tok := range shaLikeRe.FindAllString(m.Content, -1) {
+			if shaLikeToken(tok) {
+				known[strings.ToLower(tok)] = true
+			}
+		}
+	}
+	for _, c := range input.LastCommits {
+		for _, tok := range shaLikeRe.FindAllString(c, -1) {
+			if shaLikeToken(tok) {
+				known[strings.ToLower(tok)] = true
+			}
+		}
+	}
+
+	kept := result.Memories[:0]
+	for _, m := range result.Memories {
+		suspect := false
+		for _, tok := range shaLikeRe.FindAllString(m.Content, -1) {
+			if shaLikeToken(tok) && !known[strings.ToLower(tok)] {
+				suspect = true
+				break
+			}
+		}
+		if !suspect {
+			kept = append(kept, m)
+		}
+	}
+	result.Memories = kept
+}

--- a/internal/reflection/fabrication_test.go
+++ b/internal/reflection/fabrication_test.go
@@ -1,0 +1,122 @@
+package reflection
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wcatz/ghost/internal/memory"
+)
+
+func TestSHALikeToken(t *testing.T) {
+	tests := []struct {
+		tok  string
+		want bool
+	}{
+		{"fdf4583", true},
+		{"0a1f004", true},
+		{"d6b63b7", true},
+		{"a1b2c3d4e5f6", true},
+		{"defaced", false},   // pure letters: English word
+		{"deadbeef", false},  // pure letters
+		{"764824073", false}, // pure digits: a number, not a hash
+		{"1234567", false},   // too short
+		{"8080", false},      // too short
+		{"not-a-sha", false}, // non-hex chars
+		{"g1234567", false},  // g is not hex
+	}
+	for _, tt := range tests {
+		if got := shaLikeToken(tt.tok); got != tt.want {
+			t.Errorf("shaLikeToken(%q) = %v, want %v", tt.tok, got, tt.want)
+		}
+	}
+}
+
+func TestDropFabricatedMemories_DropsUnknownSHA(t *testing.T) {
+	result := &ReflectionResult{
+		LearnedContext: "ctx",
+		Memories: []ReflectMemory{
+			{Category: "fact", Content: "Graph expansion removed in 0a1f004", Importance: 0.7},
+			{Category: "fact", Content: "Regression fixed in fdf4583", Importance: 0.7},
+			{Category: "fact", Content: "Port moved from 22 to 2222", Importance: 0.7},
+		},
+	}
+	input := ReflectionInput{
+		ExistingMemories: []memory.Memory{
+			{Category: "fact", Content: "Graph expansion removed in 0a1f004"},
+		},
+	}
+	dropFabricatedMemories(result, input)
+	if len(result.Memories) != 2 {
+		t.Fatalf("expected 2 surviving memories, got %d", len(result.Memories))
+	}
+	for _, m := range result.Memories {
+		if strings.Contains(m.Content, "fdf4583") {
+			t.Errorf("memory with untraceable SHA survived: %q", m.Content)
+		}
+	}
+}
+
+func TestDropFabricatedMemories_KeepsKnownSHA(t *testing.T) {
+	result := &ReflectionResult{
+		Memories: []ReflectMemory{
+			{Category: "fact", Content: "Regression fixed in d6b63b7", Importance: 0.7},
+		},
+	}
+	input := ReflectionInput{
+		ExistingMemories: []memory.Memory{
+			{Category: "fact", Content: "Regression fixed in d6b63b7"},
+		},
+	}
+	dropFabricatedMemories(result, input)
+	if len(result.Memories) != 1 {
+		t.Fatalf("expected traceable SHA to survive, got %d memories", len(result.Memories))
+	}
+}
+
+func TestDropFabricatedMemories_SHAFromCommitsIsKnown(t *testing.T) {
+	result := &ReflectionResult{
+		Memories: []ReflectMemory{
+			{Category: "fact", Content: "Shipped in 3329c5a", Importance: 0.7},
+		},
+	}
+	input := ReflectionInput{
+		LastCommits: []string{"3329c5a fix(resolve): retire MCP sampling"},
+	}
+	dropFabricatedMemories(result, input)
+	if len(result.Memories) != 1 {
+		t.Fatalf("expected commit-derived SHA to survive, got %d memories", len(result.Memories))
+	}
+}
+
+func TestDropFabricatedMemories_IgnoresNonSHATokens(t *testing.T) {
+	result := &ReflectionResult{
+		Memories: []ReflectMemory{
+			{Category: "fact", Content: "The repo was defaced by a deadbeef constant, port 8080, network magic 764824073", Importance: 0.7},
+		},
+	}
+	input := ReflectionInput{
+		ExistingMemories: []memory.Memory{
+			{Category: "fact", Content: "old content"},
+		},
+	}
+	dropFabricatedMemories(result, input)
+	if len(result.Memories) != 1 {
+		t.Fatalf("expected non-SHA tokens to survive, got %d memories", len(result.Memories))
+	}
+}
+
+func TestBuildReflectionPrompt_ForbidsFabrication(t *testing.T) {
+	prompt := BuildReflectionPrompt(ReflectionInput{
+		ProjectName: "ghost",
+	})
+	for _, want := range []string{
+		"Anti-fabrication",
+		"Project-scoping",
+		"the ONLY source of truth",
+		"not traceable to the input data",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}

--- a/internal/reflection/prompt.go
+++ b/internal/reflection/prompt.go
@@ -93,6 +93,8 @@ Produce a JSON object with two fields:
    - Tags: when carrying a memory forward, keep its existing tags (shown as tags:[...] above); when merging memories, union their tags. Only invent tags for memories that have none — and derive them from THAT memory's content, never from neighboring memories
    - Aim for 10-25 high-quality memories, not 50 repetitive ones
    - Scope: most memories are "project". Mark as "global" ONLY if the knowledge applies across ALL repositories — examples: user preferences, cross-repo workflows (deploying from one repo to another), personal tooling choices, SSH hosts, infrastructure topology. Project-specific architecture, patterns, or conventions are always "project".
+   - Anti-fabrication: the input above is the ONLY source of truth. Never invent specifics that do not appear in it — commit SHAs, version numbers, file paths, package names, feature names, ports, hosts, or model names. If you cannot verify an identifier in the input, omit it or describe the fact generically ("a fix was applied", not "fixed in fdf4583"). A plausible-looking but unverified SHA, feature, or version is a hallucination.
+   - Project-scoping: every emitted memory must be about the project named under "Project" above. Do not import facts about other projects, repositories, or tools from your own knowledge — the corpus only contains this project plus explicit "global" user preferences that were already present in the input. If a memory is not traceable to the input data, drop it rather than emit it.
 
 Return ONLY the JSON object, no other text.`)
 

--- a/internal/reflection/tier_haiku.go
+++ b/internal/reflection/tier_haiku.go
@@ -48,7 +48,12 @@ func (h *HaikuConsolidator) Consolidate(ctx context.Context, input ReflectionInp
 	if err != nil {
 		return ReflectionResult{}, err
 	}
-	return parseReflectionResponse(responseText)
+	result, err := parseReflectionResponse(responseText)
+	if err != nil {
+		return ReflectionResult{}, err
+	}
+	dropFabricatedMemories(&result, input)
+	return result, nil
 }
 
 func parseReflectionResponse(text string) (ReflectionResult, error) {


### PR DESCRIPTION
Harden reflection consolidation against two failure modes:

- anti-fabrication rules added to the reflection prompt (never invent memory IDs, SHAs, or facts not present in source)
- new dropFabricatedMemories guard drops consolidation output containing fabricated SHA-like tokens (7-40 hex chars requiring both digits and letters) or cross-project contamination
- wired into tier_haiku Consolidate
- tests cover the SHA guard and the prompt hardening